### PR TITLE
[INFO] Conversion to string

### DIFF
--- a/src/CBot/CBotInstr/CBotInstrUtils.cpp
+++ b/src/CBot/CBotInstr/CBotInstrUtils.cpp
@@ -97,9 +97,9 @@ bool TypeCompatible(CBotTypResult& type1, CBotTypResult& type2, int op)
     if (max == 99) return false;    // result is void?
 
     // special case for strin concatenation
-    if (op == ID_ADD && max >= CBotTypString) return true;
-    if (op == ID_ASSADD && max >= CBotTypString) return true;
-    if (op == ID_ASS && t1 == CBotTypString) return true;
+    if (op == ID_ADD && t1 == CBotTypString) return true;
+    if (op == ID_ASSADD && t2 == CBotTypString) return true;
+    if (op == ID_ASS && t2 == CBotTypString) return true;
 
     if (max >= CBotTypBoolean)
     {

--- a/src/CBot/CBotInstr/CBotInstrUtils.h
+++ b/src/CBot/CBotInstr/CBotInstrUtils.h
@@ -39,7 +39,13 @@ CBotInstr* CompileParams(CBotToken* &p, CBotCStack* pStack, CBotVar** ppVars);
 
 /*!
  * \brief TypeCompatible Check if two results are consistent to make an
- * operation.
+ * operation. TypeCompatible is used in two ways:
+ * For non-assignment operations:  see CBotTwoOpExpr::Compile
+ * TypeCompatible( leftType, rightType, opType )
+
+ * For assignment or compound assignment operations (it's reversed):
+ * see CBotReturn::Compile & CBotExpression::Compile
+ * TypeCompatible( valueType, varType, opType ) 
  * \param type1
  * \param type2
  * \param op

--- a/src/CBot/CBotInstr/CBotLeftExprVar.cpp
+++ b/src/CBot/CBotInstr/CBotLeftExprVar.cpp
@@ -64,6 +64,12 @@ bool CBotLeftExprVar::Execute(CBotStack* &pj)
     CBotVar* var2 = pj->GetVar(); // Initial value on the stack
     if (var2 != nullptr)
     {
+        if (m_typevar.Eq(CBotTypString) && var2->GetType() != CBotTypString)
+        {
+            var2->Update(pj->GetUserPtr());
+            var1->SetValString(var2->GetValString());
+            return true;
+        }
         var1->SetVal(var2); // Set the value
     }
 


### PR DESCRIPTION
@krzys-h, I saw you were working on this so I'm sharing what I did a few days ago.

But first, recent changes appear to have broke these conversions:
```c++
message("" + this);      // output: "Pointer"
message("" + array);     // output: "("
message("" + position);  // output: "point("
```
As for this PR:
The first two commits are good, imo.
I'm not very happy with the third, but it works.

Fixes these bugs:
[TEST_F(CBotUT, DISABLED_FunctionBadReturn)](https://github.com/colobot/colobot/blob/dev/test/unit/CBot/CBot_test.cpp#L664)
Currently, you can return a string from **any** non-void function
and crash the game if you assign that to something other than a string.

[TEST_F(CBotUT, DISABLED_BadStringAdd_Issue535)](https://github.com/colobot/colobot/blob/dev/test/unit/CBot/CBot_test.cpp#L936)
```c++
anArray[0] = "A"; // "issue-419"

voidfunc() + "";  // crash on run

message( "" + voidfunc() ); // crash on run

aVar += ;
aVar = ;
```

