### PR TITLE
Fix "this" bug "256 & 436"

### DIFF
--- a/src/CBot/CBotInstr/CBotInstrMethode.cpp
+++ b/src/CBot/CBotInstr/CBotInstrMethode.cpp
@@ -119,7 +119,7 @@ bool CBotInstrMethode::ExecuteVar(CBotVar* &pVar, CBotStack* &pj, CBotToken* pre
 
         pThis->SetName("this");
         pThis->SetUniqNum(-2);
-        pile1->AddVar(pThis);
+        pile1->SetVar(pThis);
         pile1->IncState();
     }
     int        i = 0;
@@ -144,7 +144,7 @@ bool CBotInstrMethode::ExecuteVar(CBotVar* &pVar, CBotStack* &pj, CBotToken* pre
     ppVars[i] = nullptr;
 
     CBotClass*    pClass = CBotClass::Find(m_className);
-    CBotVar*    pThis  = pile1->FindVar(-2, false);
+    CBotVar*    pThis  = pile1->GetVar();
     CBotVar*    pResult = nullptr;
     if (m_typRes.GetType() > 0) pResult = CBotVar::Create("", m_typRes);
     if (m_typRes.Eq(CBotTypClass))
@@ -174,7 +174,10 @@ void CBotInstrMethode::RestoreStateVar(CBotStack* &pile, bool bMain)
     CBotStack*    pile2 = pile1->RestoreStack();        // and for the parameters coming
     if (pile2 == nullptr) return;
 
-    CBotVar*    pThis  = pile1->FindVar("this");
+    CBotVar*    pThis  = pile1->GetVar();
+
+    assert(pThis != nullptr); // see fix for issues #256 & #436
+
     pThis->SetUniqNum(-2);
 
     int        i = 0;
@@ -226,7 +229,7 @@ bool CBotInstrMethode::Execute(CBotStack* &pj)
         // Test.Action (Test = Other);
         // Action must act on the value before test = Other!
         pThis->SetName("this");
-        pile1->AddVar(pThis);
+        pile1->SetVar(pThis);
         pile1->IncState();
     }
     int        i = 0;
@@ -250,7 +253,7 @@ bool CBotInstrMethode::Execute(CBotStack* &pj)
     ppVars[i] = nullptr;
 
     CBotClass*    pClass = CBotClass::Find(m_className);
-    CBotVar*    pThis  = pile1->FindVar("this");
+    CBotVar*    pThis  = pile1->GetVar();
     CBotVar*    pResult = nullptr;
     if (m_typRes.GetType()>0) pResult = CBotVar::Create("", m_typRes);
     if (m_typRes.Eq(CBotTypClass))

--- a/src/CBot/CBotStack.cpp
+++ b/src/CBot/CBotStack.cpp
@@ -805,6 +805,8 @@ bool CBotVar::RestoreState(FILE* pf, CBotVar* &pVar)
 
         CBotToken token(name, std::string());
 
+        bool isClass = false;
+
         switch (w)
         {
         case CBotTypInt:
@@ -826,6 +828,7 @@ bool CBotVar::RestoreState(FILE* pf, CBotVar* &pVar)
 
         // returns an intrinsic object or element of an array
         case CBotTypIntrinsic:
+            isClass = true;
         case CBotTypArrayBody:
             {
                 CBotTypResult    r;
@@ -842,6 +845,17 @@ bool CBotVar::RestoreState(FILE* pf, CBotVar* &pVar)
                                                                     // attention cptuse = 0
                     if ( !RestoreState(pf, (static_cast<CBotVarClass*>(pNew))->m_pVar)) return false;
                     pNew->SetIdent(id);
+
+                    if (isClass && p == nullptr) // set id for each item in this instance
+                    {
+                        CBotVar* pVars = pNew->GetItemList();
+                        long itemId = 1;
+                        while (pVars != nullptr)
+                        {
+                            pVars->m_ident = itemId++;
+                            pVars = pVars->GetNext();
+                        }
+                    }
 
                     if ( p != nullptr )
                     {


### PR DESCRIPTION
----------------------------------------------------
Found another bug while fixing "this" bug.
The following bug happens because RestoreState leaves
all instance.variables with m_ident == 0.
```c++
extern void object::New()
{
    point pnt(2,4,6);
    Test  tst(1,2,3);
    message("waiting");
    wait(3);             // save the game here, then reload.
    message("" + pnt.x); // error: this is not a member of this class
    message("" + tst.b); // error: this is not a member of this class
}
public class Test {
    void Test(float A, float B, float C) {
    // saving the game here also breaks a, b, c.
    this.a = A; b = B; c = C;
    }
    float a, b, c;
}
```
----------------------------------------------------
Fix for #256 and #436:

Games that were saved while executing a method call
in a user defined class are not directly compatible
with this fix and will cause a failed assert.

It can be made compatible, but it's probably not needed.
There are probably very few such saved games, if any.
