### PR TITLE
Command history for cheat console

### DIFF
--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -1171,7 +1171,7 @@ bool CRobotMain::ProcessEvent(Event &event)
 //! Executes a command
 void CRobotMain::ExecuteCmd(const std::string& cmd)
 {
-    if(cmd.empty()) return;
+    if (cmd.empty()) return;
 
     if (m_phase == PHASE_SIMUL)
     {

--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -5904,7 +5904,7 @@ void CRobotMain::PushToCommandHistory(std::string str)
 
 std::string CRobotMain::GetNextFromCommandHistory()
 {
-    if (m_commandHistory.empty() || m_commandHistory.size() <= m_commandHistoryIndex + 1) // no next element
+    if (m_commandHistory.empty() || (int)m_commandHistory.size() <= m_commandHistoryIndex + 1) // no next element
         return "";
     return m_commandHistory[++m_commandHistoryIndex];
 }

--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -5904,7 +5904,7 @@ void CRobotMain::PushToCommandHistory(std::string str)
 
 std::string CRobotMain::GetNextFromCommandHistory()
 {
-    if (m_commandHistory.empty() || (int)m_commandHistory.size() <= m_commandHistoryIndex + 1) // no next element
+    if (m_commandHistory.empty() || static_cast<int>(m_commandHistory.size()) <= m_commandHistoryIndex + 1) // no next element
         return "";
     return m_commandHistory[++m_commandHistoryIndex];
 }

--- a/src/level/robotmain.h
+++ b/src/level/robotmain.h
@@ -413,6 +413,9 @@ protected:
     void        SetCodeBattleSpectatorMode(bool mode);
     void        UpdateDebugCrashSpheres();
 
+    void        PushToCommandHistory(std::string obj);
+    std::string    GetNextFromCommandHistory();
+    std::string    GetPreviousFromCommandHistory();
 
 protected:
     CApplication*       m_app = nullptr;
@@ -585,4 +588,8 @@ protected:
 
     std::deque<CObject*> m_selectionHistory;
     bool            m_debugCrashSpheres;
+
+    std::deque<std::string> m_commandHistory;
+    bool        m_isCommand;
+    int m_commadHistoryIndex;
 };

--- a/src/level/robotmain.h
+++ b/src/level/robotmain.h
@@ -413,9 +413,13 @@ protected:
     void        SetCodeBattleSpectatorMode(bool mode);
     void        UpdateDebugCrashSpheres();
 
+    //! Adds element to the beginning of command history
     void        PushToCommandHistory(std::string obj);
+    //! Returns next/previous element from command history and updates index
+    //@{
     std::string    GetNextFromCommandHistory();
     std::string    GetPreviousFromCommandHistory();
+    //@}
 
 protected:
     CApplication*       m_app = nullptr;
@@ -589,7 +593,8 @@ protected:
     std::deque<CObject*> m_selectionHistory;
     bool            m_debugCrashSpheres;
 
+    //! Cheat console command history
     std::deque<std::string> m_commandHistory;
-    bool        m_isCommand;
-    int m_commadHistoryIndex;
+    //! Index of currently selected element in command history
+    int             m_commandHistoryIndex;
 };


### PR DESCRIPTION
Adds console command history that store only correctly spelled commands.
Browsable by up and down arrow keys.

Issue: #316

Nobody made i so far, so I rewited my old code using std::deque and std::string. Looks much clearner and works well.