### PR TITLE
Set CBotVar::m_binit type to specific enum instead of plain int.

### DIFF
--- a/src/CBot/CBot.cpp
+++ b/src/CBot/CBot.cpp
@@ -1593,7 +1593,7 @@ CBotInstr* CBotExpression::Compile(CBotToken* &p, CBotCStack* pStack)
             return NULL;
         }
 
-        if (OpType != ID_ASS && !var->InitDefined())
+        if (OpType != ID_ASS && !var->IsDefined())
         {
             pStack->SetError(TX_NOTINIT, pp);
             delete inst;
@@ -2075,12 +2075,12 @@ bool CBotPostIncExpr::Execute(CBotStack* &pj)
     CBotStack* pile3 = pile2->AddStack(this);
     if (pile3->IfStep()) return false;
 
-    if (var1->InitNAN())
+    if (var1->IsNAN())
     {
         pile1->SetError(TX_OPNAN, &m_token);
     }
 
-    if (!var1->InitDefined())
+    if (!var1->IsDefined())
     {
         pile1->SetError(TX_NOTINIT, &m_token);
     }
@@ -2118,13 +2118,13 @@ bool CBotPreIncExpr::Execute(CBotStack* &pj)
         // pile2 is modified on return
         if (!(static_cast<CBotExprVar*>(m_Instr))->ExecuteVar(var1, pile2, NULL, true)) return false;
 
-        if (var1->InitNAN())
+        if (var1->IsNAN())
         {
             pile->SetError(TX_OPNAN, &m_token);
             return pj->Return(pile);    // operation performed
         }
 
-        if (!var1->InitDefined())
+        if (!var1->IsDefined())
         {
             pile->SetError(TX_NOTINIT, &m_token);
             return pj->Return(pile);    // operation performed
@@ -3256,7 +3256,7 @@ bool CBotExprVar::Execute(CBotStack* &pj)
         return pj->Return(pile1);
     }
 
-    if (pVar->InitUndefined())
+    if (pVar->IsUndefined())
     {
         CBotToken* pt = &m_token;
         while (pt->GetNext() != NULL) pt = pt->GetNext();

--- a/src/CBot/CBotClass.cpp
+++ b/src/CBot/CBotClass.cpp
@@ -605,7 +605,7 @@ CBotInstr* CBotClassInst::Compile(CBotToken* &p, CBotCStack* pStack, CBotClass* 
                 var->SetPointer( pvar );                    // variable already declared instance pointer
                 delete pvar;                                // removes the second pointer
             }
-            var->SetInit(true);                         // marks the pointer as init
+            var->SetInit(CBotVar::InitType::DEF);                         // marks the pointer as init
         }
         else if (inst->m_hasParams)
         {
@@ -617,7 +617,7 @@ CBotInstr* CBotClassInst::Compile(CBotToken* &p, CBotCStack* pStack, CBotClass* 
                 var->SetPointer( pvar );                    // variable already declared instance pointer
                 delete pvar;                                // removes the second pointer
             }
-            var->SetInit(2);                            // marks the pointer as init
+            var->SetInit(CBotVar::InitType::IS_POINTER);                            // marks the pointer as init
         }
 suite:
         if (IsOfType(p,  ID_COMMA))                         // several chained definitions
@@ -704,7 +704,7 @@ bool CBotClassInst::Execute(CBotStack* &pj)
                 pInstance = (static_cast<CBotVarPointer*>(pile->GetVar()))->GetPointer();    // value for the assignment
                 pThis->SetPointer(pInstance);
             }
-            pThis->SetInit(true);
+            pThis->SetInit(CBotVar::InitType::DEF);
         }
 
         else if ( m_hasParams )
@@ -757,7 +757,7 @@ bool CBotClassInst::Execute(CBotStack* &pj)
                                          pThis, ppVars,
                                          pResult, pile2, GetToken())) return false; // interrupt
 
-            pThis->SetInit(true);
+            pThis->SetInit(CBotVar::InitType::DEF);
             pThis->ConstructorSet();        // indicates that the constructor has been called
             pile->Return(pile2);                                // releases a piece of stack
 

--- a/src/CBot/CBotDll.h
+++ b/src/CBot/CBotDll.h
@@ -547,11 +547,6 @@ bool rMean(CBotVar* pVar, CBotVar* pResult, int& Exception)
 // may be useful to the outside of the module
 // ( it is currently not expected to be able to create these objects in outer )
 
