### PR TITLE
Allow PHYSFS to follow symlinks, fixes the launch on Debian systems

### DIFF
--- a/src/common/resources/resourcemanager.cpp
+++ b/src/common/resources/resourcemanager.cpp
@@ -127,6 +127,7 @@ SDL_RWops* CResourceManager::GetSDLFileHandler(const std::string &filename)
         return nullptr;
     }
 
+    PHYSFS_permitSymbolicLinks(1);
     PHYSFS_File *file = PHYSFS_openRead(CleanPath(filename).c_str());
     if (!file)
     {


### PR DESCRIPTION
On Debian, I'm adding symlinks for the fonts to avoid binaries' duplication on the user's systems.

This patch makes this setup work.
