### PR TITLE
CBot parser separated from CBot compiler

### DIFF
--- a/po/colobot.pot
+++ b/po/colobot.pot
@@ -1739,6 +1739,15 @@ msgstr ""
 msgid "Function needs return type \"void\""
 msgstr ""
 
+msgid "Expected \"class\" keyword"
+msgstr ""
+
+msgid "Expected name of class"
+msgstr ""
+
+msgid "This class does not exist"
+msgstr ""
+
 msgid "Dividing by zero"
 msgstr ""
 
@@ -1755,9 +1764,6 @@ msgid "No function running"
 msgstr ""
 
 msgid "Calling an unknown function"
-msgstr ""
-
-msgid "This class does not exist"
 msgstr ""
 
 msgid "Unknown Object"

--- a/po/de.po
+++ b/po/de.po
@@ -522,6 +522,12 @@ msgstr "Liste der Übungen des Kapitels:"
 msgid "Exercises\\Programming exercises"
 msgstr "Programmieren\\Programmierübungen"
 
+msgid "Expected \"class\" keyword"
+msgstr ""
+
+msgid "Expected name of class"
+msgstr ""
+
 msgid "Explode (\\key action;)"
 msgstr "Explodieren (\\key action;)"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -509,6 +509,12 @@ msgstr "Liste des exercices du chapitre :"
 msgid "Exercises\\Programming exercises"
 msgstr "Programmation\\Exercices de programmation"
 
+msgid "Expected \"class\" keyword"
+msgstr ""
+
+msgid "Expected name of class"
+msgstr ""
+
 msgid "Explode (\\key action;)"
 msgstr "Exploser (\\key action;)"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -511,6 +511,12 @@ msgstr "Ćwiczenia w tym rozdziale:"
 msgid "Exercises\\Programming exercises"
 msgstr "Ćwiczenia\\Ćwiczenia programistyczne"
 
+msgid "Expected \"class\" keyword"
+msgstr ""
+
+msgid "Expected name of class"
+msgstr ""
+
 msgid "Explode (\\key action;)"
 msgstr "Wysadź (\\key action;)"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -518,6 +518,12 @@ msgstr "Упражнения в разделе:"
 msgid "Exercises\\Programming exercises"
 msgstr "Упражнения\\Упражнения по программированию"
 
+msgid "Expected \"class\" keyword"
+msgstr ""
+
+msgid "Expected name of class"
+msgstr ""
+
 msgid "Explode (\\key action;)"
 msgstr "Взорвать (\\key action;)"
 

--- a/src/CBot/CBotCStack.h
+++ b/src/CBot/CBotCStack.h
@@ -28,6 +28,8 @@ namespace CBot
 class CBotInstr;
 class CBotDefParam;
 class CBotToken;
