### PR TITLE
Added functions "canbuild(category)" and "buildinfo(category)"

### DIFF
--- a/src/script/cbottoken.cpp
+++ b/src/script/cbottoken.cpp
@@ -262,6 +262,8 @@ std::string GetHelpFilename(const char *token)
     if ( strcmp(token, "turn"          ) == 0 )  return std::string("help/") + CApplication::GetInstancePointer()->GetLanguageChar() + std::string("/cbot/turn.txt");
     if ( strcmp(token, "goto"          ) == 0 )  return std::string("help/") + CApplication::GetInstancePointer()->GetLanguageChar() + std::string("/cbot/goto.txt");
     if ( strcmp(token, "grab"          ) == 0 )  return std::string("help/") + CApplication::GetInstancePointer()->GetLanguageChar() + std::string("/cbot/grab.txt");
+    if ( strcmp(token, "buildinfo"     ) == 0 )  return std::string("help/") + CApplication::GetInstancePointer()->GetLanguageChar() + std::string("/cbot/buildinfo.txt");
+    if ( strcmp(token, "canbuild"      ) == 0 )  return std::string("help/") + CApplication::GetInstancePointer()->GetLanguageChar() + std::string("/cbot/canbuild.txt");
     if ( strcmp(token, "build"         ) == 0 )  return std::string("help/") + CApplication::GetInstancePointer()->GetLanguageChar() + std::string("/cbot/build.txt");
     if ( strcmp(token, "drop"          ) == 0 )  return std::string("help/") + CApplication::GetInstancePointer()->GetLanguageChar() + std::string("/cbot/drop.txt");
     if ( strcmp(token, "sniff"         ) == 0 )  return std::string("help/") + CApplication::GetInstancePointer()->GetLanguageChar() + std::string("/cbot/sniff.txt");
@@ -380,7 +382,9 @@ bool IsFunction(const char *token)
     if ( strcmp(token, "turn"         ) == 0 )  return true;
     if ( strcmp(token, "goto"         ) == 0 )  return true;
     if ( strcmp(token, "grab"         ) == 0 )  return true;
-    if ( strcmp(token, "build"         ) == 0 ) return true;
+    if ( strcmp(token, "buildinfo"    ) == 0 ) return true;
+    if ( strcmp(token, "canbuild"     ) == 0 ) return true;
+    if ( strcmp(token, "build"        ) == 0 ) return true;
     if ( strcmp(token, "drop"         ) == 0 )  return true;
     if ( strcmp(token, "sniff"        ) == 0 )  return true;
     if ( strcmp(token, "receive"      ) == 0 )  return true;
@@ -463,7 +467,9 @@ const char* GetHelpText(const char *token)
     if ( strcmp(token, "turn"      ) == 0 )  return "turn ( angle );";
     if ( strcmp(token, "goto"      ) == 0 )  return "goto ( position, altitude );";
     if ( strcmp(token, "grab"      ) == 0 )  return "grab ( order );";
-    if ( strcmp(token, "build"      ) == 0 )  return "build ( category );";
+    if ( strcmp(token, "buildinfo" ) == 0 )  return "buildinfo ( category );";
+    if ( strcmp(token, "canbuild"  ) == 0 )  return "canbuild ( category );";
+    if ( strcmp(token, "build"     ) == 0 )  return "build ( category );";
     if ( strcmp(token, "drop"      ) == 0 )  return "drop ( order );";
     if ( strcmp(token, "sniff"     ) == 0 )  return "sniff ( );";
     if ( strcmp(token, "receive"   ) == 0 )  return "receive ( name, power );";

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -104,7 +104,8 @@ private:
     static CBotTypResult cSearch(CBotVar* &var, void* user);
     static CBotTypResult cRadar(CBotVar* &var, void* user);
     static CBotTypResult cDetect(CBotVar* &var, void* user);
-    static CBotTypResult cDirection(CBotVar* &var, void* user);    
+    static CBotTypResult cDirection(CBotVar* &var, void* user);
+    static CBotTypResult cCanBuild(CBotVar* &var, void* user);
     static CBotTypResult cProduce(CBotVar* &var, void* user);
     static CBotTypResult cDistance(CBotVar* &var, void* user);
     static CBotTypResult cSpace(CBotVar* &var, void* user);
@@ -139,6 +140,8 @@ private:
     static bool rRadar(CBotVar* var, CBotVar* result, int& exception, void* user);
     static bool rDetect(CBotVar* var, CBotVar* result, int& exception, void* user);
     static bool rDirection(CBotVar* var, CBotVar* result, int& exception, void* user);
+    static bool rBuildInfo(CBotVar* var, CBotVar* result, int& exception, void* user);
+    static bool rCanBuild(CBotVar* var, CBotVar* result, int& exception, void* user);
     static bool rBuild(CBotVar* var, CBotVar* result, int& exception, void* user);
     static bool rProduce(CBotVar* var, CBotVar* result, int& exception, void* user);
     static bool rDistance(CBotVar* var, CBotVar* result, int& exception, void* user);


### PR DESCRIPTION
Also fixed issue with undefined behavior of build(category) function.

canbuild(category)

returns true if a player can build this category for in this mission. If category is Nuclear Plant or Tower, also checks, if they were researched, and if not, then returns false

buildinfo(category) 

the same as above,  but you can determine if this category is not researched, or you can't build it in this mission:
 returns   0(ERR_OK)             if this building can be built
 returns 132 (ERR_BUILD_DISABLED) if can not build in a current mission
 returns 133 (ERR_BUILD_RESEARCH) if this building needs to be researched

Also this pull request should fix issue with undefined behavior of "build(instruction)"
