### PR TITLE
Reproducibility: Disable timestamps in the Doxygen-generated HTML documentation

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -952,7 +952,7 @@ HTML_COLORSTYLE_GAMMA  = 80
 # page will contain the date and time when the page was generated. Setting
 # this to NO can help when comparing the output of multiple runs.
 
-HTML_TIMESTAMP         = YES
+HTML_TIMESTAMP         = NO
 
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the


### PR DESCRIPTION
Maria Valentina Marin reported the [#787829 Debian bug](https://bugs.debian.org/787829) in the context of the [Reproducible Builds Initiative](https://wiki.debian.org/ReproducibleBuilds) .

Disabling the timestamps in the Doxygen-generated HTML documentation makes Colobot build reproducibly; please merge this change. :)