+class CBotFunction;
+class CBotProgram;
 
 /*!
  * \brief The CBotCStack class Management of the stack of compilation.

--- a/src/CBot/CBotEnums.h
+++ b/src/CBot/CBotEnums.h
@@ -238,6 +238,9 @@ enum CBotError : int
     CBotErrNoExpression  = 5043, //!< expression expected after =
     CBotErrAmbiguousCall = 5044, //!< ambiguous call to overloaded function
     CBotErrFuncNotVoid   = 5045, //!< function needs return type "void"
+    CBotErrClassExpected = 5046, //!< Expected class keyword
+    CBotErrClassNameExpected = 5047, //!< Expected name of class
+    CBotErrNotClass      = 5048, //!< this class does not exist
 
     // Runtime errors
     CBotErrZeroDiv       = 6000, //!< division by zero
@@ -246,7 +249,6 @@ enum CBotError : int
     CBotErrNoRetVal      = 6003, //!< function did not return results
     CBotErrNoRun         = 6004, //!< Run() without active function
     CBotErrUndefFunc     = 6005, //!< calling a function that no longer exists
-    CBotErrNotClass      = 6006, //!< this class does not exist
     CBotErrNull          = 6007, //!< null pointer
     CBotErrNan           = 6008, //!< calculation with a NAN
     CBotErrOutArray      = 6009, //!< index out of array

--- a/src/CBot/CBotInstr/CBotInstr.cpp
+++ b/src/CBot/CBotInstr/CBotInstr.cpp
@@ -39,6 +39,7 @@
 #include "CBot/CBotVar/CBotVar.h"
 
 #include "CBot/CBotClass.h"
+#include "CBot/CBotParser.h"
 #include "CBot/CBotStack.h"
 
 #include <cassert>
@@ -247,15 +248,9 @@ CBotInstr* CBotInstr::Compile(CBotToken* &p, CBotCStack* pStack)
         return nullptr;
     }
 
-    // If not, this might be an instance of class definnition
-    CBotToken*    ppp = p;
-    if (IsOfType(ppp, TokenTypVar))
+    if (CBotParser::IsClassInstance(p))
     {
-        if (CBotClass::Find(p) != nullptr) // Does class with this name exist?
-        {
-            // Yes, compile the declaration of the instance
-            return CBotDefClass::Compile(p, pStack);
-        }
+        return CBotDefClass::Compile(p, pStack);
     }
 
     // This can be an arithmetic expression

--- a/src/CBot/CBotParser.cpp
+++ b/src/CBot/CBotParser.cpp
@@ -1,0 +1,178 @@
+/*
+ * This file is part of the Colobot: Gold Edition source code
+ * Copyright (C) 2001-2016, Daniel Roux, EPSITEC SA & TerranovaTeam
+ * http://epsitec.ch; http://colobot.info; http://github.com/colobot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://gnu.org/licenses
+ */
+
+#include "CBot/CBotParser.h"
+
+namespace CBot
+{
+
+bool CBotParser::IsClass(CBotToken* p)
+{
+    SkipAllModifiers(p);
+
+    return SkipType(p, ID_CLASS);
+}
+
+bool CBotParser::IsFunctionDefinition(CBotToken* p)
+{
+    SkipAllModifiers(p);
+
+    SkipTokens(p, {TokenTypVar, ID_DBLDOTS});
+
+    if (!SkipType(p, ID_OPENPAR)) return false;
+
+    SkipTokens(p, {TokenTypVar, ID_COMMA});
+
+    return SkipType(p, ID_CLOSEPAR) && SkipType(p, ID_OPBLK);
+}
+
+bool CBotParser::IsFunctionCall(CBotToken* p)
+{
+    return SkipType(p, TokenTypVar) && SkipType(p, ID_OPENPAR);
+}
+
+bool CBotParser::IsClassInstance(CBotToken* p)
+{
+    return IsTokenSeries(p, {TokenTypVar, TokenTypVar}) ||                     // ClassName variableName
+           IsTokenSeries(p, {TokenTypVar, ID_OPBRK, ID_CLBRK, TokenTypVar});   // ClassName[] variableName
+}
+
+bool CBotParser::IsTokenSeries(CBotToken* p, std::vector<int> tokens)
+{
+    for (int token : tokens)
+    {
+        if (!SkipType(p, token)) return false;
+    }
+
+    return true;
+}
+
+std::string CBotParser::GetString(CBotToken* p)
+{
+    if (p == nullptr) return "";
+
+    return p->GetString();
+}
+
+std::string CBotParser::ReadString(CBotToken* &p)
+{
+    std::string result = GetString(p);
+
+    Next(p);
+
+    return result;
+}
+
+bool CBotParser::SkipRequiredType(CBotToken* &p, int type, CBotCStack* stack, CBotError error)
+{
+    if (SkipType(p, type)) return false;
+    else
+    {
+        stack->SetError(error, p);
+        return true;
+    }
+}
+
+bool CBotParser::SkipType(CBotToken* &p, int type)
+{
+    if (p == nullptr) return false;
+
+    if (p->GetType() == type)
+    {
+        p = p->GetNext();
+
+        return true;
+    }
+
+    return false;
+}
+
+bool CBotParser::Next(CBotToken* &p)
+{
+    if (p == nullptr) return false;
+
+    p = p->GetNext();
+
+    return true;
+}
+
+bool CBotParser::ValidateBlock(CBotToken* &p, CBotCStack* stack)
+{
+    CBotToken* openBlock = p;
+
+    if (SkipRequiredType(p, ID_OPBLK, stack, CBotErrOpenBlock)) return false;
+
+    bool success = TrySkipToExitBlock(p);
+
+    if (!success)
+    {
+        stack->SetError(CBotErrCloseBlock, openBlock);
+        return false;
+    }
+    else return true;
+}
+
+void CBotParser::SkipClassOrFunction(CBotToken* &p)
+{
+    while (p != nullptr && p->GetType() != TokenTypNone)
+    {
+        if (p->GetType() == ID_OPBLK) break;
+        else p = p->GetNext();
+    }
+
+    if (!SkipType(p, ID_OPBLK)) return; // skip "{", return if p = nullptr
+
+    TrySkipToExitBlock(p);
+}
+
+bool CBotParser::TrySkipToExitBlock(CBotToken* &p)
+{
+    int level = 1;
+    while (level > 0 && p != nullptr)
+    {
+        int type = p->GetType();
+        if (type == ID_OPBLK) level++;
+        if (type == ID_CLBLK) level--;
+        p = p->GetNext();
+    }
+
+    return level == 0;
+}
+
+void CBotParser::SkipAllModifiers(CBotToken* &p)
+{
+    SkipTokens(p, {ID_PUBLIC, ID_PROTECTED, ID_PRIVATE, ID_EXTERN, ID_SYNCHO, ID_STATIC});
+}
+
+void CBotParser::SkipTokens(CBotToken* &p, std::vector<int> tokens)
+{
+    unsigned int i = 0;
+
+    while (i < tokens.size() && p != nullptr)
+    {
+        if (SkipType(p, tokens[i])) i = 0;
+        else i++;
+    }
+}
+
+} // namespace CBot
+
+
+
+

