### PR TITLE
Use system-provided Google tools in dev-graphics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,13 +127,25 @@ endif()
 ##
 
 if(${TESTS})
+    # Google Mock
+    find_path(GMOCK_INCLUDE_DIR NAMES gmock.h PATH_SUFFIXES gmock)
+    find_path(GMOCK_SRC_DIR NAMES src/gmock-all.cc PATHS /usr/src/ PATH_SUFFIXES gmock)
     # Google Test library
     find_path(GTEST_SRC_DIR NAMES src/gtest.cc src/gtest-all.cc PATHS /usr/src/ PATH_SUFFIXES gtest)
-    if(NOT GTEST_SRC_DIR)
+    if(GTEST_SRC_DIR AND GMOCK_INCLUDE_DIR AND GMOCK_SRC_DIR)
+        include_directories(${GMOCK_SRC_DIR})
+    else(GTEST_SRC_DIR AND GMOCK_INCLUDE_DIR AND GMOCK_SRC_DIR)
         set(GTEST_SRC_DIR lib/gtest)
-    endif(NOT GTEST_SRC_DIR)
-    message(STATUS "Use Google Test from ${GTEST_SRC_DIR}")
+        set(GMOCK_SRC_DIR ${GTEST_SRC_DIR})
+        set(GMOCK_INCLUDE_DIR ${GTEST_SRC_DIR}/include/gmock)
+        include_directories(${GTEST_SRC_DIR} ${GTEST_SRC_DIR}/include/)
+    endif(GTEST_SRC_DIR AND GMOCK_INCLUDE_DIR AND GMOCK_SRC_DIR)
+
+    add_library(gmock STATIC ${GMOCK_SRC_DIR}/src/gmock-all.cc)
     add_subdirectory(${GTEST_SRC_DIR} bin/test)
+
+    message(STATUS "Use Google Mock from ${GMOCK_SRC_DIR}")
+    message(STATUS "Use Google Test from ${GTEST_SRC_DIR}")
 endif()
 
 # Subdirectory with sources

--- a/lib/gtest/CMakeLists.txt
+++ b/lib/gtest/CMakeLists.txt
@@ -7,4 +7,3 @@ add_definitions(-DGTEST_HAS_PTHREAD=0)
 
 # gtest-all.cc includes all other sources
 add_library(gtest STATIC src/gtest-all.cc)
-add_library(gmock STATIC src/gmock-all.cc)


### PR DESCRIPTION
This is the counterpart for dev-graphics of what is proposed on https://github.com/colobot/colobot/pull/87 : it adds to it the Google Mock handling.

I have tested here that it works in both situations: with the google mock + google test system libraries installed (and with lib/ deleted) or without either, with the embedded lib/ .

I'd be in favour of dropping lib/ altogether, for clarity, but with that change, it is not strictly needed as the system libraries will be used if they exist.

Cheers, 

OdyX
