### PR TITLE
Allow building and installation of documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,3 +167,16 @@ set(COLOBOT_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib/colobot CACHE PATH "Colobot libr
 add_subdirectory(src bin)
 
 install(DIRECTORY ../data DESTINATION ${COLOBOT_DATA_DIR})
+
+# Build and install documentation
+set(COLOBOT_DOC_DIR ${CMAKE_INSTALL_PREFIX}/share/doc/colobot CACHE PATH "Colobot documentation directory")
+
+find_package(Doxygen)
+if(DOXYGEN_FOUND AND DOXYGEN_DOT_FOUND)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+    add_custom_target(doc
+                      ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                      COMMENT "Generating API documentation with Doxygen" VERBATIM )
+    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc/ DESTINATION ${COLOBOT_DOC_DIR} OPTIONAL)
+endif(DOXYGEN_FOUND AND DOXYGEN_DOT_FOUND)

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -665,8 +665,8 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = "src" \
-                         "src/CBot"
+INPUT                  = "@CMAKE_CURRENT_SOURCE_DIR@/src" \
+                         "@CMAKE_CURRENT_SOURCE_DIR@/src/CBot"
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is


### PR DESCRIPTION
Run `make doc` for the building. Then `make install` will install the
generated documentation.
- Move Doxyfile to Doxyfile.in, put CMAKE_CURRENT_SOURCE_DIR into it.