-// results of GetInit()
-#define    IS_UNDEF    0        // undefined variable
-#define IS_DEF        1        // variable defined
-#define    IS_NAN        999        // variable defined as not a number
-
 // variable type SetPrivate / IsPrivate
 #define PR_PUBLIC    0        // public variable
 #define    PR_READ        1        // read only
@@ -560,6 +555,10 @@ bool rMean(CBotVar* pVar, CBotVar* pResult, int& Exception)
 
 class CBotVar
 {
+public:
+    // results of GetInit()
+    enum class InitType : int { UNDEF = 0, DEF = 1, IS_POINTER = 2, IS_NAN = 999 };
+
 protected:
     CBotToken*        m_token;                    // the corresponding token
 
@@ -571,7 +570,7 @@ protected:
 
     CBotTypResult    m_type;                        // type of value
 
-    int                m_binit;                    // not initialized?
+    InitType         m_binit;                    // not initialized?
     CBotVarClass*    m_pMyThis;                    // ^ corresponding this element
     void*            m_pUserPtr;                    // ^user data if necessary
     bool            m_bStatic;                    // static element (in class)
@@ -635,9 +634,11 @@ virtual                ~CBotVar( );                        // destructor
     CBotToken*        GetToken();
     void            SetType(CBotTypResult& type);
 
-    void            SetInit(int bInit);            // is the variable in the state IS_UNDEF, IS_DEF, IS_NAN
-
-    int                GetInit();                    // gives the state of the variable
+    void            SetInit(InitType initKind);            // is the variable in the state IS_UNDEF, IS_DEF, IS_NAN
+    InitType        GetInit() const;                    // gives the state of the variable
+    bool InitUndefined() const { return GetInit() == InitType::UNDEF; }
+    bool InitDefined() const { return GetInit() == InitType::DEF; }
+    bool InitNAN() const { return GetInit() == InitType::IS_NAN; }
 
     void            SetStatic(bool bStatic);
     bool            IsStatic();

--- a/src/CBot/CBotDll.h
+++ b/src/CBot/CBotDll.h
@@ -634,11 +634,11 @@ virtual                ~CBotVar( );                        // destructor
     CBotToken*        GetToken();
     void            SetType(CBotTypResult& type);
 
-    void            SetInit(InitType initKind);            // is the variable in the state IS_UNDEF, IS_DEF, IS_NAN
-    InitType        GetInit() const;                    // gives the state of the variable
-    bool InitUndefined() const { return GetInit() == InitType::UNDEF; }
-    bool InitDefined() const { return GetInit() == InitType::DEF; }
-    bool InitNAN() const { return GetInit() == InitType::IS_NAN; }
+    void            SetInit(InitType initType);            // is the variable in the state UNDEF, DEF, NAN
+    InitType        GetInit() const;                       // gives the state of the variable
+    bool IsUndefined() const { return GetInit() == InitType::UNDEF; }
+    bool IsDefined() const { return GetInit() == InitType::DEF; }
+    bool IsNAN() const { return GetInit() == InitType::IS_NAN; }
 
     void            SetStatic(bool bStatic);
     bool            IsStatic();

--- a/src/CBot/CBotTwoOpExpr.cpp
+++ b/src/CBot/CBotTwoOpExpr.cpp
@@ -29,9 +29,7 @@ namespace
 {
 bool VarIsNAN(const CBotVar* var)
 {
-    const CBotVar::InitType initType = var->GetInit();
-    return initType != CBotVar::InitType::IS_NAN
-           && initType != CBotVar::InitType::IS_POINTER;
+    return var->GetInit() > CBotVar::InitType::DEF;
 }
 }
 

--- a/src/CBot/CBotTwoOpExpr.cpp
+++ b/src/CBot/CBotTwoOpExpr.cpp
@@ -25,6 +25,16 @@
 
 #include <cassert>
 
+namespace
+{
+bool VarIsNAN(const CBotVar* var)
+{
+    const CBotVar::InitType initType = var->GetInit();
+    return initType != CBotVar::InitType::IS_NAN
+           && initType != CBotVar::InitType::IS_POINTER;
+}
+}
+
 // various constructors
 
 CBotTwoOpExpr::CBotTwoOpExpr()
@@ -288,7 +298,7 @@ CBotInstr* CBotTwoOpExpr::Compile(CBotToken* &p, CBotCStack* pStack, int* pOpera
 
 bool IsNan(CBotVar* left, CBotVar* right, int* err = NULL)
 {
-    if ( left ->GetInit() > IS_DEF || right->GetInit() > IS_DEF )
+    if ( VarIsNAN(left) || VarIsNAN(right) )
     {
         if ( err != NULL ) *err = TX_OPNAN ;
         return true;

--- a/src/CBot/StringFunctions.cpp
+++ b/src/CBot/StringFunctions.cpp
@@ -323,7 +323,7 @@ bool rStrFind( CBotVar* pVar, CBotVar* pResult, int& ex, void* pUser )
     // puts the result on the stack
     int res = s.Find(s2);
     pResult->SetValInt( res );
-    if ( res < 0 ) pResult->SetInit( IS_NAN );
+    if ( res < 0 ) pResult->SetInit( CBotVar::InitType::IS_NAN );
     return true;
 }
 

--- a/src/object/old_object.cpp
+++ b/src/object/old_object.cpp
@@ -117,11 +117,11 @@ void uObject(CBotVar* botThis, void* user)
     else    // object transported?
     {
         pSub = pVar->GetItemList();  // "x"
-        pSub->SetInit(IS_NAN);
+        pSub->SetInit(CBotVar::InitType::IS_NAN);
         pSub = pSub->GetNext();  // "y"
-        pSub->SetInit(IS_NAN);
+        pSub->SetInit(CBotVar::InitType::IS_NAN);
         pSub = pSub->GetNext();  // "z"
-        pSub->SetInit(IS_NAN);
+        pSub->SetInit(CBotVar::InitType::IS_NAN);
     }
 
     // Updates the angle.

--- a/src/script/scriptfunc.cpp
+++ b/src/script/scriptfunc.cpp
@@ -3390,7 +3390,7 @@ bool CScriptFunctions::rfdestruct (CBotVar* pThis, CBotVar* pVar, CBotVar* pResu
     pVar = pThis->GetItem("handle");
 
     // don't open? no problem :)
-    if ( pVar->InitDefined()) return true;
+    if ( pVar->IsDefined()) return true;
 
     int fileHandle = pVar->GetValInt();
 
@@ -3443,7 +3443,7 @@ bool CScriptFunctions::rfopen (CBotVar* pThis, CBotVar* pVar, CBotVar* pResult, 
     pVar = pThis->GetItem("handle");
 
     // which must not be initialized
-    if ( pVar->InitDefined()) { Exception = CBotErrFileOpen; return false; }
+    if ( pVar->IsDefined()) { Exception = CBotErrFileOpen; return false; }
 
     // file contains the name
     pVar = pThis->GetItem("filename");
@@ -3511,11 +3511,11 @@ bool CScriptFunctions::rfclose (CBotVar* pThis, CBotVar* pVar, CBotVar* pResult,
     // retrieve the item "handle"
     pVar = pThis->GetItem("handle");
 
-    if ( !pVar->InitDefined()) { Exception = CBotErrNotOpen; return false; }
+    if ( !pVar->IsDefined()) { Exception = CBotErrNotOpen; return false; }
 
     int fileHandle = pVar->GetValInt();
 
-    const FilesMap::const_iterator handleIter = m_files.find(fileHandle);
+    const auto handleIter = m_files.find(fileHandle);
     if (handleIter == m_files.end())
     {
         Exception = CBotErrNotOpen;
@@ -3559,11 +3559,11 @@ bool CScriptFunctions::rfwrite (CBotVar* pThis, CBotVar* pVar, CBotVar* pResult,
     // retrieve the item "handle"
     pVar = pThis->GetItem("handle");
 
-    if ( !pVar->InitDefined()) { Exception = CBotErrNotOpen; return false; }
+    if ( !pVar->IsDefined()) { Exception = CBotErrNotOpen; return false; }
 
     int fileHandle = pVar->GetValInt();
 
-    const FilesMap::const_iterator handleIter = m_files.find(fileHandle);
+    const auto handleIter = m_files.find(fileHandle);
     if (handleIter == m_files.end())
     {
         Exception = CBotErrNotOpen;
@@ -3605,11 +3605,11 @@ bool CScriptFunctions::rfread(CBotVar* pThis, CBotVar* pVar, CBotVar* pResult, i
     // retrieve the item "handle"
     pVar = pThis->GetItem("handle");
 
-    if (!pVar->InitDefined()) { Exception = CBotErrNotOpen; return false; }
+    if (!pVar->IsDefined()) { Exception = CBotErrNotOpen; return false; }
 
     int fileHandle = pVar->GetValInt();
 
-    const FilesMap::const_iterator handleIter = m_files.find(fileHandle);
+    const auto handleIter = m_files.find(fileHandle);
     if (handleIter == m_files.end())
     {
         Exception = CBotErrNotOpen;
@@ -3654,11 +3654,11 @@ bool CScriptFunctions::rfeof (CBotVar* pThis, CBotVar* pVar, CBotVar* pResult, i
     // retrieve the item "handle"
     pVar = pThis->GetItem("handle");
 
-    if ( !pVar->InitDefined()) { Exception = CBotErrNotOpen; return false; }
+    if ( !pVar->IsDefined()) { Exception = CBotErrNotOpen; return false; }
 
     int fileHandle = pVar->GetValInt();
 
-    const FilesMap::const_iterator handleIter = m_files.find(fileHandle);
+    const auto handleIter = m_files.find(fileHandle);
     if (handleIter == m_files.end())
     {
         Exception = CBotErrNotOpen;

--- a/src/script/scriptfunc.cpp
+++ b/src/script/scriptfunc.cpp
@@ -2311,16 +2311,16 @@ bool CScriptFunctions::rReceive(CBotVar* var, CBotVar* result, int& exception, v
         {
             delete script->m_primaryTask;
             script->m_primaryTask = 0;
-            result->SetInit(IS_NAN);
+            result->SetInit(CBotVar::InitType::IS_NAN);
             return true;
         }
     }
     if ( !Process(script, result, exception) )  return false;  // not finished
 
     value = pThis->GetInfoReturn();
-    if ( value == NAN )
+    if ( std::isnan(value) )
     {
-        result->SetInit(IS_NAN);
+        result->SetInit(CBotVar::InitType::IS_NAN);
     }
     else
     {
@@ -3390,7 +3390,7 @@ bool CScriptFunctions::rfdestruct (CBotVar* pThis, CBotVar* pVar, CBotVar* pResu
     pVar = pThis->GetItem("handle");
 
     // don't open? no problem :)
-    if ( pVar->GetInit() != IS_DEF) return true;
+    if ( pVar->InitDefined()) return true;
 
     int fileHandle = pVar->GetValInt();
 
@@ -3398,7 +3398,7 @@ bool CScriptFunctions::rfdestruct (CBotVar* pThis, CBotVar* pVar, CBotVar* pResu
     fclose(pFile);
     m_numberOfOpenFiles--;
 
-    pVar->SetInit(IS_NAN);
+    pVar->SetInit(CBotVar::InitType::IS_NAN);
 
     m_files.erase(fileHandle);
 
@@ -3443,7 +3443,7 @@ bool CScriptFunctions::rfopen (CBotVar* pThis, CBotVar* pVar, CBotVar* pResult, 
     pVar = pThis->GetItem("handle");
 
     // which must not be initialized
-    if ( pVar->GetInit() == IS_DEF) { Exception = CBotErrFileOpen; return false; }
+    if ( pVar->InitDefined()) { Exception = CBotErrFileOpen; return false; }
 
     // file contains the name
     pVar = pThis->GetItem("filename");
@@ -3511,17 +3511,24 @@ bool CScriptFunctions::rfclose (CBotVar* pThis, CBotVar* pVar, CBotVar* pResult,
     // retrieve the item "handle"
     pVar = pThis->GetItem("handle");
 
-    if ( pVar->GetInit() != IS_DEF) { Exception = CBotErrNotOpen; return false; }
+    if ( !pVar->InitDefined()) { Exception = CBotErrNotOpen; return false; }
 
     int fileHandle = pVar->GetValInt();
 
-    FILE* pFile = m_files[fileHandle];
-    fclose(pFile);
+    const FilesMap::const_iterator handleIter = m_files.find(fileHandle);
+    if (handleIter == m_files.end())
+    {
+        Exception = CBotErrNotOpen;
+        return false;
+    }
+
+    assert(handleIter->second);
+    fclose(handleIter->second);
     m_numberOfOpenFiles--;
 
-    pVar->SetInit(IS_NAN);
+    pVar->SetInit(CBotVar::InitType::IS_NAN);
 
-    m_files.erase(fileHandle);
+    m_files.erase(handleIter);
 
     return true;
 }
@@ -3552,13 +3559,18 @@ bool CScriptFunctions::rfwrite (CBotVar* pThis, CBotVar* pVar, CBotVar* pResult,
     // retrieve the item "handle"
     pVar = pThis->GetItem("handle");
 
-    if ( pVar->GetInit() != IS_DEF) { Exception = CBotErrNotOpen; return false; }
+    if ( !pVar->InitDefined()) { Exception = CBotErrNotOpen; return false; }
 
     int fileHandle = pVar->GetValInt();
 
-    FILE* pFile = m_files[fileHandle];
+    const FilesMap::const_iterator handleIter = m_files.find(fileHandle);
+    if (handleIter == m_files.end())
+    {
+        Exception = CBotErrNotOpen;
+        return false;
+    }
 
-    int res = fputs(param+CBotString("\n"), pFile);
+    int res = fputs(param+CBotString("\n"), handleIter->second);
 
     // if an error occurs generate an exception
     if ( res < 0 ) { Exception = CBotErrWrite; return false; }
@@ -3593,23 +3605,28 @@ bool CScriptFunctions::rfread(CBotVar* pThis, CBotVar* pVar, CBotVar* pResult, i
     // retrieve the item "handle"
     pVar = pThis->GetItem("handle");
 
-    if (pVar->GetInit() != IS_DEF) { Exception = CBotErrNotOpen; return false; }
+    if (!pVar->InitDefined()) { Exception = CBotErrNotOpen; return false; }
 
     int fileHandle = pVar->GetValInt();
 
-    FILE* pFile = m_files[fileHandle];
-
+    const FilesMap::const_iterator handleIter = m_files.find(fileHandle);
+    if (handleIter == m_files.end())
+    {
+        Exception = CBotErrNotOpen;
+        return false;
+    }
+    
     char    chaine[2000];
     int     i;
     for (i = 0; i < 2000; i++) chaine[i] = 0;
 
-    if (fgets(chaine, 1999, pFile) != nullptr)
+    if (fgets(chaine, 1999, handleIter->second) != nullptr)
     {
         for (i = 0; i < 2000; i++) if (chaine[i] == '\n') chaine[i] = 0;
     }
 
     // if an error occurs generate an exception
-    if ( ferror(pFile) ) { Exception = CBotErrRead; return false; }
+    if ( ferror(handleIter->second) ) { Exception = CBotErrRead; return false; }
 
     pResult->SetValString( chaine );
 
@@ -3637,13 +3654,18 @@ bool CScriptFunctions::rfeof (CBotVar* pThis, CBotVar* pVar, CBotVar* pResult, i
     // retrieve the item "handle"
     pVar = pThis->GetItem("handle");
 
-    if ( pVar->GetInit() != IS_DEF) { Exception = CBotErrNotOpen; return false; }
+    if ( !pVar->InitDefined()) { Exception = CBotErrNotOpen; return false; }
 
     int fileHandle = pVar->GetValInt();
 
-    FILE* pFile = m_files[fileHandle];
+    const FilesMap::const_iterator handleIter = m_files.find(fileHandle);
+    if (handleIter == m_files.end())
+    {
+        Exception = CBotErrNotOpen;
+        return false;
+    }
 
-    pResult->SetValInt( feof( pFile ) );
+    pResult->SetValInt( feof(handleIter->second) );
 
     return true;
 }

--- a/src/script/scriptfunc.h
+++ b/src/script/scriptfunc.h
@@ -185,6 +185,7 @@ private:
     static bool     ShouldProcessStop(Error err, int errMode);
     static CExchangePost* FindExchangePost(CObject* object, float power);
 
-    static std::unordered_map<int, FILE*> m_files;
+    typedef std::unordered_map<int, FILE*> FilesMap;
+    static FilesMap m_files;
     static int m_nextFile;
 };

--- a/src/script/scriptfunc.h
+++ b/src/script/scriptfunc.h
@@ -185,7 +185,6 @@ private:
     static bool     ShouldProcessStop(Error err, int errMode);
     static CExchangePost* FindExchangePost(CObject* object, float power);
 
-    typedef std::unordered_map<int, FILE*> FilesMap;
-    static FilesMap m_files;
+    static std::unordered_map<int, FILE*> m_files;
     static int m_nextFile;
 };


### PR DESCRIPTION
Hi!

The main purpose of this request is to fix compiler warnings about CBotVar::m_binit member.
It was just int variable and there were many lines when m_binit was initialized with a boolean value.
Also sometimes literal '2' was used as value for this member (if I understand it correctly, that means an object value or a pointer value).
I used class based enumeration for all possible values to fix unwanted type casts.
As a minor changes I can mention comparison with NAN (replaced with std::isnan() function), and changing unordered_map::operator[] to unordered_map::find (to avoid cases when the map doesn't contain requested key).

Hope that it can be useful.