### PR TITLE
colobot-data: Files under unclear license

### DIFF
--- a/src/ui/maindialog.cpp
+++ b/src/ui/maindialog.cpp
@@ -1841,17 +1841,6 @@ pos.y -= 0.048f;
         pe->SetFontSize(Gfx::FONT_SIZE_SMALL);
         pe->ReadText(std::string("help/") + m_app->GetLanguageChar() + std::string("/authors.txt"));
 
-        pos.x  =  80.0f/640.0f;
-        pos.y  = 140.0f/480.0f;
-        ddim.x = 490.0f/640.0f;
-        ddim.y = 100.0f/480.0f;
-        pe = pw->CreateEdit(pos, ddim, 0, EVENT_EDIT2);
-        pe->SetGenericMode(true);
-        pe->SetEditCap(false);
-        pe->SetHighlightCap(false);
-        pe->SetFontType(Gfx::FONT_COURIER);
-        pe->SetFontSize(Gfx::FONT_SIZE_SMALL);
-        pe->ReadText(std::string("help/") + m_app->GetLanguageChar() + std::string("/licences.txt"));
         // #endif
         /* TODO: #if _SCHOOL
         #if _CEEBOTDEMO


### PR DESCRIPTION
The file data/help/*/licenses.txt points to two suspect files:

1) data/textures/back01.png

> The photograph of the nebula NGC3606 illuminating the sky on Orpheon and the installation program was taken with the Hubble space telescope. It is used with the permission of the authors Wolfgang Brandner (JPL/IPAC), Eva K. Grebel (Washington University), You-Hua Chu (Illinois Urbana-Champaign University) and NASA.

I think this is an other version of the file is referred to from http://commons.wikimedia.org/wiki/File:Life_Cycle_of_Stars_-_GPN-2000-000938.jpg which is licensed in the public-domain by the NASA, which is itself compatible with the GPL-3. The restriction should be removed from licenses.txt to reflect this.

2) data/?

> The thunder sound on Orpheon is used by limited permission from CREATIVE.

I couldn't find the thunder sound on Orpheon. The above restriction is incompatible with GPL-3 so the file should either be dropped or replaced by a GPL-3-compatible version. If that restriction doesn't apply anymore to the mentionned file, the mention should be removed from licenses.txt too.

If both these cases are resolved, the licenses.txt file should be completely removed from the data repository. Resolving these two issues is absolutely needed to make sure the game is fully GPL-3.

Cheers, OdyX
