### PR TITLE
Only use PO4A on desktop file and manpages on non-Windows builds

### DIFF
--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -72,34 +72,33 @@ if(NOT PLATFORM_WINDOWS)
 	    podman(PODFILE colobot.pod)
 	
 	endif()
-
+	
+	# Translate translatable material
+	find_program(PO4A po4a)
+	
+	if(PO4A)
+	    add_custom_target(desktop_po4a
+	        COMMAND ${PO4A} po4a.cfg
+	        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	    )
+	    add_dependencies(desktopfile desktop_po4a)
+	
+	    if(POD2MAN)
+	        add_custom_target(man_po4a
+	            COMMAND ${PO4A} po4a.cfg
+	            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	        )
+	        add_dependencies(man man_po4a)
+	        file(GLOB LINGUAS_PO RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/po/ ${CMAKE_CURRENT_SOURCE_DIR}/po/*.po)
+	        string(REGEX REPLACE ".po$" "" LINGUAS ${LINGUAS_PO})
+	        foreach(LOCALE ${LINGUAS})
+	            podman(PODFILE lang/${LOCALE}/colobot.pod LOCALE ${LOCALE})
+	            add_dependencies(man${PM_LOCALE} man_po4a)
+	        endforeach()
+	    endif()
+	endif()
+	
 else() # if(NOT PLATFORM_WINDOWS)
 	set(COLOBOT_VERSION_4COMMAS "${COLOBOT_VERSION_MAJOR},${COLOBOT_VERSION_MINOR},${COLOBOT_VERSION_REVISION},0")
 	configure_file(colobot.rc.cmake ${CMAKE_CURRENT_BINARY_DIR}/colobot.rc)
 endif()
-
-# Translate translatable material
-find_program(PO4A po4a)
-
-if(PO4A)
-    add_custom_target(desktop_po4a
-        COMMAND ${PO4A} po4a.cfg
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    )
-    add_dependencies(desktopfile desktop_po4a)
-
-    if(POD2MAN)
-        add_custom_target(man_po4a
-            COMMAND ${PO4A} po4a.cfg
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        )
-        add_dependencies(man man_po4a)
-        file(GLOB LINGUAS_PO RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/po/ ${CMAKE_CURRENT_SOURCE_DIR}/po/*.po)
-        string(REGEX REPLACE ".po$" "" LINGUAS ${LINGUAS_PO})
-        foreach(LOCALE ${LINGUAS})
-            podman(PODFILE lang/${LOCALE}/colobot.pod LOCALE ${LOCALE})
-            add_dependencies(man${PM_LOCALE} man_po4a)
-        endforeach()
-    endif()
-endif()
-


### PR DESCRIPTION
Fixes the MXE-with-PO4A build

@krzys_h & @Raptor, that should interest you.

Cheers,

OdyX
