### PR TITLE
Dev boost filesystem removal

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -47,7 +47,6 @@
     #include "sound/oalsound/alsound.h"
 #endif
 
-#include <boost/filesystem.hpp>
 #include <boost/tokenizer.hpp>
 
 #include <SDL.h>

--- a/src/common/resources/resourcemanager.cpp
+++ b/src/common/resources/resourcemanager.cpp
@@ -152,27 +152,17 @@ bool CResourceManager::CreateDirectory(const std::string& directory)
     return false;
 }
 
-//TODO: Don't use boost::filesystem here
 bool CResourceManager::RemoveDirectory(const std::string& directory)
 {
     if (PHYSFS_isInit())
     {
-        bool success = true;
-        std::string writeDir = PHYSFS_getWriteDir();
-        try
+        std::string path = CleanPath(directory);
+        for (auto file : ListFiles(path))
         {
-            std::string path = writeDir + "/" + CleanPath(directory);
-            #if PLATFORM_WINDOWS
-            fs::remove_all(CSystemUtilsWindows::UTF8_Decode(path));
-            #else
-            fs::remove_all(path);
-            #endif
+            if (PHYSFS_delete((path + "/" + file).c_str()) == 0)
+                return false;
         }
-        catch (std::exception&)
-        {
-            success = false;
-        }
-        return success;
+        return PHYSFS_delete(path.c_str()) != 0;
     }
     return false;
 }

--- a/src/common/resources/resourcemanager.cpp
+++ b/src/common/resources/resourcemanager.cpp
@@ -31,10 +31,7 @@
 
 #include <physfs.h>
 
-#include <boost/filesystem.hpp>
 #include <boost/regex.hpp>
-
-namespace fs = boost::filesystem;
 
 
 CResourceManager::CResourceManager(const char *argv0)
@@ -229,32 +226,6 @@ long long CResourceManager::GetLastModificationTime(const std::string& filename)
         return PHYSFS_getLastModTime(CleanPath(filename).c_str());
     }
     return -1;
-}
-
-//TODO: Don't use boost::filesystem. Why doesn't PHYSFS have this?
-bool CResourceManager::Move(const std::string& from, const std::string& to)
-{
-    if (PHYSFS_isInit())
-    {
-        bool success = true;
-        std::string writeDir = PHYSFS_getWriteDir();
-        try
-        {
-            std::string path_from = writeDir + "/" + CleanPath(from);
-            std::string path_to = writeDir + "/" + CleanPath(to);
-            #if PLATFORM_WINDOWS
-            fs::rename(CSystemUtilsWindows::UTF8_Decode(path_from), CSystemUtilsWindows::UTF8_Decode(path_to));
-            #else
-            fs::rename(path_from, path_to);
-            #endif
-        }
-        catch (std::exception&)
-        {
-            success = false;
-        }
-        return success;
-    }
-    return false;
 }
 
 bool CResourceManager::Remove(const std::string& filename)

--- a/src/common/resources/resourcemanager.h
+++ b/src/common/resources/resourcemanager.h
@@ -66,8 +66,6 @@ public:
     //! Returns last modification date as timestamp
     static long long GetLastModificationTime(const std::string &filename);
 
-    //! Move file/directory
-    static bool Move(const std::string &from, const std::string &to);
     //! Remove file
     static bool Remove(const std::string& filename);
 };

--- a/src/level/robotmain.h
+++ b/src/level/robotmain.h
@@ -402,7 +402,7 @@ protected:
     void        ExecuteCmd(const std::string& cmd);
     void        UpdateSpeedLabel();
 
-    int         AutosaveRotate(bool freeOne);
+    void        AutosaveRotate();
     void        Autosave();
     bool        DestroySelectedObject();
     void        PushToSelectionHistory(CObject* obj);

--- a/src/sound/oalsound/alsound.cpp
+++ b/src/sound/oalsound/alsound.cpp
@@ -25,7 +25,6 @@
 #include <algorithm>
 #include <iomanip>
 
-#include <boost/filesystem.hpp>
 
 CALSound::CALSound()
     : m_enabled(false),
@@ -586,11 +585,6 @@ bool CALSound::PlayMusic(const std::string &filename, bool repeat, float fadeTim
     if (m_music.find(filename) == m_music.end())
     {
         GetLogger()->Debug("Music %s was not cached!\n", filename.c_str());
-        /* TODO: if (!boost::filesystem::exists(filename))
-        {
-            GetLogger()->Debug("Requested music %s was not found.\n", filename.c_str());
-            return false;
-        } */
 
         auto newBuffer = MakeUnique<CBuffer>();
         buffer = newBuffer.get();

--- a/src/sound/sound.cpp
+++ b/src/sound/sound.cpp
@@ -27,8 +27,6 @@
 #include <iomanip>
 #include <sstream>
 
-#include <boost/filesystem.hpp>
-
 
 CSoundInterface::CSoundInterface()
 {

--- a/src/ui/screen/screen_io.cpp
+++ b/src/ui/screen/screen_io.cpp
@@ -80,7 +80,7 @@ void CScreenIO::IOReadName()
     }
 
     time(&now);
-    strftime(line, 99, "%y%m%d%H%M", localtime(&now));
+    strftime(line, 99, "%y.%m.%d %H:%M", localtime(&now));
     sprintf(name, "%s - %s %d", line, resume.c_str(), m_main->GetLevelRank());
 
     pe->SetText(name);


### PR DESCRIPTION
This pull request removes boost::filesystem from resource manager. Now boost::filesystem is only used before resource manager takes control. I did not touch CBot code and how files are handled there.

There's also small change to save naming.