--- a/src/CBot/CBotParser.h
+++ b/src/CBot/CBotParser.h
@@ -1,0 +1,64 @@
+/*
+ * This file is part of the Colobot: Gold Edition source code
+ * Copyright (C) 2001-2016, Daniel Roux, EPSITEC SA & TerranovaTeam
+ * http://epsitec.ch; http://colobot.info; http://github.com/colobot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://gnu.org/licenses
+ */
+
+#pragma once
+
+#include "CBot/CBotCStack.h"
+#include "CBot/CBotEnums.h"
+#include "CBot/CBotToken.h"
+
+namespace CBot
+{
+
+class CBotParser
+{
+public:
+
+    static bool IsClass(CBotToken* p);
+
+    static bool IsFunctionDefinition(CBotToken* p);
+
+    static bool IsFunctionCall(CBotToken* p);
+
+    static bool IsClassInstance(CBotToken* p);
+
+    static bool IsTokenSeries(CBotToken* p, std::vector<int> tokens);
+
+    static std::string GetString(CBotToken* p);
+
+    static std::string ReadString(CBotToken* &p);
+
+    static bool SkipRequiredType(CBotToken* &p, int type, CBotCStack* stack, CBotError error);
+
+    static bool SkipType(CBotToken* &p, int type);
+
+    static bool Next(CBotToken* &p);
+
+    static bool ValidateBlock(CBotToken* &p, CBotCStack* stack);
+
+    static void SkipClassOrFunction(CBotToken* &p);
+
+    static bool TrySkipToExitBlock(CBotToken* &p);
+
+    static void SkipAllModifiers(CBotToken* &p);
+
+    static void SkipTokens(CBotToken* &p, std::vector<int> tokens);
+};
+
+} // namespace CBot

