### PR TITLE
Reduce dependencies installation in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ script: cmake . -DCMAKE_VERBOSE_MAKEFILE=ON && make all doc test
 before_install:
   - git submodule update --init --recursive
   - sudo apt-get update -qq
-  - sudo apt-get install -qq libgl1-mesa-dev libsdl1.2-dev libsdl-image1.2-dev libsdl-ttf2.0-dev libpng12-dev libltdl-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-regex-dev google-mock libgtest-dev doxygen graphviz
+  - sudo apt-get install -qq --no-install-recommends libgl1-mesa-dev libsdl1.2-dev libsdl-image1.2-dev libsdl-ttf2.0-dev libpng12-dev libltdl-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-regex-dev google-mock libgtest-dev doxygen graphviz


### PR DESCRIPTION
Use apt-get's --no-install-recommends.

According to travis, this reduces the build time of 20% (from ~ 6 minutes to ~ 5 minutes)
