### PR TITLE
Deactive pause before jumping to next visit

### DIFF
--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -1631,6 +1631,12 @@ void CRobotMain::StartDisplayVisit(EventType event)
 {
     if (m_editLock) return;
 
+    if (m_visitPause)
+    {
+        m_pause->DeactivatePause(m_visitPause);
+        m_visitPause = nullptr;
+    }
+
     Ui::CWindow* pw = static_cast<Ui::CWindow*>(m_interface->SearchControl(EVENT_WINDOW2));
     if (pw == nullptr) return;
 


### PR DESCRIPTION
When pause was active setting new pause resulted in strange behavior.
This should fix issue #736.