--- a/src/CBot/CBotProgram.cpp
+++ b/src/CBot/CBotProgram.cpp
@@ -25,6 +25,7 @@
 #include "CBot/CBotClass.h"
 #include "CBot/CBotUtils.h"
 #include "CBot/CBotFileUtils.h"
+#include "CBot/CBotParser.h"
 
 #include "CBot/CBotInstr/CBotFunction.h"
 
@@ -48,104 +49,103 @@ CBotProgram::CBotProgram(CBotVar* thisVar)
 
 CBotProgram::~CBotProgram()
 {
-//  delete  m_classes;
-    for (CBotClass* c : m_classes)
-        c->Purge();
-    m_classes.clear();
-
-    CBotClass::FreeLock(this);
-
-    for (CBotFunction* f : m_functions) delete f;
-    m_functions.clear();
+    Purge();
 }
 
 bool CBotProgram::Compile(const std::string& program, std::vector<std::string>& externFunctions, void* pUser)
 {
-    // Cleanup the previously compiled program
-    Stop();
-
-    for (CBotClass* c : m_classes)
-        c->Purge();      // purge the old definitions of classes
-                         // but without destroying the object
-
-    m_classes.clear();
-    for (CBotFunction* f : m_functions) delete f;
-    m_functions.clear();
+    Stop();          // Cleanup the previously compiled program
+    Purge();
 
     externFunctions.clear();
     m_error = CBotNoErr;
 
-    // Step 1. Process the code into tokens
+    /**************** Step 1. Process the code into tokens ****************/
+
     auto tokens = CBotToken::CompileTokens(program);
     if (tokens == nullptr) return false;
+    CBotToken* p = tokens.get()->GetNext();                                // skips the first token (separator)
 
     auto pStack = std::unique_ptr<CBotCStack>(new CBotCStack(nullptr));
-    CBotToken* p = tokens.get()->GetNext();                 // skips the first token (separator)
-
-    pStack->SetProgram(this);                               // defined used routines
+    pStack->SetProgram(this);                                              // defined used routines
     m_externalCalls->SetUserPtr(pUser);
 
-    // Step 2. Find all function and class definitions
+    /************* Step 2. Find classes and outside functions *************/
+
+    std::vector<CBotToken*> classesTokens = {};         // list contains first tokens of classes
+    std::vector<CBotToken*> functionsTokens = {};       // list contains first tokens of outside functions (that is not member of any class)
+
     while ( pStack->IsOk() && p != nullptr && p->GetType() != 0)
     {
-        if ( IsOfType(p, ID_SEP) ) continue;                // semicolons lurking
+        if ( IsOfType(p, ID_SEP) ) continue;            // semicolons lurking
 
-        if ( p->GetType() == ID_CLASS ||
-            ( p->GetType() == ID_PUBLIC && p->GetNext()->GetType() == ID_CLASS ))
+        if (CBotParser::IsClass(p))
         {
-            CBotClass* newclass = CBotClass::Compile1(p, pStack.get());
-            if (newclass != nullptr)
-                m_classes.push_back(newclass);
+            classesTokens.push_back(p);
         }
         else
         {
-            CBotFunction* newfunc  = CBotFunction::Compile1(p, pStack.get(), nullptr);
-            if (newfunc != nullptr)
-                m_functions.push_back(newfunc);
+            functionsTokens.push_back(p);
         }
+
+        CBotParser::SkipClassOrFunction(p);
     }
 
-    // Define fields and pre-compile methods for each class in this program
+    /***** Step 3. Precompile headers of classes and outside functions ****/
+
+    for (CBotToken* classToken : classesTokens)
+    {
+        CBotClass* newClass = CBotClass::Compile1(classToken, pStack.get());
+
+        if (HandleErrorIfExists(pStack.get())) return false;
+
+        m_classes.push_back(newClass);
+    }
+
+    for (CBotToken* functionToken : functionsTokens)
+    {
+        CBotFunction* newFunction  = CBotFunction::Compile1(functionToken, pStack.get(), nullptr);
+
+        if (HandleErrorIfExists(pStack.get())) return false;
+
+        m_functions.push_back(newFunction);
+    }
+
+    /********** Step 4. Precompile fields and methods of classes **********/
+
     if (pStack->IsOk()) CBotClass::DefineClasses(m_classes, pStack.get());
 
-    if ( !pStack->IsOk() )
+    if (HandleErrorIfExists(pStack.get())) return false;
+
+    /************************* Step 5. Compilation ************************/
+
+    for (CBotToken* classToken : classesTokens)
     {
-        m_error = pStack->GetError(m_errorStart, m_errorEnd);
-        for (CBotFunction* f : m_functions) delete f;
-        m_functions.clear();
-        return false;
+        CBotClass::Compile(classToken, pStack.get());
+
+        if (HandleErrorIfExists(pStack.get())) return false;
     }
 
-    // Step 3. Real compilation
-    std::list<CBotFunction*>::iterator next = m_functions.begin();
-    p  = tokens.get()->GetNext();                             // returns to the beginning
-    while ( pStack->IsOk() && p != nullptr && p->GetType() != 0 )
-    {
-        if ( IsOfType(p, ID_SEP) ) continue;                // semicolons lurking
+    auto functionIter = m_functions.begin();
 
-        if ( p->GetType() == ID_CLASS ||
-            ( p->GetType() == ID_PUBLIC && p->GetNext()->GetType() == ID_CLASS ))
-        {
-            CBotClass::Compile(p, pStack.get());                  // completes the definition of the class
-        }
-        else
-        {
-            CBotFunction::Compile(p, pStack.get(), *next);
-            if ((*next)->IsExtern()) externFunctions.push_back((*next)->GetName()/* + next->GetParams()*/);
-            if ((*next)->IsPublic()) CBotFunction::AddPublic(*next);
-            (*next)->m_pProg = this;                           // keeps pointers to the module
-            ++next;
-        }
+    for (CBotToken* functionToken : functionsTokens)
+    {
+        CBotFunction* function = *functionIter;
+
+        CBotFunction::Compile(functionToken, pStack.get(), function);
+
+        if (HandleErrorIfExists(pStack.get())) return false;
+
+        if (function->IsExtern()) externFunctions.push_back(function->GetName());
+        if (function->IsPublic()) CBotFunction::AddPublic(function);
+        function->m_pProg = this;   // keeps pointers to the program
+
+        functionIter++;
     }
 
-    if ( !pStack->IsOk() )
-    {
-        m_error = pStack->GetError(m_errorStart, m_errorEnd);
-        for (CBotFunction* f : m_functions) delete f;
-        m_functions.clear();
-    }
+    if (HandleErrorIfExists(pStack.get())) return false;
 
-    return !m_functions.empty();
+    return true;
 }
 
 bool CBotProgram::Start(const std::string& name)
@@ -222,6 +222,18 @@ void CBotProgram::Stop()
     }
     m_entryPoint = nullptr;
     CBotClass::FreeLock(this);
