### PR TITLE
Fix class redefinition error and CloseBlock error

### DIFF
--- a/src/CBot/CBotClass.cpp
+++ b/src/CBot/CBotClass.cpp
@@ -442,7 +442,7 @@ bool CBotClass::CheckCall(CBotProgram* program, CBotDefParam* pParam, CBotToken*
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-CBotClass* CBotClass::Compile1(CBotToken* &p, CBotCStack* pStack)
+CBotClass* CBotClass::Compile1(CBotToken* &p, CBotCStack* pStack, CBotProgram* program)
 {
     if ( !IsOfType(p, ID_PUBLIC) )
     {
@@ -455,7 +455,8 @@ CBotClass* CBotClass::Compile1(CBotToken* &p, CBotCStack* pStack)
     std::string name = p->GetString();
 
     CBotClass* pOld = CBotClass::Find(name);
-    if ( pOld != nullptr && pOld->m_IsDef )
+    if ( (pOld != nullptr && pOld->m_IsDef) || /* public class exists in different program */
+         program->ClassExists(name))           /* class exists in this program */
     {
         pStack->SetError( CBotErrRedefClass, p );
         return nullptr;
@@ -491,6 +492,8 @@ CBotClass* CBotClass::Compile1(CBotToken* &p, CBotCStack* pStack)
         int level = 1;
         do                                          // skip over the definition
         {
+            if (p == nullptr) break; // end of code
+
             int type = p->GetType();
             p = p->GetNext();
             if (type == ID_OPBLK) level++;

--- a/src/CBot/CBotClass.cpp
+++ b/src/CBot/CBotClass.cpp
@@ -490,16 +490,13 @@ CBotClass* CBotClass::Compile1(CBotToken* &p, CBotCStack* pStack, CBotProgram* p
         }
 
         int level = 1;
-        do                                          // skip over the definition
+        while (level > 0 && p != nullptr)
         {
-            if (p == nullptr) break; // end of code
-
             int type = p->GetType();
             p = p->GetNext();
             if (type == ID_OPBLK) level++;
             if (type == ID_CLBLK) level--;
-        }
-        while (level > 0 && p != nullptr);
+        }     
 
         if (level > 0) pStack->SetError(CBotErrCloseBlock, classe->m_pOpenblk);
 

--- a/src/CBot/CBotClass.h
+++ b/src/CBot/CBotClass.h
@@ -278,6 +278,7 @@ public:
      * \brief Pre-compile a new class
      * \param p[in, out] Pointer to first token of the class, will be updated to point to first token after the class definition
      * \param pStack Compile stack
+     * \param program Currently precompiling program
      *
      * This function is used to find the beginning and end of class definition.
      *
@@ -286,7 +287,8 @@ public:
      * \return Precompiled class, or nullptr in case of error
      */
     static CBotClass* Compile1(CBotToken* &p,
-                               CBotCStack* pStack);
+                               CBotCStack* pStack,
+                               CBotProgram* program);
 
     /*!
      * \brief DefineClasses Calls CompileDefItem for each class in a list

--- a/src/CBot/CBotProgram.cpp
+++ b/src/CBot/CBotProgram.cpp
@@ -93,7 +93,8 @@ bool CBotProgram::Compile(const std::string& program, std::vector<std::string>& 
         if ( p->GetType() == ID_CLASS ||
             ( p->GetType() == ID_PUBLIC && p->GetNext()->GetType() == ID_CLASS ))
         {
-            CBotClass* newclass = CBotClass::Compile1(p, pStack.get());
+            CBotClass* newclass = CBotClass::Compile1(p, pStack.get(), this);
+
             if (newclass != nullptr)
                 m_classes.push_back(newclass);
         }
@@ -279,6 +280,16 @@ bool CBotProgram::GetError(CBotError& code, int& start, int& end, CBotProgram*& 
 const std::list<CBotFunction*>& CBotProgram::GetFunctions()
 {
     return m_functions;
+}
+
+bool CBotProgram::ClassExists(std::string name)
+{
+    for (CBotClass* p : m_classes)
+    {
+        if ( p->GetName() == name ) return true;
+    }
+
+    return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/CBot/CBotProgram.h
+++ b/src/CBot/CBotProgram.h
@@ -334,6 +334,12 @@ public:
     const std::list<CBotFunction*>& GetFunctions();
 
     /**
+     * \brief Check if class with that name exists (public or private)
+     * \return True if exists, otherwise false
+     */
+    bool ClassExists(std::string name);
+
+    /**
      * \brief Returns static list of all registered external calls
      */
     static CBotExternalCallList* GetExternalCalls();

--- a/test/unit/CBot/CBot_test.cpp
+++ b/test/unit/CBot/CBot_test.cpp
@@ -932,13 +932,34 @@ TEST_F(CBotUT, ClassMethodRedefined)
     );
 }
 
-// TODO: Not only doesn't work but segfaults
-TEST_F(CBotUT, DISABLED_ClassRedefined)
+TEST_F(CBotUT, ClassRedefinedInDifferentPrograms)
+{
+    // Keep the program, so that the class continues to exist after ExecuteTest finishes
+    auto publicProgram = ExecuteTest(
+        "public class TestClass {}\n"
+    );
+
+    ExecuteTest(
+        "public class TestClass {}\n",
+        CBotErrRedefClass
+    );
+}
+
+TEST_F(CBotUT, ClassRedefinedInOneProgram)
 {
     ExecuteTest(
         "public class TestClass {}\n"
         "public class TestClass {}\n",
         CBotErrRedefClass
+    );
+}
+
+TEST_F(CBotUT, ClassMissingCloseBlock)
+{
+    ExecuteTest(
+        "public class Something\n"
+        "{\n",
+        CBotErrCloseBlock
     );
 }
 


### PR DESCRIPTION
Fix  #703
Before we checked if class exists in other programs
```
CBotClass* pOld = CBotClass::Find(name);
if ( pOld != nullptr && pOld->m_IsDef )
```
Now we also check if class was defined in precompilation phase
```
if ( (pOld != nullptr && pOld->m_IsDef) || /* public class exists in different program */
      program->ClassExists(name))           /* class exists in this program */
```

Additionally before CBot code
```
public class Something
{
```
threw exception. Now it works.