### PR TITLE
Install libCBot to a private directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,9 +159,11 @@ if(${TESTS})
 
 endif()
 
+# TODO: provide data files as git submodule
+set(COLOBOT_DATA_DIR ${CMAKE_INSTALL_PREFIX}/share/games/colobot CACHE PATH "Colobot shared data directory")
+set(COLOBOT_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib/colobot CACHE PATH "Colobot libraries directory")
+
 # Subdirectory with sources
 add_subdirectory(src bin)
 
-# TODO: provide data files as git submodule
-set(COLOBOT_DATA_DIR ${CMAKE_INSTALL_PREFIX}/share/games/colobot CACHE PATH "Colobot shared data directory")
 install(DIRECTORY ../data DESTINATION ${COLOBOT_DATA_DIR})

--- a/src/CBot/CMakeLists.txt
+++ b/src/CBot/CMakeLists.txt
@@ -18,4 +18,4 @@ else()
     add_library(CBot SHARED ${SOURCES})
 endif()
 
-INSTALL_TARGETS(/lib CBot)
+install(TARGETS CBot LIBRARY DESTINATION "${COLOBOT_LIB_DIR}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -195,4 +195,5 @@ add_executable(colobot ${SOURCES})
 
 target_link_libraries(colobot ${LIBS})
 
-install_targets(/games colobot)
+install(TARGETS colobot RUNTIME DESTINATION games/)
+set_target_properties(colobot PROPERTIES INSTALL_RPATH ${COLOBOT_LIB_DIR})


### PR DESCRIPTION
closes #90
- Make it configurable;
- Move stanzas above the src directory inclusion, otherwise the value doesn't propagate.