+}
+
+void CBotProgram::Purge()
+{
+    for (CBotClass* c : m_classes)
+    {
+        c->Purge();
+    }
+    m_classes.clear();
+
+    for (CBotFunction* f : m_functions) delete f;
+    m_functions.clear();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -421,6 +433,17 @@ void CBotProgram::Free()
 CBotExternalCallList* CBotProgram::GetExternalCalls()
 {
     return m_externalCalls;
+}
+
+bool CBotProgram::HandleErrorIfExists(CBotCStack* stack)
+{
+    if (stack->IsOk()) return false;
+
+    m_error = stack->GetError(m_errorStart, m_errorEnd);
+
+    Purge();
+
+    return true;
 }
 
 } // namespace CBot

--- a/src/CBot/CBotProgram.h
+++ b/src/CBot/CBotProgram.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "CBot/CBotCStack.h"
 #include "CBot/CBotTypResult.h"
 #include "CBot/CBotEnums.h"
 
@@ -200,6 +201,8 @@ public:
      */
     void Stop();
 
+    void Purge();
+
     /**
      * \brief Sets the number of steps (parts of instructions) to execute in Run() before suspending the program execution
      * \param n new timer value
@@ -345,6 +348,8 @@ public:
     static CBotExternalCallList* GetExternalCalls();
 
 private:
+    bool HandleErrorIfExists(CBotCStack* stack);
+
     //! All external calls
     static CBotExternalCallList* m_externalCalls;
     //! All user-defined functions

--- a/src/CBot/CMakeLists.txt
+++ b/src/CBot/CMakeLists.txt
@@ -110,6 +110,8 @@ set(SOURCES
     CBotInstr/CBotTwoOpExpr.h
     CBotInstr/CBotWhile.cpp
     CBotInstr/CBotWhile.h
+    CBotParser.cpp
+    CBotParser.h
     CBotProgram.cpp
     CBotProgram.h
     CBotStack.cpp

--- a/src/common/restext.cpp
+++ b/src/common/restext.cpp
@@ -720,6 +720,9 @@ void InitializeRestext()
     stringsCbot[CBot::CBotErrNoExpression]  = TR("Expression expected after =");
     stringsCbot[CBot::CBotErrAmbiguousCall] = TR("Ambiguous call to overloaded function");
     stringsCbot[CBot::CBotErrFuncNotVoid]   = TR("Function needs return type \"void\"");
+    stringsCbot[CBot::CBotErrClassExpected] = TR("Expected \"class\" keyword");
+    stringsCbot[CBot::CBotErrClassNameExpected] = TR("Expected name of class");
+    stringsCbot[CBot::CBotErrNotClass]      = TR("This class does not exist");
 
     stringsCbot[CBot::CBotErrZeroDiv]       = TR("Dividing by zero");
     stringsCbot[CBot::CBotErrNotInit]       = TR("Variable not initialized");
@@ -727,7 +730,6 @@ void InitializeRestext()
     stringsCbot[CBot::CBotErrNoRetVal]      = TR("The function returned no value");
     stringsCbot[CBot::CBotErrNoRun]         = TR("No function running");
     stringsCbot[CBot::CBotErrUndefFunc]     = TR("Calling an unknown function");
-    stringsCbot[CBot::CBotErrNotClass]      = TR("This class does not exist");
     stringsCbot[CBot::CBotErrNull]          = TR("Unknown Object");
     stringsCbot[CBot::CBotErrNan]           = TR("Operation impossible with value \"nan\"");
     stringsCbot[CBot::CBotErrOutArray]      = TR("Access beyond array limit");

--- a/test/unit/CBot/CBot_test.cpp
+++ b/test/unit/CBot/CBot_test.cpp
@@ -292,6 +292,10 @@ protected:
 TEST_F(CBotUT, EmptyTest)
 {
     ExecuteTest(
+        ""
+    );
+
+    ExecuteTest(
         "extern void EmptyTest()\n"
         "{\n"
         "}\n"
@@ -328,6 +332,19 @@ TEST_F(CBotUT, UndefinedFunction)
         "    foo();\n"
         "}\n",
         CBotErrUndefCall
+    );
+}
+
+TEST_F(CBotUT, FunctionBeforeClassDefinition)
+{
+    ExecuteTest(
+	"extern Test Foo()\n"
+        "{\n"
+        "    return new Test();\n"
+        "}\n"
+        "public class Test\n"
+        "{\n"
+        "}\n"    
     );
 }
 
@@ -777,6 +794,8 @@ TEST_F(CBotUT, ClassConstructor)
         "    ASSERT(t3.instanceCounter == 2);\n"
         "    ASSERT(t3 != null);\n"
         "    ASSERT(t3 != t1);\n"
+        "    TestClass d1 = new TestClass();\n"
+        "    TestClass d2 = new TestClass(), d3(), d4;\n"
         "}\n"
     );
 }
@@ -1038,6 +1057,81 @@ TEST_F(CBotUT, DISABLED_PublicClasses)
         "    TestClass t();\n"
         "}\n",
         CBotErrUndefClass
+    );
+}
+
+TEST_F(CBotUT, CreateNonExistentClass1)
+{
+    ExecuteTest(
+        "extern void TestPublic()\n"
+        "{\n"
+        "    NonExistentClass t();\n"
+        "}\n",
+        CBotErrNotClass
+    );
+
+    ExecuteTest(
+        "extern void TestPublic()\n"
+        "{\n"
+        "    NonExistentClass t = new NonExistentClass();\n"
+        "}\n",
+        CBotErrNotClass
+    );
+}
+
+TEST_F(CBotUT, DefineClassWithoutPublic)
+{
+    ExecuteTest(
+        "class TestClass\n"
+        "{\n"
+        "}\n",
+        CBotErrNoPublic
+    );
+}
+
+TEST_F(CBotUT, DefineClassWithTwoPublic)
+{
+    ExecuteTest(
+        "public public class TestClass\n"
+        "{\n"
+        "}\n",
+        CBotErrClassExpected
+    );
+}
+
+TEST_F(CBotUT, DefineClassWithBadName)
+{
+    ExecuteTest(
+        "public class 123\n"
+        "{\n"
+        "}\n",
+        CBotErrClassNameExpected
+    );
+
+    ExecuteTest(
+        "public class while\n"
+        "{\n"
+        "}\n",
+        CBotErrClassNameExpected
+    );
+}
+
+// TODO: I think we need End of File token
+TEST_F(CBotUT, DISABLED_DefineClassWithoutName)
+{
+    // It works ( CBot compiler says that expected class name and mark '{' ), but ...
+    ExecuteTest(
+        "public class\n"
+        "{\n"
+        "}\n",
+        CBotErrClassNameExpected
+    );
+
+    /* ... it throws error ( CBot compiler says that expected class name, but it doesn't know what
+       it should mark - there is nothing after class keyword ) */
+    ExecuteTest(
+        "public class",
+        CBotErrClassNameExpected
     );
 }
 

