### PR TITLE
fix MacOSX install instruction and compilation after switch to SDL2

### DIFF
--- a/INSTALL-MacOSX.md
+++ b/INSTALL-MacOSX.md
@@ -8,7 +8,7 @@ After installing Developer Command Line Tools, you should have basic tools like 
 ```
 And then:
 ```bash
-  brew install cmake sdl sdl_image sdl_ttf boost glew physfs flac libsndfile libvorbis vorbis-tools gettext libicns librsvg wget
+  brew install cmake sdl2 sdl2_image sdl2_ttf boost glew physfs flac libsndfile libvorbis vorbis-tools gettext libicns librsvg wget
 ```
 Gettext is installed in separate directory without adding the files to system path, so in order to get it working normally, you should call also:
 ```bash

--- a/src/common/config.h.cmake
+++ b/src/common/config.h.cmake
@@ -16,13 +16,7 @@
 
 #cmakedefine OPENAL_SOUND
 
-#cmakedefine USE_SDL_MAIN @USE_SDL_MAIN@
-
-#ifdef USE_SDL_MAIN
-#define SDL_MAIN_FUNC SDL_main
-#else
 #define SDL_MAIN_FUNC main
-#endif
 
 #cmakedefine PORTABLE @PORTABLE@
 

--- a/src/ui/controls/edit.cpp
+++ b/src/ui/controls/edit.cpp
@@ -304,7 +304,7 @@ bool CEdit::EventProcess(const Event &event)
     {
         bShift   = ( (event.kmodState & KEY_MOD(SHIFT) ) != 0 );
         #if PLATFORM_MACOSX
-        bControl = ( (event.kmodState & KEY_MOD(META) ) != 0);
+        bControl = ( (event.kmodState & KEY_MOD(GUI) ) != 0);
         #else
         bControl = ( (event.kmodState & KEY_MOD(CTRL) ) != 0);
         #endif


### PR DESCRIPTION
@piotrdz @krzys-h this might break windows/linux, I only compile on Mac, please take a look.