### PR TITLE
Fix function and method overloading

### DIFF
--- a/src/CBot/CBotInstr/CBotFunction.cpp
+++ b/src/CBot/CBotInstr/CBotFunction.cpp
@@ -840,8 +840,8 @@ bool CBotFunction::CheckParam(CBotDefParam* pParam)
     CBotDefParam*   pp = m_param;
     while ( pp != nullptr && pParam != nullptr )
     {
-        CBotTypResult type1 = pp->GetType();
-        CBotTypResult type2 = pParam->GetType();
+        CBotTypResult type1 = pp->GetTypResult();
+        CBotTypResult type2 = pParam->GetTypResult();
         if ( !type1.Compare(type2) ) return false;
         pp = pp->GetNext();
         pParam = pParam->GetNext();


### PR DESCRIPTION
Specifically, with array types as parameters.

Currently, this compiles and shouldn't.
```c++
void test(int[] i){}
void test(int[] i){}
extern void object::New()
{
}
```
This crashes the game on compile.
```c++
public class AClass
{
    void testMethod(int[] i){}
}
extern void object::New()
{
}
```
This is the bug that broke UserLevelHelper userlevel,
when method overloading was fixed.