--- a/test/unit/CBot/CBot_test.cpp
+++ b/test/unit/CBot/CBot_test.cpp
@@ -1060,7 +1060,7 @@ TEST_F(CBotUT, DISABLED_PublicClasses)
     );
 }
 
-TEST_F(CBotUT, CreateNonExistentClass1)
+TEST_F(CBotUT, CreateNonExistentClass)
 {
     ExecuteTest(
         "extern void TestPublic()\n"


### PR DESCRIPTION
_It is only idea. If you like it, I will properly comment and document this piece of code._

I propose to separate CBot parser from CBot compiler. This allows code to stay clean. I showed examples of using new separeted parser in:
- CBotClass::Compile1
- CBotClass::Compile
- CBotInstr::Compile (just a little)
- CBotProgram::Compile

I also suggest to completely replace **IsOfType** function by **CBotParser::SkipType** (name IsOfType suggests that function only checks type, but it also goes to next token).

I had to move **CBotErrClassExpected** to compiler error section (before it was in runtime error section), because otherwise _CreateNonExistentClass_ test failed.

Additionally, I discoveried new bug (described in _DISABLED_DefineClassWithoutName_)

Order of precompilation was little changed. Before classes and outside functions were precompiled at the same time. Now classes are precompiled first and next outside functions (outside function = functions defined outside of class). Thanks to this, test _FunctionBeforeClassDefinition_ is passed.

Little change in CBotInstr::Compile allows _CreateNonExistentClass_ to be passed.
  