### PR TITLE
CBot File Append

### DIFF
--- a/src/CBot/stdlib/FileFunctions.cpp
+++ b/src/CBot/stdlib/FileFunctions.cpp
@@ -51,7 +51,7 @@ bool FileClassOpenFile(CBotVar* pThis, CBotVar* pVar, CBotVar* pResult, int& Exc
     {
         // recover mode
         mode = pVar->GetValString();
-        if ( mode != "r" && mode != "w" ) { Exception = CBotErrBadParam; return false; }
+        if ( mode != "r" && mode != "w" && mode != "a" ) { Exception = CBotErrBadParam; return false; }
 
         // no third parameter
         if ( pVar->GetNext() != nullptr ) { Exception = CBotErrOverParam; return false; }
@@ -70,7 +70,13 @@ bool FileClassOpenFile(CBotVar* pThis, CBotVar* pVar, CBotVar* pResult, int& Exc
     {
         // opens the requested file
         assert(g_fileHandler != nullptr);
-        std::unique_ptr<CBotFile> file = g_fileHandler->OpenFile(filename, mode == "r" ? CBotFileAccessHandler::OpenMode::Read : CBotFileAccessHandler::OpenMode::Write);
+
+        CBotFileAccessHandler::OpenMode openMode;
+        if ( mode == "r" ) openMode = CBotFileAccessHandler::OpenMode::Read;
+        else if ( mode == "w" ) openMode = CBotFileAccessHandler::OpenMode::Write;
+        else if ( mode == "a" ) openMode = CBotFileAccessHandler::OpenMode::Append;
+
+        std::unique_ptr<CBotFile> file = g_fileHandler->OpenFile(filename, openMode);
 
         if (!file->Opened()) { Exception = CBotErrFileOpen; return false; }
 

--- a/src/CBot/stdlib/stdlib_public.h
+++ b/src/CBot/stdlib/stdlib_public.h
@@ -44,7 +44,7 @@ class CBotFileAccessHandler
 public:
     virtual ~CBotFileAccessHandler() {}
 
-    enum class OpenMode : char { Read = 'r', Write = 'w' };
+    enum class OpenMode : char { Read = 'r', Write = 'w', Append = 'a' };
     virtual std::unique_ptr<CBotFile> OpenFile(const std::string& filename, OpenMode mode) = 0;
     virtual bool DeleteFile(const std::string& filename) = 0;
 };

--- a/src/common/resources/outputstream.cpp
+++ b/src/common/resources/outputstream.cpp
@@ -28,20 +28,20 @@ COutputStream::COutputStream()
 {
 }
 
-COutputStream::COutputStream(const std::string& filename)
+COutputStream::COutputStream(const std::string& filename, std::ios_base::openmode mode)
     : COutputStreamBufferContainer(),
       std::ostream(&m_buffer)
 {
-    open(filename);
+    open(filename, mode);
 }
 
 COutputStream::~COutputStream()
 {
 }
 
-void COutputStream::open(const std::string& filename)
+void COutputStream::open(const std::string& filename, std::ios_base::openmode mode)
 {
-    m_buffer.open(filename);
+    m_buffer.open(filename, mode);
 }
 
 void COutputStream::close()

--- a/src/common/resources/outputstream.h
+++ b/src/common/resources/outputstream.h
@@ -35,10 +35,23 @@ class COutputStream : public COutputStreamBufferContainer, public std::ostream
 {
 public:
     COutputStream();
-    COutputStream(const std::string& filename);
+
+    /** Construct and Open Stream for writing
+     *
+     * \param filename
+     * \param Mode one of: std::ios_base::out - Open for writing, std::ios_base::app - Append to file
+     *
+     */
+    COutputStream(const std::string& filename, std::ios_base::openmode mode = std::ios_base::out);
     virtual ~COutputStream();
 
-    void open(const std::string& filename);
+    /** Open Stream for writing
+     *
+     * \param filename
+     * \param Mode one of: std::ios_base::out - Open for writing, std::ios_base::app - Append to file
+     *
+     */
+    void open(const std::string& filename, std::ios_base::openmode mode = std::ios_base::out);
     void close();
     bool is_open();
 };

--- a/src/common/resources/outputstreambuffer.cpp
+++ b/src/common/resources/outputstreambuffer.cpp
@@ -45,10 +45,13 @@ COutputStreamBuffer::~COutputStreamBuffer()
 }
 
 
-void COutputStreamBuffer::open(const std::string &filename)
+void COutputStreamBuffer::open(const std::string &filename, std::ios_base::openmode mode)
 {
     if (PHYSFS_isInit())
-        m_file = PHYSFS_openWrite(CResourceManager::CleanPath(filename).c_str());
+    {
+        if ( mode == std::ios_base::out ) m_file = PHYSFS_openWrite(CResourceManager::CleanPath(filename).c_str());
+        else if ( mode == std::ios_base::app ) m_file = PHYSFS_openAppend(CResourceManager::CleanPath(filename).c_str());
+    }
 }
 
 

--- a/src/common/resources/outputstreambuffer.h
+++ b/src/common/resources/outputstreambuffer.h
@@ -35,7 +35,13 @@ public:
     COutputStreamBuffer(const COutputStreamBuffer &) = delete;
     COutputStreamBuffer &operator= (const COutputStreamBuffer &) = delete;
 
-    void open(const std::string &filename);
+    /** Open Stream Buffer for writing
+     *
+     * \param filename
+     * \param Mode one of: std::ios_base::out - Open for writing, std::ios_base::app - Append to file
+     *
+     */
+    void open(const std::string &filename, std::ios_base::openmode mode);
     void close();
     bool is_open();
 

--- a/src/script/scriptfunc.cpp
+++ b/src/script/scriptfunc.cpp
@@ -3000,6 +3000,14 @@ public:
                 m_file = std::move(os);
             }
         }
+        else if (mode == CBotFileAccessHandler::OpenMode::Append)
+        {
+            auto os = MakeUnique<COutputStream>(filename, std::ios_base::app);
+            if (os->is_open())
+            {
+                m_file = std::move(os);
+            }
+        }
 
         if (Opened())
         {


### PR DESCRIPTION
CBot File now is able to Append to file.
Example:
`extern void object::FileAppend()
{
	file handle();
	handle.open("test1.txt", "a");
	handle.writeln("abc");
	handle.close();
}`
Issue: https://github.com/colobot/colobot/issues/813
