### PR TITLE
Fix CMake flags handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,9 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 # Global compile flags
 # These are specific to GCC/MinGW; for other compilers, change as necessary
-set(CMAKE_CXX_FLAGS_RELEASE "-O2 -Wall -Wold-style-cast -std=gnu++0x")
-set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wold-style-cast -std=gnu++0x")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wold-style-cast -std=gnu++0x")
+set(CMAKE_CXX_FLAGS_RELEASE "-O2")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 
 # Asserts can be enabled/disabled regardless of build type
 option(ASSERTS "Enable assert()s" ON)

--- a/src/CBot/tests/CBot_console/CMakeLists.txt
+++ b/src/CBot/tests/CBot_console/CMakeLists.txt
@@ -8,8 +8,9 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 
 # Global compile flags
-set(CMAKE_CXX_FLAGS_RELEASE "-O2 -Wall -Wold-style-cast -std=gnu++0x")
-set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wold-style-cast -std=gnu++0x")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wold-style-cast -std=gnu++0x")
+set(CMAKE_CXX_FLAGS_RELEASE "-O2")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 
 # Include cmake directory
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${colobot_SOURCE_DIR}/cmake")

--- a/src/common/test/CMakeLists.txt
+++ b/src/common/test/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 2.8)
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE debug)
 endif(NOT CMAKE_BUILD_TYPE)
-set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wold-style-cast -std=gnu++0x")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wold-style-cast -std=gnu++0x")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 
 include_directories(
 .

--- a/src/graphics/engine/test/CMakeLists.txt
+++ b/src/graphics/engine/test/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 2.8)
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE debug)
 endif(NOT CMAKE_BUILD_TYPE)
-set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wold-style-cast -std=gnu++0x")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wold-style-cast -std=gnu++0x")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 
 set(MODELFILE_TEST_SOURCES
 modelfile_test.cpp

--- a/src/graphics/opengl/test/CMakeLists.txt
+++ b/src/graphics/opengl/test/CMakeLists.txt
@@ -8,7 +8,8 @@ find_package(PNG REQUIRED)
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE debug)
 endif(NOT CMAKE_BUILD_TYPE)
-set(CMAKE_CXX_FLAGS_DEBUG "-Wall -g -O0 -Wold-style-cast -std=gnu++0x")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wold-style-cast -std=gnu++0x")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 
 set(ADD_LIBS "")
 

--- a/src/math/test/CMakeLists.txt
+++ b/src/math/test/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 2.8)
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE debug)
 endif(NOT CMAKE_BUILD_TYPE)
-set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wold-style-cast -std=gnu++0x")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wold-style-cast -std=gnu++0x")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 
 include_directories(
 .

--- a/src/plugins/test/CMakeLists.txt
+++ b/src/plugins/test/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 2.8)
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE debug)
 endif(NOT CMAKE_BUILD_TYPE)
-set(CMAKE_CXX_FLAGS_DEBUG "-Wall -g -O0 -std=c++11 -rdynamic")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11 -rdynamic")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 
 add_executable(manager_test manager_test.cpp ../../common/logger.cpp ../../common/profile.cpp ../../common/iman.cpp ../pluginmanager.cpp ../pluginloader.cpp)
 

--- a/src/sound/plugins/oalsound/CMakeLists.txt
+++ b/src/sound/plugins/oalsound/CMakeLists.txt
@@ -6,7 +6,8 @@ set(SOURCES
     channel.cpp
 )
 
-SET (CMAKE_CXX_FLAGS "-Wall  -g -std=c++0x -fPIC")
+SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++0x -fPIC")
+SET (CMAKE_CXX_FLAGS_DEBUG "-g")
 
 include(FindPkgConfig)
 include(FindOpenAL)

--- a/src/sound/plugins/oalsound/test/CMakeLists.txt
+++ b/src/sound/plugins/oalsound/test/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 2.8)
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE debug)
 endif(NOT CMAKE_BUILD_TYPE)
-set(CMAKE_CXX_FLAGS_DEBUG "-Wall -g -O0 -std=c++11 -rdynamic")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11 -rdynamic")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 
 add_executable(plugin_test plugin_test.cpp ../../../../common/iman.cpp ../../../../common/logger.cpp ../../../../plugins/pluginloader.cpp)
 

--- a/src/ui/test/CMakeLists.txt
+++ b/src/ui/test/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 2.8)
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE debug)
 endif(NOT CMAKE_BUILD_TYPE)
-set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wold-style-cast -std=gnu++0x")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wold-style-cast -std=gnu++0x")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 
 include_directories(
 .


### PR DESCRIPTION
As explained in the commits, there are two problems:

1) it is not possible to override (at compile time) the CMAKE_BUILD_TYPE;

2) redundantly putting the "common" flags in both CMAKE_CXX_FLAGS_RELEASE and CMAKE_CXX_FLAGS_DEBUG doesn't really scale. And doesn't work if you use a non-Release, non-Debug build-type;

Also I'm not sure I understand why this logic is duplicated all over the CMakeLists.txt's : could that not be simply dropped (and overriden in the cases where it is necessary) ?
