### PR TITLE
Fix some bugs in CBOT

### DIFF
--- a/src/CBot/CBotInstr/CBotDefArray.cpp
+++ b/src/CBot/CBotInstr/CBotDefArray.cpp
@@ -121,6 +121,15 @@ CBotInstr* CBotDefArray::Compile(CBotToken* &p, CBotCStack* pStack, CBotTypResul
                     }
                 }
             }
+
+            if (pStk->IsOk()) while (true)       // mark initialized
+            {
+                var = var->GetItem(0, true);
+                if (var == nullptr) break;
+                if (var->GetType() == CBotTypArrayPointer) continue;
+                if (var->GetType() <= CBotTypString) var->SetInit(CBotVar::InitType::DEF);
+                break;
+            }
         }
 
         if (pStk->IsOk()) return pStack->Return(inst, pStk);

--- a/src/CBot/CBotInstr/CBotInstrMethode.cpp
+++ b/src/CBot/CBotInstr/CBotInstrMethode.cpp
@@ -103,6 +103,7 @@ bool CBotInstrMethode::ExecuteVar(CBotVar* &pVar, CBotStack* &pj, CBotToken* pre
     if (pVar->GetPointer() == nullptr)
     {
         pj->SetError(CBotErrNull, prevToken);
+        return pj->Return(pile1);
     }
 
     if (pile1->IfStep()) return false;

--- a/src/CBot/CBotInstr/CBotListArray.cpp
+++ b/src/CBot/CBotInstr/CBotListArray.cpp
@@ -98,7 +98,7 @@ CBotInstr* CBotListArray::Compile(CBotToken* &p, CBotCStack* pStack, CBotTypResu
                     }
                 }
 
-                inst->m_expr->AddNext3(i);
+                inst->m_expr->AddNext3b(i);
 
                 if ( p->GetType() == ID_COMMA ) continue;
                 if ( p->GetType() == ID_CLBLK ) break;
@@ -114,10 +114,10 @@ CBotInstr* CBotListArray::Compile(CBotToken* &p, CBotCStack* pStack, CBotTypResu
             {
                 goto error;
             }
-            CBotVar* pv = pStk->GetVar();                                       // result of the expression
 
-            if (pv == nullptr || (!TypesCompatibles( type, pv->GetTypResult()) &&
-                !(type.Eq(CBotTypPointer) && pv->GetTypResult().Eq(CBotTypNullPointer)) ))
+            CBotTypResult valType = pStk->GetTypResult();
+
+            if (!TypeCompatible(valType, type, ID_ASS) )
             {
                 pStk->SetError(CBotErrBadType1, p->GetStart());
                 goto error;
@@ -133,15 +133,14 @@ CBotInstr* CBotListArray::Compile(CBotToken* &p, CBotCStack* pStack, CBotTypResu
                     goto error;
                 }
 
-                CBotVar* pv = pStk->GetVar();                                   // result of the expression
+                CBotTypResult valType = pStk->GetTypResult();
 
-                if (pv == nullptr || (!TypesCompatibles( type, pv->GetTypResult()) &&
-                    !(type.Eq(CBotTypPointer) && pv->GetTypResult().Eq(CBotTypNullPointer)) ))
+                if (!TypeCompatible(valType, type, ID_ASS) )
                 {
                     pStk->SetError(CBotErrBadType1, p->GetStart());
                     goto error;
                 }
-                inst->m_expr->AddNext3(i);
+                inst->m_expr->AddNext3b(i);
 
                 if (p->GetType() == ID_COMMA) continue;
                 if (p->GetType() == ID_CLBLK) break;
@@ -175,7 +174,7 @@ bool CBotListArray::Execute(CBotStack* &pj, CBotVar* pVar)
 
     int n = 0;
 
-    for (; p != nullptr ; n++, p = p->GetNext3())
+    for (; p != nullptr ; n++, p = p->GetNext3b())
     {
         if (pile1->GetState() > n) continue;
 
@@ -207,7 +206,7 @@ void CBotListArray::RestoreState(CBotStack* &pj, bool bMain)
 
         int    state = pile->GetState();
 
-        while(state-- > 0) p = p->GetNext3() ;
+        while(state-- > 0) p = p->GetNext3b() ;
 
         p->RestoreState(pile, bMain);                    // size calculation //interrupted!
     }

--- a/src/CBot/CBotInstr/CBotListArray.h
+++ b/src/CBot/CBotInstr/CBotListArray.h
@@ -62,7 +62,7 @@ protected:
     virtual std::map<std::string, CBotInstr*> GetDebugLinks() override;
 
 private:
-    //! An expression for an element others are linked with CBotInstr :: m_next3;
+    //! An expression for an element others are linked with CBotInstr :: m_next3b;
     CBotInstr* m_expr;
 };
 

--- a/src/CBot/CBotInstr/CBotNew.cpp
+++ b/src/CBot/CBotInstr/CBotNew.cpp
@@ -50,7 +50,11 @@ CBotInstr* CBotNew::Compile(CBotToken* &p, CBotCStack* pStack)
     if (!IsOfType(p, ID_NEW)) return nullptr;
 
     // verifies that the token is a class name
-    if (p->GetType() != TokenTypVar) return nullptr;
+    if (p->GetType() != TokenTypVar)
+    {
+        pStack->SetError(CBotErrBadNew, p);
+        return nullptr;
+    }
 
     CBotClass* pClass = CBotClass::Find(p);
     if (pClass == nullptr)

--- a/src/CBot/CBotProgram.cpp
+++ b/src/CBot/CBotProgram.cpp
@@ -214,6 +214,7 @@ bool CBotProgram::Run(void* pUser, int timer)
         m_error = m_stack->GetError(m_errorStart, m_errorEnd);
         m_stack->Delete();
         m_stack = nullptr;
+        CBotClass::FreeLock(this);
         return true;                                // execution is finished!
     }
 
@@ -226,6 +227,7 @@ void CBotProgram::Stop()
     m_stack->Delete();
     m_stack = nullptr;
     m_entryPoint = nullptr;
+    CBotClass::FreeLock(this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Fixes these bugs:**

```int x=1, y=2, z=3;```
```int i[] = { x, y, z };    <---```These don't work [#728 comment](https://github.com/colobot/colobot/issues/728#issuecomment-205039570)
```    i[0] += 1;    <--------------/```

This compiles:
```c++
    point  p = new 12345;
    AClass a = new "abc";

    message("" + a + " " + p); // crash on run (failed assert)
```

SegFault when calling a method on null object.
This is true for any pointer-to-class that is null.
```c++
extern void object::New()
{
    object obj = radar(BotFactory); <----- does not exist in level

    //  "obj" is null
    bool b = obj.busy(); <---------------crash on run
}
```
Classes with an active synchronized method
don't get un-locked when a program is stopped. "626"
