### PR TITLE
Minor cmake grammar fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,8 +160,8 @@ if(${TESTS})
 endif()
 
 # TODO: provide data files as git submodule
-set(COLOBOT_DATA_DIR ${CMAKE_INSTALL_PREFIX}/share/games/colobot CACHE PATH "Colobot shared data directory")
-set(COLOBOT_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib/colobot CACHE PATH "Colobot libraries directory")
+set(COLOBOT_DATA_DIR share/games/colobot CACHE PATH "Colobot shared data directory")
+set(COLOBOT_LIB_DIR lib/colobot CACHE PATH "Colobot libraries directory")
 
 # Subdirectory with sources
 add_subdirectory(src bin)

--- a/src/CBot/CMakeLists.txt
+++ b/src/CBot/CMakeLists.txt
@@ -18,4 +18,4 @@ else()
     add_library(CBot SHARED ${SOURCES})
 endif()
 
-install(TARGETS CBot LIBRARY DESTINATION "${COLOBOT_LIB_DIR}")
+install(TARGETS CBot LIBRARY DESTINATION ${COLOBOT_LIB_DIR})


### PR DESCRIPTION
It is redundant to have CMAKE_INSTALL_PREFIX in path definitions; drop them.
