### PR TITLE
Move part of CRobotMain::CreateScene() to separate class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -224,6 +224,9 @@ set(BASE_SOURCES
     level/build_type.h
     level/level_category.cpp
     level/level_category.h
+    level/level_load_mode.h
+    level/level_loader.cpp
+    level/level_loader.h
     level/mainmovie.cpp
     level/mainmovie.h
     level/parser/parser.cpp

--- a/src/graphics/engine/engine.cpp
+++ b/src/graphics/engine/engine.cpp
@@ -1564,6 +1564,21 @@ int CEngine::CreateGroundSpot()
     return index;
 }
 
+int CEngine::CreateGroundSpot(Math::Vector position, float radius, Gfx::Color color, float min, float max, float smooth)
+{
+    int rank = CreateGroundSpot();
+    if (rank != -1)
+    {
+        SetObjectGroundSpotPos(rank, position);
+        SetObjectGroundSpotRadius(rank, radius);
+        SetObjectGroundSpotColor(rank, color);
+        SetObjectGroundSpotSmooth(rank, smooth);
+        SetObjectGroundSpotMinMax(rank, min, max);
+    }
+
+    return rank;
+}
+
 void CEngine::DeleteGroundSpot(int rank)
 {
     assert(rank >= 0 && rank < static_cast<int>( m_groundSpots.size() ));

--- a/src/graphics/engine/engine.h
+++ b/src/graphics/engine/engine.h
@@ -835,6 +835,7 @@ public:
     void            DeleteAllGroundSpots();
     //! Creates a new ground spot and returns its rank
     int             CreateGroundSpot();
+    int             CreateGroundSpot(Math::Vector position, float radius, Gfx::Color color, float min, float max, float smooth);
     //! Deletes the given ground spot
     void            DeleteGroundSpot(int rank);
 
@@ -868,6 +869,9 @@ public:
 
     //! Specifies the location and direction of view
     void SetViewParams(const Math::Vector &eyePt, const Math::Vector &lookatPt, const Math::Vector &upVec);
+
+    //! Updates the textures used for drawing ground spot
+    void            UpdateGroundSpotTextures();
 
     //! Loads texture, creating it if not already present
     Texture         LoadTexture(const std::string& name);
@@ -1196,9 +1200,6 @@ protected:
     void        DrawObject(const EngineBaseObjDataTier& p4);
     //! Draws the user interface over the scene
     void        DrawInterface();
-
-    //! Updates the textures used for drawing ground spot
-    void        UpdateGroundSpotTextures();
 
     //! Draws old-style shadow spots
     void        DrawShadowSpots();

--- a/src/graphics/engine/lightning.cpp
+++ b/src/graphics/engine/lightning.cpp
@@ -177,15 +177,9 @@ bool CLightning::EventFrame(const Event &event)
 
 bool CLightning::Create(float sleep, float delay, float magnetic)
 {
-    m_lightningExists = true;
     if (sleep < 1.0f) sleep = 1.0f;
-    m_sleep = sleep;
-    m_delay = delay;
-    m_magnetic = magnetic;
 
-    m_phase    = LightningPhase::Wait;
-    m_progress = 0.0f;
-    m_speed    = 1.0f / m_sleep;
+    SetStatus(sleep, delay, magnetic, 0.0f);
 
     return false;
 }

--- a/src/graphics/engine/planet.cpp
+++ b/src/graphics/engine/planet.cpp
@@ -144,6 +144,11 @@ void CPlanet::Draw()
     }
 }
 
+void CPlanet::Add(Planet planet)
+{
+    m_planets.push_back(planet);
+}
+
 void CPlanet::Create(PlanetType type, Math::Point start, float dim, float speed,
                      float dir, const std::string& name, Math::Point uv1, Math::Point uv2,
                      bool transparent)
@@ -163,7 +168,7 @@ void CPlanet::Create(PlanetType type, Math::Point start, float dim, float speed,
 
     planet.transparent = transparent;
 
-    m_planets.push_back(planet);
+    Add(planet);
 }
 
 bool CPlanet::PlanetExist()

--- a/src/graphics/engine/planet.h
+++ b/src/graphics/engine/planet.h
@@ -49,40 +49,10 @@ class CEngine;
 class CPlanet
 {
 public:
-    CPlanet(CEngine* engine);
-    ~CPlanet();
-
-    //! Removes all the planets
-    void        Flush();
-    //! Management of an event
-    bool        EventProcess(const Event &event);
-    //! Creates a new planet
-    void        Create(PlanetType type, Math::Point start, float dim, float speed, float dir,
-                       const std::string& name, Math::Point uv1, Math::Point uv2,
-                       bool transparent);
-    //! Indicates if there is at least one planet
-    bool        PlanetExist();
-    //! Load all the textures for the planets
-    void        LoadTexture();
-    //! Draws all the planets
-    void        Draw();
-
-    //! Set which planet types to display
-    void        SetVisiblePlanetType(PlanetType type);
-
-protected:
-    //! Makes the planets evolve
-    bool        EventFrame(const Event &event);
-
-protected:
-    CEngine* m_engine = nullptr;
-    float m_time = 0.0f;
-    PlanetType m_visibleType = PlanetType::Sky;
-
     /**
-    * \struct Planet
-    * \brief Planet texture definition
-    */
+     * \struct Planet
+     * \brief Planet texture definition
+     */
     struct Planet
     {
         //! Type of planet
@@ -106,6 +76,39 @@ protected:
         //! Transparent texture
         bool            transparent = false;
     };
+
+    CPlanet(CEngine* engine);
+    ~CPlanet();
+
+    //! Removes all the planets
+    void        Flush();
+    //! Management of an event
+    bool        EventProcess(const Event &event);
+    //! Adds planet
+    void        Add(Planet planet);
+    //! Creates a new planet
+    void        Create(PlanetType type, Math::Point start, float dim, float speed, float dir,
+                       const std::string& name, Math::Point uv1, Math::Point uv2,
+                       bool transparent);
+    //! Indicates if there is at least one planet
+    bool        PlanetExist();
+    //! Load all the textures for the planets
+    void        LoadTexture();
+    //! Draws all the planets
+    void        Draw();
+
+    //! Set which planet types to display
+    void        SetVisiblePlanetType(PlanetType type);
+
+protected:
+    //! Makes the planets evolve
+    bool        EventFrame(const Event &event);
+
+protected:
+    CEngine* m_engine = nullptr;
+    float m_time = 0.0f;
+    PlanetType m_visibleType = PlanetType::Sky;
+
     std::vector<Planet> m_planets;
 };
 

--- a/src/graphics/engine/terrain.cpp
+++ b/src/graphics/engine/terrain.cpp
@@ -165,11 +165,6 @@ void CTerrain::AddMaterial(int id, const std::string& texName, const Math::Point
                            int up, int right, int down, int left,
                            float hardness)
 {
-    InitMaterialPoints();
-
-    if (id == 0)
-        id = m_materialAutoID++;
-
     TerrainMaterial tm;
     tm.texName  = texName;
     tm.id       = id;
@@ -180,12 +175,22 @@ void CTerrain::AddMaterial(int id, const std::string& texName, const Math::Point
     tm.mat[3]   = left;
     tm.hardness = hardness;
 
-    m_materials.push_back(tm);
+    AddMaterial(tm);
+}
 
-    if (m_maxMaterialID < up+1   )  m_maxMaterialID = up+1;
-    if (m_maxMaterialID < right+1)  m_maxMaterialID = right+1;
-    if (m_maxMaterialID < down+1 )  m_maxMaterialID = down+1;
-    if (m_maxMaterialID < left+1 )  m_maxMaterialID = left+1;
+void CTerrain::AddMaterial(TerrainMaterial material)
+{
+    InitMaterialPoints();
+
+    if (material.id == 0)
+        material.id = m_materialAutoID++;
+
+    m_materials.push_back(material);
+
+    if ( m_maxMaterialID < material.mat[0]+1 )  m_maxMaterialID = material.mat[0]+1;
+    if ( m_maxMaterialID < material.mat[1]+1 )  m_maxMaterialID = material.mat[1]+1;
+    if ( m_maxMaterialID < material.mat[2]+1 )  m_maxMaterialID = material.mat[2]+1;
+    if ( m_maxMaterialID < material.mat[3]+1 )  m_maxMaterialID = material.mat[3]+1;
 
     m_useMaterials = true;
     m_textureSubdivCount = 4;
@@ -1857,7 +1862,12 @@ void CTerrain::AddFlyingLimit(Math::Vector center,
     fl.extRadius = extRadius;
     fl.intRadius = intRadius;
     fl.maxHeight = maxHeight;
-    m_flyingLimits.push_back(fl);
+    AddFlyingLimit(fl);
+}
+
+void CTerrain::AddFlyingLimit(FlyingLimit limit)
+{
+    m_flyingLimits.push_back(limit);
 }
 
 float CTerrain::GetFlyingLimit(Math::Vector pos, bool noLimit)

--- a/src/graphics/engine/terrain.h
+++ b/src/graphics/engine/terrain.h
@@ -147,6 +147,36 @@ Gfx::IntColor ResourceToColor(TerrainRes res);
 class CTerrain
 {
 public:
+    /**
+     * \struct FlyingLimit
+     * \brief Spherical limit of flight
+     */
+    struct FlyingLimit
+    {
+        Math::Vector center;
+        float        extRadius = 0.0f;
+        float        intRadius = 0.0f;
+        float        maxHeight = 0.0f;
+    };
+
+    /**
+     * \struct TerrainMaterial
+     * \brief Material for ground surface
+     */
+    struct TerrainMaterial
+    {
+        //! Unique ID
+        short       id = 0;
+        //! Texture
+        std::string texName;
+        //! UV texture coordinates
+        Math::Point uv;
+        //! Terrain hardness (defines e.g. sound of walking)
+        float       hardness = 0.0f;
+        //! IDs of neighbor materials: up, right, down, left
+        char        mat[4] = {};
+    };
+
     CTerrain();
     ~CTerrain();
 
@@ -161,6 +191,7 @@ public:
     //! Adds a terrain material the names of textures to use for the land
     void        AddMaterial(int id, const std::string& texName, const Math::Point& uv,
                             int up, int right, int down, int left, float hardness);
+    void        AddMaterial(TerrainMaterial material);
     //! Initializes all the ground with one material
     bool        InitMaterials(int id);
     //! Generates a level in the terrain
@@ -243,6 +274,7 @@ public:
     void        FlushFlyingLimit();
     //! Adds a new flying limit
     void        AddFlyingLimit(Math::Vector center, float extRadius, float intRadius, float maxHeight);
+    void        AddFlyingLimit(FlyingLimit limit);
     //! Returns the maximum height of flight
     float       GetFlyingLimit(Math::Vector pos, bool noLimit);
 
@@ -260,7 +292,6 @@ protected:
     //! Creates all objects in a mesh square ground
     bool        CreateSquare(int x, int y);
 
-    struct TerrainMaterial;
     //! Seeks a material based on its ID
     TerrainMaterial* FindMaterial(int id);
     //! Seeks a material based on neighbor values
@@ -323,23 +354,6 @@ protected:
     std::string     m_texBaseExt;
     //! Default hardness for level material
     float           m_defaultHardness;
-    /**
-     * \struct TerrainMaterial
-     * \brief Material for ground surface
-     */
-    struct TerrainMaterial
-    {
-        //! Unique ID
-        short       id = 0;
-        //! Texture
-        std::string texName;
-        //! UV texture coordinates
-        Math::Point uv;
-        //! Terrain hardness (defines e.g. sound of walking)
-        float       hardness = 0.0f;
-        //! IDs of neighbor materials: up, right, down, left
-        char        mat[4] = {};
-    };
     //! Terrain materials
     std::vector<TerrainMaterial> m_materials;
 
@@ -391,17 +405,6 @@ protected:
     //! Global flying height limit
     float           m_flyingMaxHeight;
 
-    /**
-     * \struct FlyingLimit
-     * \brief Spherical limit of flight
-     */
-    struct FlyingLimit
-    {
-        Math::Vector center;
-        float        extRadius = 0.0f;
-        float        intRadius = 0.0f;
-        float        maxHeight = 0.0f;
-    };
     //! List of local flight limits
     std::vector<FlyingLimit> m_flyingLimits;
 };

--- a/src/graphics/engine/water.cpp
+++ b/src/graphics/engine/water.cpp
@@ -48,6 +48,7 @@ const int WATERLINE_PREALLOCATE_COUNT = 500;
 const int VAPOR_SIZE = 10;
 } // anonymous namespace
 
+const Color CWater::COLOR_REF_WATER = Color( 25.0f/256.0f, 255.0f/256.0f, 240.0f/256.0f);  // cyan
 
 CWater::CWater(CEngine* engine)
     : m_engine(engine),
@@ -342,7 +343,7 @@ void CWater::DrawSurf()
     m_engine->SetTexture(m_fileName, 1);
 
     if (m_type[rankview] == WATER_TT)
-        m_engine->SetState(ENG_RSTATE_TTEXTURE_BLACK | ENG_RSTATE_DUAL_WHITE | ENG_RSTATE_WRAP, m_color);
+        m_engine->SetState(ENG_RSTATE_TTEXTURE_BLACK | ENG_RSTATE_DUAL_WHITE | ENG_RSTATE_WRAP, Color(1.0f, 1.0f, 1.0f, 1.0f)); // transparent water
 
     else if (m_type[rankview] == WATER_TO)
         m_engine->SetState(ENG_RSTATE_NORMAL | ENG_RSTATE_DUAL_WHITE | ENG_RSTATE_WRAP);
@@ -621,5 +622,25 @@ void CWater::AdjustEye(Math::Vector &eye)
     }
 }
 
+void CWater::SetColor(Gfx::Color color, float shift)
+{
+    m_color = color;
+    m_colorShift = shift;
+}
+
+void CWater::UpdateTextureColor()
+{
+    Gfx::Color black = Gfx::Color(0.0f, 0.0f, 0.f);
+
+    // PARTIPLOUF0 and PARTIDROP :
+    Math::Point ts = Math::Point(0.500f, 0.500f);
+    Math::Point ti = Math::Point(0.875f, 0.750f);
+    m_engine->ChangeTextureColor("textures/effect00.png", COLOR_REF_WATER, m_color, black, black, 0.20f, -1.0f, ts, ti, nullptr, m_colorShift, true);
+
+    // PARTIFLIC :
+    ts = Math::Point(0.00f, 0.75f);
+    ti = Math::Point(0.25f, 1.00f);
+    m_engine->ChangeTextureColor("textures/effect02.png", COLOR_REF_WATER, m_color, black, black, 0.20f, -1.0f, ts, ti, nullptr, m_colorShift, true);
+}
 
 } // namespace Gfx

--- a/src/graphics/engine/water.h
+++ b/src/graphics/engine/water.h
@@ -102,6 +102,14 @@ public:
     //! Adjusts the eye of the camera, not to be in the water
     void        AdjustEye(Math::Vector &eye);
 
+    //! Set new color of water (changes will applied after call CWater::UpdateTextureColor())
+    void        SetColor(Gfx::Color color, float shift);
+    //! Update texture of water
+    void        UpdateTextureColor();
+
+public:
+    static const Gfx::Color COLOR_REF_WATER;
+
 protected:
     //! Makes water evolve
     bool        EventFrame(const Event &event);
@@ -144,6 +152,9 @@ protected:
     float           m_lastLava = 0.0f;
     int             m_subdiv = 4;
 
+    Gfx::Color      m_color;
+    float           m_colorShift = 0.0f;
+
     //! Number of brick*mosaics
     int             m_brickCount = 0;
     //! Size of a item in an brick
@@ -183,7 +194,6 @@ protected:
 
     bool            m_draw = true;
     bool            m_lava = false;
-    Color           m_color = Color(1.0f, 1.0f, 1.0f, 1.0f);
 };
 
 

--- a/src/level/level_load_mode.h
+++ b/src/level/level_load_mode.h
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the Colobot: Gold Edition source code
+ * Copyright (C) 2001-2016, Daniel Roux, EPSITEC SA & TerranovaTeam
+ * http://epsitec.ch; http://colobot.info; http://github.com/colobot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://gnu.org/licenses
+ */
+
+#pragma once
+
+/**
+ * \brief List of modes used in CLevelLoader::CreateScene()
+ */
+enum LevelLoadMode
+{
+    Normal          = (1 << 0), //!< used when starting new game
+    Reset           = (1 << 1), //!< used when restarting level
+    LoadSavedGame   = (1 << 2)  //!< used when loading saved game
+};
+

--- a/src/level/level_loader.cpp
+++ b/src/level/level_loader.cpp
@@ -1,0 +1,1025 @@
+/* This file is part of the Colobot: Gold Edition source code
+ * Copyright (C) 2001-2016, Daniel Roux, EPSITEC SA & TerranovaTeam
+ * http://epsitec.ch; http://colobot.info; http://github.com/colobot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://gnu.org/licenses
+ */
+
+#include "level/level_loader.h"
+
+#include "CBot/CBot.h"
+
+#include "app/app.h"
+#include "app/input.h"
+#include "app/pausemanager.h"
+
+#include "common/config_file.h"
+#include "common/event.h"
+#include "common/logger.h"
+#include "common/make_unique.h"
+#include "common/restext.h"
+#include "common/settings.h"
+#include "common/stringutils.h"
+
+#include "common/resources/inputstream.h"
+#include "common/resources/outputstream.h"
+#include "common/resources/resourcemanager.h"
+
+#include "graphics/engine/camera.h"
+#include "graphics/engine/cloud.h"
+#include "graphics/engine/engine.h"
+#include "graphics/engine/lightman.h"
+#include "graphics/engine/lightning.h"
+#include "graphics/engine/oldmodelmanager.h"
+#include "graphics/engine/particle.h"
+#include "graphics/engine/planet.h"
+#include "graphics/engine/pyro_manager.h"
+#include "graphics/engine/terrain.h"
+#include "graphics/engine/text.h"
+#include "graphics/engine/water.h"
+
+#include "graphics/model/model_manager.h"
+
+#include "level/level_loader.h"
+#include "level/mainmovie.h"
+#include "level/player_profile.h"
+#include "level/scene_conditions.h"
+
+#include "level/parser/parser.h"
+
+#include "math/const.h"
+#include "math/geometry.h"
+
+#include "object/object.h"
+#include "object/object_create_exception.h"
+#include "object/object_manager.h"
+
+#include "object/auto/auto.h"
+
+#include "object/motion/motion.h"
+#include "object/motion/motionhuman.h"
+#include "object/motion/motiontoto.h"
+
+#include "object/subclass/exchange_post.h"
+
+#include "object/task/task.h"
+#include "object/task/taskbuild.h"
+#include "object/task/taskmanip.h"
+
+#include "physics/physics.h"
+
+#include "script/cbottoken.h"
+#include "script/script.h"
+#include "script/scriptfunc.h"
+
+#include "sound/sound.h"
+
+#include "ui/debug_menu.h"
+#include "ui/displayinfo.h"
+#include "ui/displaytext.h"
+#include "ui/maindialog.h"
+#include "ui/mainmap.h"
+#include "ui/mainshort.h"
+#include "ui/mainui.h"
+
+#include "ui/controls/button.h"
+#include "ui/controls/edit.h"
+#include "ui/controls/group.h"
+#include "ui/controls/interface.h"
+#include "ui/controls/label.h"
+#include "ui/controls/map.h"
+#include "ui/controls/shortcut.h"
+#include "ui/controls/slider.h"
+#include "ui/controls/window.h"
+
+#include "ui/screen/screen_loading.h"
+
+#include <algorithm>
+#include <iomanip>
+#include <stdexcept>
+#include <ctime>
+
+#include <boost/lexical_cast.hpp>
+
+const int ALL_LOAD_LEVEL_MODES = LevelLoadMode::Normal | LevelLoadMode::Reset | LevelLoadMode::LoadSavedGame;
+
+std::map<std::string,std::shared_ptr<CLevelLoader::Command>> CLevelLoader::m_commands =
+{
+        { "Title",              MakeCommand(&CLevelLoader::HandleCommand_Title) },
+        { "Resume",             MakeCommand(&CLevelLoader::HandleCommand_Resume) },
+        { "ScriptName",         MakeCommand(&CLevelLoader::HandleCommand_ScriptName) },
+        { "ScriptFile",         MakeCommand(&CLevelLoader::HandleCommand_ScriptFile) },
+        { "Instructions",       MakeCommand(&CLevelLoader::HandleCommand_Instructions) },
+        { "Satellite",          MakeCommand(&CLevelLoader::HandleCommand_Satellite) },
+        { "Loading",            MakeCommand(&CLevelLoader::HandleCommand_Loading) },
+        { "HelpFile",           MakeCommand(&CLevelLoader::HandleCommand_HelpFile) },
+        { "SoluceFile",         MakeCommand(&CLevelLoader::HandleCommand_SoluceFile) },
+        { "EndingFile",         MakeCommand(&CLevelLoader::HandleCommand_EndingFile) },
+        { "MessageDelay",       MakeCommand(&CLevelLoader::HandleCommand_MessageDelay) },
+        { "MissionTimer",       MakeCommand(&CLevelLoader::HandleCommand_MissionTimer, ALL_LOAD_LEVEL_MODES) },
+        { "TeamName",           MakeCommand(&CLevelLoader::HandleCommand_TeamName, ALL_LOAD_LEVEL_MODES) },
+        { "CacheAudio",         MakeCommand(&CLevelLoader::HandleCommand_CacheAudio) },
+        { "AudioChange",        MakeCommand(&CLevelLoader::HandleCommand_AudioChange) },
+        { "Audio",              MakeCommand(&CLevelLoader::HandleCommand_Audio) },
+        { "AmbientColor",       MakeCommand(&CLevelLoader::HandleCommand_AmbientColor) },
+        { "FogColor",           MakeCommand(&CLevelLoader::HandleCommand_FogColor) },
+        { "VehicleColor",       MakeCommand(&CLevelLoader::HandleCommand_VehicleColor) },
+        { "InsectColor",        MakeCommand(&CLevelLoader::HandleCommand_InsectColor) },
+        { "GreeneryColor",      MakeCommand(&CLevelLoader::HandleCommand_GreeneryColor) },
+        { "DeepView",           MakeCommand(&CLevelLoader::HandleCommand_DeepView) },
+        { "FogStart",           MakeCommand(&CLevelLoader::HandleCommand_FogStart) },
+        { "SecondTexture",      MakeCommand(&CLevelLoader::HandleCommand_SecondTexture) },
+        { "Background",         MakeCommand(&CLevelLoader::HandleCommand_Background) },
+        { "Planet",             MakeCommand(&CLevelLoader::HandleCommand_Planet) },
+        { "ForegroundName",     MakeCommand(&CLevelLoader::HandleCommand_ForegroundName) },
+        { "Level",              MakeCommand(&CLevelLoader::HandleCommand_Level) },
+        { "TerrainGenerate",    MakeCommand(&CLevelLoader::HandleCommand_TerrainGenerate) },
+        { "TerrainWind",        MakeCommand(&CLevelLoader::HandleCommand_TerrainWind) },
+        { "TerrainRelief",      MakeCommand(&CLevelLoader::HandleCommand_TerrainRelief) },
+        { "TerrainRandomRelief",MakeCommand(&CLevelLoader::HandleCommand_TerrainRandomRelief) },
+        { "TerrainResource",    MakeCommand(&CLevelLoader::HandleCommand_TerrainResource) },
+        { "TerrainWater",       MakeCommand(&CLevelLoader::HandleCommand_TerrainWater) },
+        { "TerrainLava",        MakeCommand(&CLevelLoader::HandleCommand_TerrainLava) },
+        { "TerrainCloud",       MakeCommand(&CLevelLoader::HandleCommand_TerrainCloud) },
+        { "TerrainBlitz",       MakeCommand(&CLevelLoader::HandleCommand_TerrainBlitz) },
+        { "TerrainInitTextures",MakeCommand(&CLevelLoader::HandleCommand_TerrainInitTextures) },
+        { "TerrainInit",        MakeCommand(&CLevelLoader::HandleCommand_TerrainInit) },
+        { "TerrainMaterial",    MakeCommand(&CLevelLoader::HandleCommand_TerrainMaterial) },
+        { "TerrainLevel",       MakeCommand(&CLevelLoader::HandleCommand_TerrainLevel) },
+        { "TerrainCreate",      MakeCommand(&CLevelLoader::HandleCommand_TerrainCreate) },
+        { "BeginObject",        MakeCommand(&CLevelLoader::HandleCommand_BeginObject, ALL_LOAD_LEVEL_MODES) },
+        { "LevelController",    MakeCommand(&CLevelLoader::HandleCommand_LevelController, LevelLoadMode::Normal | LevelLoadMode::Reset) },
+        { "CreateObject",       MakeCommand(&CLevelLoader::HandleCommand_CreateObject, LevelLoadMode::Normal | LevelLoadMode::Reset) },
+        { "CreateFog",          MakeCommand(&CLevelLoader::HandleCommand_CreateFog) },
+        { "CreateLight",        MakeCommand(&CLevelLoader::HandleCommand_CreateLight) },
+        { "CreateSpot",         MakeCommand(&CLevelLoader::HandleCommand_CreateSpot) },
+        { "GroundSpot",         MakeCommand(&CLevelLoader::HandleCommand_GroundSpot) },
+        { "WaterColor",         MakeCommand(&CLevelLoader::HandleCommand_WaterColor) },
+        { "MapColor",           MakeCommand(&CLevelLoader::HandleCommand_MapColor) },
+        { "MapZoom",            MakeCommand(&CLevelLoader::HandleCommand_MapZoom) },
+        { "MaxFlyingHeight",    MakeCommand(&CLevelLoader::HandleCommand_MaxFlyingHeight) },
+        { "AddFlyingHeight",    MakeCommand(&CLevelLoader::HandleCommand_AddFlyingHeight) },
+        { "Camera",             MakeCommand(&CLevelLoader::HandleCommand_Camera, ALL_LOAD_LEVEL_MODES) },
+        { "EndMissionTake",     MakeCommand(&CLevelLoader::HandleCommand_EndMissionTake) },
+        { "EndMissionDelay",    MakeCommand(&CLevelLoader::HandleCommand_EndMissionDelay) },
+        { "EndMissionResearch", MakeCommand(&CLevelLoader::HandleCommand_EndMissionResearch) },
+        { "ObligatoryToken",    MakeCommand(&CLevelLoader::HandleCommand_ObligatoryToken) },
+        { "ProhibitedToken",    MakeCommand(&CLevelLoader::HandleCommand_ProhibitedToken) },
+        { "EnableBuild",        MakeCommand(&CLevelLoader::HandleCommand_EnableBuild) },
+        { "EnableResearch",     MakeCommand(&CLevelLoader::HandleCommand_EnableResearch) },
+        { "DoneResearch",       MakeCommand(&CLevelLoader::HandleCommand_DoneResearch, LevelLoadMode::Normal) },
+        { "NewScript",          MakeCommand(&CLevelLoader::HandleCommand_NewScript) }
+};
+
+CLevelLoader::Result::Result()
+{
+    unit = CRobotMain::UNIT;
+
+    GetResource(RES_TEXT, RT_SCRIPT_NEW, scriptName);
+
+    newBotColors = { {0, CRobotMain::COLOR_REF_BOT} };
+    newAlienColor = CRobotMain::COLOR_REF_ALIEN;
+    newGreenColor = CRobotMain::COLOR_REF_GREEN;
+
+    infoFilenames.resize(SatCom::MAX, "");
+    infoFilenames[SatCom::Object] = "objects.txt";
+}
+
+CLevelLoader::CLevelLoader(WarningCallback warningCllback)
+{
+    m_warningCallback =  warningCllback;
+}
+
+CLevelLoader::Result CLevelLoader::LoadScene(CLevelReadOnlyParser* sceneParser, LevelLoadMode mode, WarningCallback warningCallback,
+                                    CLevelReadOnlyParser* savedSceneParser)
+{
+    Validate(sceneParser);
+
+    auto levelLoader = std::unique_ptr<CLevelLoader>(new CLevelLoader(warningCallback));
+
+    for (auto& line : sceneParser->GetLines())
+    {
+        CLevelLoader::Command* command = m_commands[line->GetCommand()].get();
+
+        if (command == nullptr)
+        {
+            throw CLevelParserException("Unknown command: '" + line->GetCommand() + "' in " + line->GetLevelFilename() + ":" + boost::lexical_cast<std::string>(line->GetLineNumber()));
+        }
+
+        if ( !(command->executionConditions & mode) ) continue;
+
+        command->function(levelLoader.get(), line.get(), mode);
+    }
+
+    if (mode == LevelLoadMode::LoadSavedGame)
+    {
+        levelLoader->ReadScene(savedSceneParser);
+    }
+
+    return std::move(levelLoader->m_result);
+}
+
+void CLevelLoader::SetExecutionStack(const CObjectContainerProxy& objects, const std::string& filecbot)
+{
+    FILE* file = CBot::fOpen((CResourceManager::GetSaveLocation() + "/" + filecbot).c_str(), "rb");
+    if (file != nullptr)
+    {
+        long version;
+        CBot::fRead(&version, sizeof(long), 1, file);  // version of COLOBOT
+        if (version == 1)
+        {
+            CBot::fRead(&version, sizeof(long), 1, file);  // version of CBOT
+            if (version == CBot::CBotProgram::GetVersion())
+            {
+                for (CObject* obj : objects)
+                {
+                    if (obj->GetType() == OBJECT_TOTO) continue;
+                    if (IsObjectBeingTransported(obj)) continue;
+                    if (obj->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject*>(obj)->IsDying()) continue;
+
+                    if (!ReadFileStack(obj, file)) break;
+                }
+            }
+        }
+        CBot::CBotClass::RestoreStaticState(file);
+        CBot::fClose(file);
+    }
+}
+
+void CLevelLoader::Validate(CLevelReadOnlyParser* parser)
+{
+    if (parser->CountLines("LevelController") > 1)
+    {
+        throw CLevelParserException("There can be only one LevelController in the level");
+    }
+}
+
+void CLevelLoader::ShowLoadingWarning(const std::string& message)
+{
+    m_warningCallback(message);
+}
+
+CLevelLoader::ObjectCreate CLevelLoader::ReadObject(CLevelParserLine *line)
+{
+    ObjectCreateParams params = CObject::ReadCreateParams(line);
+    params.id = line->GetParam("id")->AsInt();
+    params.power = -1.0f;
+
+    return ObjectCreate(params, line);
+}
+
+void CLevelLoader::ReadScene(CLevelReadOnlyParser* parser)
+{
+    boost::optional<ObjectCreate> cargo = boost::optional<ObjectCreate>();
+    boost::optional<ObjectCreate> power = boost::optional<ObjectCreate>();
+    for (auto& line : parser->GetLines())
+    {
+        if (line->GetCommand() == "Map")
+            m_result.map.defaultZoom = line->GetParam("zoom")->AsFloat();
+
+        if (line->GetCommand() == "DoneResearch")
+            m_result.researchDone[0] = line->GetParam("bits")->AsInt();
+
+        if (line->GetCommand() == "BlitzMode")
+        {
+            m_result.lightning.sleep = line->GetParam("sleep")->AsFloat();
+            m_result.lightning.delay = line->GetParam("delay")->AsFloat();
+            m_result.lightning.magnetic = line->GetParam("magnetic")->AsFloat()*m_result.unit;
+            m_result.lightning.progress = line->GetParam("progress")->AsFloat();
+        }
+
+        if (line->GetCommand() == "CreateFret")
+        {
+            cargo = ReadObject(line.get());
+        }
+
+        if (line->GetCommand() == "CreatePower")
+        {
+            power = ReadObject(line.get());
+        }
+
+        if (line->GetCommand() == "CreateObject")
+        {
+            ObjectCreate obj = ReadObject(line.get());
+            LoadedObjectCreate loadedObject = LoadedObjectCreate(obj, cargo, power);
+
+            m_result.loadedObjects.push_back(loadedObject);
+
+            cargo.reset();
+            power.reset();
+        }
+    }
+}
+
+bool CLevelLoader::ReadFileStack(CObject *obj, FILE *file)
+{
+    if (! obj->Implements(ObjectInterfaceType::Programmable)) return true;
+
+    CProgrammableObject* programmable = dynamic_cast<CProgrammableObject*>(obj);
+
+    ObjectType type = obj->GetType();
+    if (type == OBJECT_HUMAN) return true;
+
+    return programmable->ReadStack(file);
+}
+
+std::shared_ptr<CLevelLoader::Command> CLevelLoader::MakeCommand(CommandFunction function, int executionConditions)
+{
+    return std::make_shared<CLevelLoader::Command>(function, executionConditions);
+}
+
+void CLevelLoader::HandleCommand_Title(CLevelParserLine* line, LevelLoadMode mode)
+{
+    // empty
+}
+
+void CLevelLoader::HandleCommand_Resume(CLevelParserLine* line, LevelLoadMode mode)
+{
+    // empty
+}
+
+void CLevelLoader::HandleCommand_ScriptName(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.scriptName = line->GetParam("text")->AsString();
+}
+
+void CLevelLoader::HandleCommand_ScriptFile(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.scriptFile = line->GetParam("name")->AsString();
+}
+
+void CLevelLoader::HandleCommand_Instructions(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.infoFilenames[SatCom::Huston] = line->GetParam("name")->AsPath("help/%lng%");
+    m_result.immediatSatcom = line->GetParam("immediat")->AsBool(false);
+    m_result.beginSatCom = line->GetParam("lock")->AsBool(false);
+}
+
+void CLevelLoader::HandleCommand_Satellite(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.infoFilenames[SatCom::Sat] = line->GetParam("name")->AsPath("help/%lng%");
+}
+
+void CLevelLoader::HandleCommand_Loading(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.infoFilenames[SatCom::Loading] = line->GetParam("name")->AsPath("help/%lng%");
+}
+
+void CLevelLoader::HandleCommand_HelpFile(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.infoFilenames[SatCom::Prog] = line->GetParam("name")->AsPath("help/%lng%");
+}
+
+void CLevelLoader::HandleCommand_SoluceFile(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.infoFilenames[SatCom::Solution] = line->GetParam("name")->AsPath("help/%lng%");
+}
+
+void CLevelLoader::HandleCommand_EndingFile(CLevelParserLine* line, LevelLoadMode mode)
+{
+    auto Process = [&](const std::string& type) -> std::string
+    {
+        if (line->GetParam(type)->IsDefined())
+        {
+            try
+            {
+                int rank = boost::lexical_cast<int>(line->GetParam(type)->GetValue());
+                if (rank >= 0)
+                {
+                    // TODO: Fix default levels and add a future removal warning
+                    GetLogger()->Warn("This level is using deprecated way of defining %1$s scene. Please change the %1$s= parameter in EndingFile from %2$d to \"levels/other/%1$s%2$03d.txt\".\n", type.c_str(), rank);
+                    std::stringstream ss;
+                    ss << "levels/other/" << type << std::setfill('0') << std::setw(3) << rank << ".txt";
+                    return ss.str();
+                }
+                else
+                {
+                    // TODO: Fix default levels and add a future removal warning
+                    GetLogger()->Warn("This level is using deprecated way of defining %1$s scene. Please remove the %1$s= parameter in EndingFile.\n", type.c_str());
+                    return "";
+                }
+
+            }
+            catch (boost::bad_lexical_cast &e)
+            {
+                return line->GetParam(type)->AsPath("levels");
+            }
+        }
+        return "";
+    };
+
+    m_result.mission.endingWin = Process("win");
+    m_result.mission.endingLost = Process("lost");
+}
+
+void CLevelLoader::HandleCommand_MessageDelay(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.messageDelay = line->GetParam("factor")->AsFloat();
+}
+
+void CLevelLoader::HandleCommand_MissionTimer(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.mission.missionTimerEnabled = line->GetParam("enabled")->AsBool();
+    m_result.mission.missionTimerStarted = !line->GetParam("program")->AsBool(false);
+}
+
+void CLevelLoader::HandleCommand_TeamName(CLevelParserLine* line, LevelLoadMode mode)
+{
+    int team = line->GetParam("team")->AsInt();
+    std::string name = line->GetParam("name")->AsString();
+    m_result.teamNames[team] = name;
+}
+
+void CLevelLoader::HandleCommand_CacheAudio(CLevelParserLine* line, LevelLoadMode mode)
+{
+    std::string filename = line->GetParam("filename")->AsPath("music");
+    m_result.audio.cacheAudioFileNames.push_back(filename);
+}
+
+void CLevelLoader::HandleCommand_AudioChange(CLevelParserLine* line, LevelLoadMode mode)
+{
+    auto audioChange = MakeUnique<CAudioChangeCondition>();
+    audioChange->Read(line);
+    m_result.audio.cacheAudioFileNames.push_back(audioChange->music);
+    m_result.audio.audioChangeConditions.push_back(std::move(audioChange));
+
+    if (!line->GetParam("pos")->IsDefined() || !line->GetParam("dist")->IsDefined())
+    {
+        ShowLoadingWarning("The defaults for pos= and dist= are going to change, specify them explicitly. See issue #759 (https://git.io/vVBzH)");
+    }
+}
+
+void CLevelLoader::HandleCommand_Audio(CLevelParserLine* line, LevelLoadMode mode)
+{
+    if (line->GetParam("track")->IsDefined())
+    {
+        if (line->GetParam("filename")->IsDefined())
+            throw CLevelParserException("You can't use track and filename at the same time");
+
+        GetLogger()->Warn("Using track= is deprecated. Please replace this with filename=\n");
+        int trackid = line->GetParam("track")->AsInt();
+        if (trackid != 0)
+        {
+            std::stringstream filenameStr;
+            filenameStr << "music/music" << std::setfill('0') << std::setw(3) << trackid << ".ogg";
+            m_result.audio.audioTrack = filenameStr.str();
+        }
+        else
+        {
+            m_result.audio.audioTrack = "";
+        }
+    }
+    else
+    {
+        if (line->GetParam("filename")->IsDefined())
+        {
+            m_result.audio.audioTrack = line->GetParam("filename")->AsPath("music");
+        }
+        else
+        {
+            m_result.audio.audioTrack = "";
+        }
+    }
+    if (!m_result.audio.audioTrack.empty())
+    {
+        m_result.audio.audioRepeat = line->GetParam("repeat")->AsBool(true);
+    }
+
+    if (line->GetParam("satcom")->IsDefined())
+    {
+        m_result.audio.satcomAudioTrack = line->GetParam("satcom")->AsPath("music");
+        m_result.audio.satcomAudioRepeat = line->GetParam("satcomRepeat")->AsBool(true);
+    }
+    else
+    {
+        m_result.audio.satcomAudioTrack = "";
+    }
+
+    if (line->GetParam("editor")->IsDefined())
+    {
+        m_result.audio.editorAudioTrack = line->GetParam("editor")->AsPath("music");
+        m_result.audio.editorAudioRepeat = line->GetParam("editorRepeat")->AsBool(true);
+    }
+    else
+    {
+        m_result.audio.editorAudioTrack = "";
+    }
+
+    if (!m_result.audio.audioTrack.empty())
+    {
+        m_result.audio.cacheAudioFileNames.push_back(m_result.audio.audioTrack);
+    }
+    if (!m_result.audio.satcomAudioTrack.empty())
+    {
+        m_result.audio.cacheAudioFileNames.push_back(m_result.audio.satcomAudioTrack);
+    }
+    if (!m_result.audio.editorAudioTrack.empty())
+    {
+        m_result.audio.cacheAudioFileNames.push_back(m_result.audio.editorAudioTrack);
+    }
+}
+
+void CLevelLoader::HandleCommand_AmbientColor(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.airAmbientColor = line->GetParam("air")->AsColor(Gfx::Color(0.533f, 0.533f, 0.533f, 0.533f));
+    m_result.waterAmbientColor = line->GetParam("water")->AsColor(Gfx::Color(0.533f, 0.533f, 0.533f, 0.533f));
+}
+
+void CLevelLoader::HandleCommand_FogColor(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.airFogColor = line->GetParam("air")->AsColor(Gfx::Color(0.533f, 0.533f, 0.533f, 0.533f));
+    m_result.waterFogColor = line->GetParam("water")->AsColor(Gfx::Color(0.533f, 0.533f, 0.533f, 0.533f));
+}
+
+void CLevelLoader::HandleCommand_VehicleColor(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.newBotColors[line->GetParam("team")->AsInt(0)] = line->GetParam("color")->AsColor(Gfx::Color(0.533f, 0.533f, 0.533f, 0.533f));
+}
+
+void CLevelLoader::HandleCommand_InsectColor(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.newAlienColor = line->GetParam("color")->AsColor(Gfx::Color(0.533f, 0.533f, 0.533f, 0.533f));
+}
+
+void CLevelLoader::HandleCommand_GreeneryColor(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.newGreenColor = line->GetParam("color")->AsColor(Gfx::Color(0.533f, 0.533f, 0.533f, 0.533f));
+}
+
+void CLevelLoader::HandleCommand_DeepView(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.airDeepView = line->GetParam("air")->AsFloat(500.0f)*m_result.unit;
+    m_result.waterDeepView = line->GetParam("water")->AsFloat(100.0f)*m_result.unit;
+}
+
+void CLevelLoader::HandleCommand_FogStart(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.airFogStart = line->GetParam("air")->AsFloat(0.5f);
+    m_result.waterFogStart = line->GetParam("water")->AsFloat(0.5f);
+}
+
+void CLevelLoader::HandleCommand_SecondTexture(CLevelParserLine* line, LevelLoadMode mode)
+{
+    if (line->GetParam("rank")->IsDefined())
+    {
+        char tex[20] = { 0 };
+        sprintf(tex, "dirty%.2d.png", line->GetParam("rank")->AsInt());
+        m_result.secondTexture = tex;
+    }
+    else
+    {
+        m_result.secondTexture = "../" + line->GetParam("texture")->AsPath("textures");
+    }
+}
+
+void CLevelLoader::HandleCommand_Background(CLevelParserLine* line, LevelLoadMode mode)
+{
+    if (line->GetParam("image")->IsDefined())
+        m_result.backgroundPath = line->GetParam("image")->AsPath("textures");
+    m_result.backgroundUp = line->GetParam("up")->AsColor(m_result.backgroundUp);
+    m_result.backgroundDown = line->GetParam("down")->AsColor(m_result.backgroundDown);
+    m_result.backgroundCloudUp = line->GetParam("cloudUp")->AsColor(m_result.backgroundCloudUp);
+    m_result.backgroundCloudDown = line->GetParam("cloudDown")->AsColor(m_result.backgroundCloudDown);
+    m_result.backgroundFull = line->GetParam("full")->AsBool(m_result.backgroundFull);
+}
+
+void CLevelLoader::HandleCommand_Planet(CLevelParserLine* line, LevelLoadMode mode)
+{
+    Math::Vector    ppos, uv1, uv2;
+
+    ppos  = line->GetParam("pos")->AsPoint();
+    uv1   = line->GetParam("uv1")->AsPoint();
+    uv2   = line->GetParam("uv2")->AsPoint();
+
+    Gfx::CPlanet::Planet planet;
+
+    planet.type = line->GetParam("mode")->AsPlanetType();
+    planet.start = Math::Point(ppos.x, ppos.z);
+    planet.angle = Math::Point(ppos.x, ppos.z);
+    planet.dim   = line->GetParam("dim")->AsFloat(0.2f);
+    planet.speed = line->GetParam("speed")->AsFloat(0.0f);
+    planet.dir   = line->GetParam("dir")->AsFloat(0.0f);
+    planet.name = line->GetParam("image")->AsPath("textures");
+    planet.uv1   = Math::Point(uv1.x, uv1.z);
+    planet.uv2   = Math::Point(uv2.x, uv2.z);
+    planet.transparent = line->GetParam("image")->AsPath("textures").find("planet") != std::string::npos; // TODO: add transparent op or modify textures
+
+    m_result.planets.push_back(planet);
+}
+
+void CLevelLoader::HandleCommand_ForegroundName(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.foregroundName = line->GetParam("image")->AsPath("textures");
+}
+
+void CLevelLoader::HandleCommand_Level(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.unit = line->GetParam("unitScale")->AsFloat(CRobotMain::UNIT);
+    m_result.traceQuality = line->GetParam("traceQuality")->AsFloat(1.0f);
+    m_result.shortcut = line->GetParam("shortcut")->AsBool(true);
+
+    m_result.mission.missionType = line->GetParam("type")->AsMissionType(MISSION_NORMAL);
+    m_result.magnifyDamage = line->GetParam("magnifyDamage")->AsFloat(1.0f);
+}
+
+void CLevelLoader::HandleCommand_TerrainGenerate(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.terrain.generate.mosaicCount = line->GetParam("mosaic")->AsInt(20);
+    m_result.terrain.generate.brickCountPow2 =  line->GetParam("brick")->AsInt(3),
+    m_result.terrain.generate.brickSize = line->GetParam("size")->AsFloat(20.0f),
+    m_result.terrain.generate.vision = line->GetParam("vision")->AsFloat(500.0f)*m_result.unit,
+    m_result.terrain.generate.depth = line->GetParam("depth")->AsInt(2),
+    m_result.terrain.generate.hardness = line->GetParam("hard")->AsFloat(0.5f);
+}
+
+void CLevelLoader::HandleCommand_TerrainWind(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.terrain.windSpeed = line->GetParam("speed")->AsPoint();
+}
+
+void CLevelLoader::HandleCommand_TerrainRelief(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.terrain.relief = TerrainRelief(
+        line->GetParam("image")->AsPath("textures"),
+        line->GetParam("factor")->AsFloat(1.0f),
+        line->GetParam("border")->AsBool(true));
+}
+
+void CLevelLoader::HandleCommand_TerrainRandomRelief(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.terrain.relief = TerrainRelief();
+}
+
+void CLevelLoader::HandleCommand_TerrainResource(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.terrain.resources = line->GetParam("image")->AsPath("textures");
+}
+
+void CLevelLoader::HandleCommand_TerrainWater(CLevelParserLine* line, LevelLoadMode mode)
+{
+    Math::Vector pos;
+    pos.x = line->GetParam("moveX")->AsFloat(0.0f);
+    pos.y = line->GetParam("moveY")->AsFloat(0.0f);
+    pos.z = pos.x;
+    m_result.water.exists = true;
+    m_result.water.type1 = line->GetParam("air")->AsWaterType(Gfx::WATER_TT);
+    m_result.water.type2 = line->GetParam("water")->AsWaterType(Gfx::WATER_TT);
+    m_result.water.imageFileName = line->GetParam("image")->AsPath("textures");
+    m_result.water.diffuse = line->GetParam("diffuse")->AsColor(Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f));
+    m_result.water.ambient = line->GetParam("ambient")->AsColor(Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f));
+    m_result.water.level = line->GetParam("level")->AsFloat(100.0f)*m_result.unit;
+    m_result.water.glint = line->GetParam("glint")->AsFloat(1.0f);
+    m_result.water.eddy = pos;
+    m_result.water.color = line->GetParam("color")->AsColor(m_result.water.color);
+    m_result.water.colorShift = line->GetParam("brightness")->AsFloat(0.0f);
+}
+
+void CLevelLoader::HandleCommand_TerrainLava(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.water.lava = line->GetParam("mode")->AsBool();
+}
+
+void CLevelLoader::HandleCommand_TerrainCloud(CLevelParserLine* line, LevelLoadMode mode)
+{
+    std::string path = "";
+    if (line->GetParam("image")->IsDefined())
+        path = line->GetParam("image")->AsPath("textures");
+    m_result.cloud.exists = true;
+    m_result.cloud.fileName = path;
+    m_result.cloud.diffuse = line->GetParam("diffuse")->AsColor(Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f));
+    m_result.cloud.ambient = line->GetParam("ambient")->AsColor(Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f));
+    m_result.cloud.level = line->GetParam("level")->AsFloat(500.0f)*m_result.unit;
+}
+
+void CLevelLoader::HandleCommand_TerrainBlitz(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.lightning.exists = true;
+    m_result.lightning.sleep = line->GetParam("sleep")->AsFloat(0.0f);
+    m_result.lightning.delay = line->GetParam("delay")->AsFloat(3.0f);
+    m_result.lightning.magnetic = line->GetParam("magnetic")->AsFloat(50.0f)*m_result.unit;
+}
+
+void CLevelLoader::HandleCommand_TerrainInitTextures(CLevelParserLine* line, LevelLoadMode mode)
+{
+    std::string name = "../" + line->GetParam("image")->AsPath("textures");
+    if (name.find(".") == std::string::npos)
+        name += ".png";
+    unsigned int dx = line->GetParam("dx")->AsInt(1);
+    unsigned int dy = line->GetParam("dy")->AsInt(1);
+
+    int tt[100]; //TODO: I have no idea how TerrainInitTextures works, but maybe we shuld remove the limit to 100?
+    if (dx*dy > 100)
+        throw CLevelParserException("In TerrainInitTextures: dx*dy must be <100");
+    if (line->GetParam("table")->IsDefined())
+    {
+        auto& table = line->GetParam("table")->AsArray();
+
+        if (table.size() > dx*dy)
+            throw CLevelParserException("In TerrainInitTextures: table size must be dx*dy");
+
+        for (unsigned int i = 0; i < dx*dy; i++)
+        {
+            if (i >= table.size())
+            {
+                tt[i] = 0;
+            }
+            else
+            {
+                tt[i] = table[i]->AsInt();
+            }
+        }
+    }
+    else
+    {
+        for (unsigned int i = 0; i < dx*dy; i++)
+        {
+            tt[i] = 0;
+        }
+    }
+
+    m_result.terrain.simpleTextureEnabled = true;
+    m_result.terrain.simpleTexture.fileName = name;
+    m_result.terrain.simpleTexture.table = std::vector<int>(tt, tt + sizeof(tt) / sizeof(tt[0]));
+    m_result.terrain.simpleTexture.width = dx;
+    m_result.terrain.simpleTexture.height = dy;
+}
+
+void CLevelLoader::HandleCommand_TerrainInit(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.terrain.simpleTextureEnabled = false;
+    m_result.terrain.complexTexture.defaultMaterial = line->GetParam("id")->AsInt(1);
+}
+
+void CLevelLoader::HandleCommand_TerrainMaterial(CLevelParserLine* line, LevelLoadMode mode)
+{
+    std::string name = line->GetParam("image")->AsPath("textures");
+    if (name.find(".") == std::string::npos)
+        name += ".png";
+    name = "../" + name;
+
+    Gfx::CTerrain::TerrainMaterial tm;
+    tm.texName  = name.c_str();
+    tm.id       = line->GetParam("id")->AsInt(0);
+    tm.uv       = Math::Point(line->GetParam("u")->AsFloat(),
+                             line->GetParam("v")->AsFloat());
+    tm.mat[0]   = line->GetParam("up")->AsInt();
+    tm.mat[1]   = line->GetParam("right")->AsInt();
+    tm.mat[2]   = line->GetParam("down")->AsInt();
+    tm.mat[3]   = line->GetParam("left")->AsInt();
+    tm.hardness = line->GetParam("hard")->AsFloat(0.5f);
+
+    m_result.terrain.complexTexture.materials.push_back(tm);
+}
+
+void CLevelLoader::HandleCommand_TerrainLevel(CLevelParserLine* line, LevelLoadMode mode)
+{
+    int id[50]; //TODO: I have no idea how TerrainLevel works, but maybe we should remove the limit to 50?
+    if (line->GetParam("id")->IsDefined())
+    {
+        auto& idArray = line->GetParam("id")->AsArray();
+
+        if (idArray.size() > 50)
+            throw CLevelParserException("In TerrainLevel: id array size must be < 50");
+
+        unsigned int i = 0;
+        while (i < 50)
+        {
+            id[i] = idArray[i]->AsInt();
+            i++;
+            if (i >= idArray.size()) break;
+        }
+        id[i] = 0;
+    }
+
+    CLevelLoader::TerrainLevel terrainLevel;
+    terrainLevel.id = std::vector<int>(id, id + sizeof(id) / sizeof(id[0]));
+    terrainLevel.min = line->GetParam("min")->AsFloat(0.0f)*m_result.unit;
+    terrainLevel.max = line->GetParam("max")->AsFloat(100.0f)*m_result.unit;
+    terrainLevel.slope = line->GetParam("slope")->AsFloat(5.0f);
+    terrainLevel.freq = line->GetParam("freq")->AsFloat(100.0f);
+    terrainLevel.center = line->GetParam("center")->AsPoint(Math::Vector(0.0f, 0.0f, 0.0f))*m_result.unit;
+    terrainLevel.radius = line->GetParam("radius")->AsFloat(0.0f)*m_result.unit;
+
+    m_result.terrain.complexTexture.levels.push_back(terrainLevel);
+}
+
+void CLevelLoader::HandleCommand_TerrainCreate(CLevelParserLine* line, LevelLoadMode mode)
+{
+    // empty
+}
+
+void CLevelLoader::HandleCommand_BeginObject(CLevelParserLine* line, LevelLoadMode mode)
+{
+    // empty
+}
+
+void CLevelLoader::HandleCommand_LevelController(CLevelParserLine* line, LevelLoadMode mode)
+{
+    ObjectCreateParams params;
+    params.pos = Math::Vector(0.0f, 0.0f, 0.0f);
+    params.angle = 0.0f;
+    params.type = OBJECT_CONTROLLER;
+
+    m_result.objects.push_back(ObjectCreate(params, line));
+}
+
+void CLevelLoader::HandleCommand_CreateObject(CLevelParserLine* line, LevelLoadMode mode)
+{
+    ObjectCreateParams params = CObject::ReadCreateParams(line);
+
+    m_result.objects.push_back(ObjectCreate(params, line));
+}
+
+void CLevelLoader::HandleCommand_CreateFog(CLevelParserLine* line, LevelLoadMode mode)
+{
+    Fog fog;
+    fog.type = static_cast<Gfx::ParticleType>(Gfx::PARTIFOG0+(line->GetParam("type")->AsInt()));
+    fog.position = line->GetParam("pos")->AsPoint()*m_result.unit;
+    fog.height = line->GetParam("height")->AsFloat(1.0f)*m_result.unit;
+    float ddim = line->GetParam("dim")->AsFloat(50.0f)*m_result.unit;
+    fog.dim.x = ddim;
+    fog.dim.y = ddim;
+    fog.delay = line->GetParam("delay")->AsFloat(2.0f);
+
+    m_result.fog.push_back(fog);
+}
+
+void CLevelLoader::HandleCommand_CreateLight(CLevelParserLine* line, LevelLoadMode mode)
+{
+    Light light;
+    light.direction = line->GetParam("dir")->AsPoint();
+    light.color = line->GetParam("color")->AsColor(Gfx::Color(0.5f, 0.5f, 0.5f, 1.0f));
+    light.type = line->GetParam("type")->AsTerrainType(Gfx::ENG_OBJTYPE_NULL);
+
+    m_result.light.push_back(light);
+}
+
+void CLevelLoader::HandleCommand_CreateSpot(CLevelParserLine* line, LevelLoadMode mode)
+{
+    LightSpot lightSpot;
+    lightSpot.position = line->GetParam("pos")->AsPoint()*m_result.unit;
+    lightSpot.color = line->GetParam("color")->AsColor(Gfx::Color(0.5f, 0.5f, 0.5f, 1.0f));
+    lightSpot.type = line->GetParam("type")->AsTerrainType(Gfx::ENG_OBJTYPE_NULL);
+
+    m_result.lightSpots.push_back(lightSpot);
+}
+
+void CLevelLoader::HandleCommand_GroundSpot(CLevelParserLine* line, LevelLoadMode mode)
+{
+    GroundSpot spot;
+    spot.position = line->GetParam("pos")->AsPoint(Math::Vector(0.0f, 0.0f, 0.0f))*m_result.unit;
+    spot.radius = line->GetParam("radius")->AsFloat(10.0f)*m_result.unit;
+    spot.color = line->GetParam("color")->AsColor(Gfx::Color(0.533f, 0.533f, 0.533f, 0.533f));
+    spot.smooth = line->GetParam("smooth")->AsFloat(1.0f);
+    spot.min = line->GetParam("min")->AsFloat(0.0f)*m_result.unit;
+    spot.max = line->GetParam("max")->AsFloat(0.0f)*m_result.unit;
+
+    m_result.groundSpots.push_back(spot);
+}
+
+void CLevelLoader::HandleCommand_WaterColor(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.waterAddColor = line->GetParam("color")->AsColor();
+}
+
+void CLevelLoader::HandleCommand_MapColor(CLevelParserLine* line, LevelLoadMode mode)
+{
+    Map map;
+    map.floorColor = line->GetParam("floor")->AsColor(Gfx::Color(0.533f, 0.533f, 0.533f, 0.533f));
+    map.waterColor = line->GetParam("water")->AsColor(Gfx::Color(0.533f, 0.533f, 0.533f, 0.533f));
+    map.show = line->GetParam("show")->AsBool(true);
+    map.toyIcon = line->GetParam("toyIcon")->AsBool(false);
+    map.imageEnable = line->GetParam("image")->AsBool(false);
+    if (map.imageEnable)
+    {
+        map.imageFileName = line->GetParam("filename")->AsPath("textures");
+        Math::Vector offset = line->GetParam("offset")->AsPoint(Math::Vector(0.0f, 0.0f, 0.0f));
+        map.imageOffsetX = offset.x;
+        map.imageOffsetY = offset.z;
+        map.imageZoom = line->GetParam("zoom")->AsFloat(1.0f);
+        map.imageAngle = line->GetParam("angle")->AsFloat(0.0f)*Math::PI/180.0f;
+        map.imageMode = line->GetParam("mode")->AsInt(0);
+        map.imageDebug = line->GetParam("debug")->AsBool(false);
+    }
+
+    m_result.map = map;
+}
+
+void CLevelLoader::HandleCommand_MapZoom(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.map.defaultZoom = line->GetParam("factor")->AsFloat(2.0f);
+    m_result.map.enable = line->GetParam("enable")->AsBool(true);
+}
+
+void CLevelLoader::HandleCommand_MaxFlyingHeight(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.terrain.maxFlyingHeight = line->GetParam("max")->AsFloat(280.0f)*m_result.unit;
+}
+
+void CLevelLoader::HandleCommand_AddFlyingHeight(CLevelParserLine* line, LevelLoadMode mode)
+{
+    Gfx::CTerrain::FlyingLimit fl;
+    fl.center = line->GetParam("center")->AsPoint()*m_result.unit;
+    fl.extRadius = line->GetParam("extRadius")->AsFloat(20.0f)*m_result.unit;
+    fl.intRadius = line->GetParam("intRadius")->AsFloat(10.0f)*m_result.unit;
+    fl.maxHeight = line->GetParam("maxHeight")->AsFloat(200.0f);
+}
+
+void CLevelLoader::HandleCommand_Camera(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.camera.eyePosition = line->GetParam("eye")->AsPoint(Math::Vector(0.0f, 0.0f, 0.0f))*m_result.unit;
+    m_result.camera.lookAt = line->GetParam("lookat")->AsPoint(Math::Vector(0.0f, 0.0f, 0.0f))*m_result.unit;
+    m_result.camera.delay = (mode == LevelLoadMode::Reset ? 0.0f : line->GetParam("delay")->AsFloat(0.0f));
+    m_result.camera.overlayEffectOnStart = line->GetParam("fadeIn")->AsBool(false);
+}
+
+void CLevelLoader::HandleCommand_EndMissionTake(CLevelParserLine* line, LevelLoadMode mode)
+{
+    auto endTake = MakeUnique<CSceneEndCondition>();
+    endTake->Read(line);
+    if ( endTake->immediat )
+        m_result.mission.endTakeImmediat = true;
+    m_result.mission.endConditions.push_back(std::move(endTake));
+
+    if (!line->GetParam("pos")->IsDefined() || !line->GetParam("dist")->IsDefined())
+    {
+        ShowLoadingWarning("The defaults for pos= and dist= are going to change, specify them explicitly. See issue #759 (https://git.io/vVBzH)");
+    }
+}
+
+void CLevelLoader::HandleCommand_EndMissionDelay(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.mission.lostDelay  = line->GetParam("win")->AsFloat(2.0f);
+    m_result.mission.winDelay = line->GetParam("lost")->AsFloat(2.0f);
+}
+
+void CLevelLoader::HandleCommand_EndMissionResearch(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.mission.requiredResearch |= line->GetParam("type")->AsResearchFlag();
+}
+
+void CLevelLoader::HandleCommand_ObligatoryToken(CLevelParserLine* line, LevelLoadMode mode)
+{
+    std::string token = line->GetParam("text")->AsString();
+    if (!line->GetParam("min")->IsDefined() && !line->GetParam("max")->IsDefined())
+        GetLogger()->Warn("ObligatoryToken without specifying min/max is provided only for backwards compatibility - instead, do this: ObligatoryToken text=\"%s\" min=1\n", token.c_str());
+    if (m_result.mission.obligatoryTokens.count(token))
+        throw CLevelParserException("Incorrect ObligatoryToken specification - you cannot define a token twice");
+
+    int min = line->GetParam("min")->AsInt(line->GetParam("max")->IsDefined() ? -1 : 1); // BACKWARDS COMPATIBILITY: if neither min or max are defined, default to min=1
+    int max = line->GetParam("max")->AsInt(-1);
+
+
+    if (min >= 0 && max >= 0 && min > max)
+    {
+        throw CLevelParserException("Incorrect ObligatoryToken specification - min cannot be greater than max");
+    }
+
+    m_result.mission.obligatoryTokens[token].min = min;
+    m_result.mission.obligatoryTokens[token].max = max;
+}
+
+void CLevelLoader::HandleCommand_ProhibitedToken(CLevelParserLine* line, LevelLoadMode mode)
+{
+    std::string token = line->GetParam("text")->AsString();
+    GetLogger()->Warn("ProhibitedToken is only provided for backwards compatibility - instead, do this: ObligatoryToken text=\"%s\" max=0\n", token.c_str());
+    if (m_result.mission.obligatoryTokens.count(token))
+        throw CLevelParserException("Incorrect ObligatoryToken specification - you cannot define a token twice");
+
+    m_result.mission.obligatoryTokens[token].min = -1;
+    m_result.mission.obligatoryTokens[token].max = 0;
+}
+
+void CLevelLoader::HandleCommand_EnableBuild(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.buildEnabled |= line->GetParam("type")->AsBuildFlag();
+}
+
+void CLevelLoader::HandleCommand_EnableResearch(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.researchEnabled |= line->GetParam("type")->AsResearchFlag();
+}
+
+void CLevelLoader::HandleCommand_DoneResearch(CLevelParserLine* line, LevelLoadMode mode)
+{
+    m_result.researchDone[0] |= line->GetParam("type")->AsResearchFlag();
+}
+
+void CLevelLoader::HandleCommand_NewScript(CLevelParserLine* line, LevelLoadMode mode)
+{
+    NewScriptName newScriptName(line->GetParam("type")->AsObjectType(OBJECT_NULL),
+                                line->GetParam("name")->AsPath("ai"));
+
+    m_result.newScriptNames.push_back(newScriptName);
+}

--- a/src/level/level_loader.h
+++ b/src/level/level_loader.h
@@ -1,0 +1,470 @@
+/*
+ * This file is part of the Colobot: Gold Edition source code
+ * Copyright (C) 2001-2016, Daniel Roux, EPSITEC SA & TerranovaTeam
+ * http://epsitec.ch; http://colobot.info; http://github.com/colobot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://gnu.org/licenses
+ */
+
+/**
+ * \file level/level_loader.h
+ */
+
+#pragma once
+
+#include "common/restext.h"
+
+#include "graphics/engine/planet.h"
+#include "graphics/engine/terrain.h"
+
+#include "level/level_load_mode.h"
+#include "object/object_manager.h"
+#include "level/parser/parser.h"
+#include "level/robotmain.h"
+#include "level/scene_conditions.h"
+
+#include "object/object.h"
+
+#include <boost/optional.hpp>
+
+#include <string>
+
+
+class MinMax;
+class NewScriptName;
+class CLevelLoader;
+
+typedef std::function<void(const std::string&)> WarningCallback;
+typedef std::function<void(CLevelLoader*, CLevelParserLine*, LevelLoadMode)> CommandFunction;
+
+/**
+ * \brief Tool to loading and building scene from file
+ */
+class CLevelLoader
+{
+public:
+    struct TerrainGenerate
+    {
+        int     mosaicCount = 0;
+        int     brickCountPow2 = 0;
+        float   brickSize = 0.0f;
+        float   vision = 0.0f;
+        int     depth = 0;
+        float   hardness = 0.0f;
+    };
+
+    struct TerrainLevel
+    {
+        std::vector<int> id = {};
+        float   min = 0.0f;
+        float   max = 0.0f;
+        float   slope = 0.0f;
+        float   freq = 0.0f;
+        Math::Vector center = Math::Vector(0.0f, 0.0f, 0.0f);
+        float   radius = 0.0f;
+    };
+
+    struct TerrainRelief
+    {
+        bool        random = true;
+        std::string fileName = "";
+        float       scaleRelief = 0.0f;
+        bool        adjustBorder = false;
+
+        TerrainRelief()
+        {
+            this->random = true;
+        }
+
+        TerrainRelief(const std::string& fileName, float scaleRelief, bool adjustBorder)
+        {
+            this->random = false;
+
+            this->fileName = fileName;
+            this->scaleRelief = scaleRelief;
+            this->adjustBorder = adjustBorder;
+        }
+    };
+
+    struct SimpleTerrainTexture
+    {
+        std::string         fileName = "";
+        std::vector<int>    table = {};
+        float               width = 0.0f;
+        float               height = 0.0f;
+    };
+
+    struct ComplexTerrainTexture
+    {
+        std::vector<Gfx::CTerrain::TerrainMaterial> materials = {};
+        int defaultMaterial = 0;
+        std::vector<TerrainLevel> levels = {};
+    };
+
+    struct Terrain
+    {
+        TerrainGenerate         generate = TerrainGenerate();
+        Math::Vector            windSpeed = Math::Vector(0.0f, 0.0f, 0.0f);
+        TerrainRelief           relief = TerrainRelief();
+        std::string             resources = "";                                 //!< Path to image containing info about resources on map
+        bool                    simpleTextureEnabled = true;                    //!< If true, use simple texture, otherwise complex texture
+        SimpleTerrainTexture    simpleTexture = SimpleTerrainTexture();
+        ComplexTerrainTexture   complexTexture = ComplexTerrainTexture();
+        float                   maxFlyingHeight = 0.0f;                         //!< Flying limit on the entire scene
+        std::vector<Gfx::CTerrain::FlyingLimit> flyingLimits = {};              //!< Flying limits on specified spots on scene
+    };
+
+    struct Water
+    {
+        bool            exists = false;
+        Gfx::WaterType  type1 = Gfx::WaterType::WATER_TT;
+        Gfx::WaterType  type2 = Gfx::WaterType::WATER_TT;
+        std::string     imageFileName = "";
+        Gfx::Color      diffuse = Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f);
+        Gfx::Color      ambient = Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f);
+        float           level = 0.0f;
+        float           glint = 0.0f;
+        Math::Vector    eddy = Math::Vector(0.0f, 0.0f, 0.0f);
+        bool            lava = false;
+        Gfx::Color      color = Gfx::CWater::COLOR_REF_WATER;
+        float           colorShift = 0.0f;
+    };
+
+    struct Cloud
+    {
+        bool        exists = false;
+        std::string fileName = "";
+        Gfx::Color  diffuse = Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f);
+        Gfx::Color  ambient = Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f);
+        float       level = 0.0f;
+    };
+
+    struct Lightning
+    {
+        bool exists = false;
+        float sleep = 0.0f;
+        float delay = 0.0f;
+        float magnetic = 0.0f;
+        float progress = 0.0f;
+    };
+
+    struct GroundSpot
+    {
+        Math::Vector position = Math::Vector(0.0f, 0.0f, 0.0f);
+        float radius = 0.0f;
+        Gfx::Color color = Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f);
+        float min = 0.0f;
+        float max = 0.0f;
+        float smooth = 0.0f;
+    };
+
+    struct Fog
+    {
+        Gfx::ParticleType type = Gfx::ParticleType::PARTIFOG0;
+        Math::Vector    position = Math::Vector(0.0f, 0.0f, 0.0f);
+        float           height = 0.0f;
+        float           delay = 0.0f;
+        Math::Point     dim = Math::Point(0.0f, 0.0f);
+    };
+
+    struct Light
+    {
+        Math::Vector    direction = Math::Vector(0.0f, 0.0f, 0.0f);
+        Gfx::Color      color = Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f);
+        Gfx::EngineObjectType type = Gfx::EngineObjectType::ENG_OBJTYPE_NULL;
+    };
+
+    struct LightSpot
+    {
+        Math::Vector    position = Math::Vector(0.0f, 0.0f, 0.0f);
+        Gfx::Color      color = Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f);
+        Gfx::EngineObjectType type = Gfx::EngineObjectType::ENG_OBJTYPE_NULL;
+    };
+
+    struct Map
+    {
+        bool            enable = true;
+        bool            show = true;
+        bool            toyIcon = false;
+        float           defaultZoom = 2.0f;
+        Gfx::Color      floorColor = Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f);
+        Gfx::Color      waterColor = Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f);
+        bool            imageEnable = false;
+        std::string     imageFileName = "";
+        float           imageZoom = 0.0f;
+        float           imageOffsetX = 0.0f;
+        float           imageOffsetY = 0.0f;
+        float           imageAngle = 0.0f;
+        int             imageMode = 0;
+        bool            imageDebug = false;
+    };
+
+    struct Audio
+    {
+        std::vector<std::string> cacheAudioFileNames = {};
+        std::vector<std::unique_ptr<CAudioChangeCondition>> audioChangeConditions = {};
+        std::string         audioTrack = "";
+        bool                audioRepeat = true;
+        std::string         satcomAudioTrack = "";
+        bool                satcomAudioRepeat = true;
+        std::string         editorAudioTrack = "";
+        bool                editorAudioRepeat = true;
+    };
+
+    struct Camera
+    {
+        Math::Vector    eyePosition = Math::Vector(0.0f, 0.0f, 0.0f);
+        Math::Vector    lookAt = Math::Vector(0.0f, 0.0f, 0.0f);
+        float           delay = 0.0f;
+        bool            overlayEffectOnStart = false;
+    };
+
+    struct Mission
+    {
+        std::vector<std::unique_ptr<CSceneEndCondition>> endConditions = {};
+        bool            endTakeImmediat = false;
+        float           winDelay = 2.0f;
+        float           lostDelay = 2.0f;
+        int             requiredResearch = 0;
+        std::map<std::string, MinMax> obligatoryTokens = {};
+        bool            missionTimerEnabled = false;
+        bool            missionTimerStarted = false;
+        MissionType     missionType = MISSION_NORMAL;
+        std::string     endingWin = "";                 //!< scene after win
+        std::string     endingLost = "";                //!< scene after lost
+    };
+
+    //! Used to creating object in ::LevelLoadMode::Normal and ::LevelLoadMode::Reset mode
+    struct ObjectCreate
+    {
+        ObjectCreate(ObjectCreateParams params, CLevelParserLine* line)
+            : params(params), line(line)
+        {
+
+        }
+
+        ObjectCreateParams params;
+        CLevelParserLine* line;
+    };
+
+    //! Used to creating object in ::LevelLoadMode::LoadSavedGame mode
+    struct LoadedObjectCreate
+    {
+        LoadedObjectCreate(ObjectCreate object, boost::optional<ObjectCreate> cargo, boost::optional<ObjectCreate> power)
+            : object(object), cargo(cargo), power(power)
+        {
+            this->object = object;
+            this->cargo = cargo;
+            this->power = power;
+        }
+
+        ObjectCreate object;
+        boost::optional<ObjectCreate> cargo;
+        boost::optional<ObjectCreate> power;
+    };
+
+    //! Result of execution CLevelLoader::LoadScene()
+    struct Result
+    {
+        Result();
+        Result(Result &&) = default;
+        Result& operator=(const Result &) = delete;
+        Result(const Result &) = delete;
+
+        float                       unit;
+
+        Terrain                     terrain = Terrain();
+        Water                       water = Water();
+        Cloud                       cloud = Cloud();
+        Lightning                   lightning = Lightning();
+        std::vector<GroundSpot>     groundSpots = std::vector<GroundSpot>();
+        std::vector<Fog>            fog = std::vector<Fog>();
+        std::vector<Light>          light = std::vector<Light>();
+        std::vector<LightSpot>      lightSpots = std::vector<LightSpot>();
+
+        std::vector<ObjectCreate>   objects = {};                               //!< objects in ::LevelLoadMode::Normal and ::LevelLoadMode::Reset mode
+        std::vector<LoadedObjectCreate> loadedObjects = {};                     //!< objects in ::LevelLoadMode::LoadSavedGame mode
+
+        Map                         map = Map();
+        Audio                       audio = Audio();
+        Camera                      camera = Camera();
+        Mission                     mission = Mission();
+
+        int                         buildEnabled = 0;
+        int                         researchEnabled = 0;
+        std::map<int, int>          researchDone = { {0, 0} };
+
+        std::vector<NewScriptName>  newScriptNames = {};
+        std::string                 scriptName = "";
+        std::string                 scriptFile = "";
+
+        bool                        immediatSatcom = false;
+        bool                        beginSatCom = false;
+        std::vector<std::string>    infoFilenames = {};
+
+        float                       airDeepView = 1000.0f;
+        float                       waterDeepView = 1000.0f;
+        float                       airFogStart = 0.75f;
+        float                       waterFogStart = 0.75f;
+
+        Gfx::Color                  airAmbientColor = Gfx::Color(0.5f, 0.5f, 0.5f, 0.5f);
+        Gfx::Color                  waterAmbientColor = Gfx::Color(0.5f, 0.5f, 0.5f, 0.5f);
+        Gfx::Color                  airFogColor = Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f);
+        Gfx::Color                  waterFogColor = Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f);
+        std::map<int, Gfx::Color>   newBotColors = {};
+        Gfx::Color                  newAlienColor = Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f);
+        Gfx::Color                  newGreenColor = Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f);
+        std::string                 backgroundPath = "";
+        Gfx::Color                  backgroundUp = Gfx::Color(0.0f, 0.0f, 0.0f, 0.0f);
+        Gfx::Color                  backgroundDown = Gfx::Color(0.0f, 0.0f, 0.0f, 0.0f);
+        Gfx::Color                  backgroundCloudUp = Gfx::Color(0.0f, 0.0f, 0.0f, 0.0f);
+        Gfx::Color                  backgroundCloudDown = Gfx::Color(0.0f, 0.0f, 0.0f, 0.0f);
+        bool                        backgroundFull = false;
+
+        std::map<int, std::string>  teamNames = {};
+        float                       messageDelay = 1.0f;                        //!< how long message is displayed, 2.0f means twice longer than normal
+        std::string                 secondTexture = "";                         //!< dirt on robots and buildings
+        std::vector<Gfx::CPlanet::Planet> planets = {};                         //!< planets on the sky and in the space while cutscenes
+        std::string                 foregroundName = "";                        //!< lens flare effect
+        float                       traceQuality = 1.0f;                        //!< see Gfx::CEngine::SetTracePrecision()
+        bool                        shortcut = true;
+        float                       magnifyDamage = 1.0f;
+        Gfx::Color                  waterAddColor = Gfx::Color(1.0f, 1.0f, 1.0f, 1.0f);     //!< underwater camera effect
+    };
+
+    /**
+     * \brief Read and process data from parser and return informations about scene in convenient form
+     * \param sceneParser Contains information about scene
+     * \param mode See ::LevelLoadMode
+     * \param warningCallback Executed when loader want show warning
+     * \param savedSceneParser Contains information about loaded game file, used only with LevelLoadMode::LoadSavedGame mode
+     */
+    static Result       LoadScene(CLevelReadOnlyParser* sceneParser, LevelLoadMode mode, WarningCallback warningCallback,
+                                CLevelReadOnlyParser* savedSceneParser = nullptr);
+    //! Restore stacks of execution from file
+    static void         SetExecutionStack(const CObjectContainerProxy& objects, const std::string& filecbot);
+
+private:
+    struct Command
+    {
+        Command(CommandFunction function, int executionConditions)
+        {
+            this->function = function;
+            this->executionConditions = executionConditions;
+        }
+
+        CommandFunction function;
+        int executionConditions;
+    };
+
+    CLevelLoader(WarningCallback warningCllback);
+
+    //! Sketchily check if parser is ill-formed, if true, throw error
+    static void         Validate(CLevelReadOnlyParser* parser);
+
+    void                ShowLoadingWarning(const std::string& message);
+
+    //! Read object from saved game file
+    ObjectCreate        ReadObject(CLevelParserLine *line);
+    //! Read saved game file
+    void                ReadScene(CLevelReadOnlyParser* parser);
+    //! Restore stack of execution of object from file
+    static bool         ReadFileStack(CObject *obj, FILE *file);
+
+    /**
+     * \biref Add handling of ::CLevelParserLine command while execution of CLevelLoader::LoadScene()
+     * \param function Function that handles command, should has following form
+     * \code
+     *      void HandleCommand_%NAME_OF_COMMAND%(CLevelParserLine* line, LevelLoadMode mode);
+     * \endcode
+     * \param executionConditions Specifies for which modes command is processed, see ::LevelLoadMode
+     */
+    static std::shared_ptr<CLevelLoader::Command> MakeCommand(CommandFunction function, int executionConditions = LevelLoadMode::Normal | LevelLoadMode::LoadSavedGame);
+
+    void HandleCommand_Title(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_Resume(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_ScriptName(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_ScriptFile(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_Instructions(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_Satellite(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_Loading(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_HelpFile(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_SoluceFile(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_EndingFile(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_MessageDelay(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_MissionTimer(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_TeamName(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_CacheAudio(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_AudioChange(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_Audio(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_AmbientColor(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_FogColor(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_VehicleColor(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_InsectColor(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_GreeneryColor(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_DeepView(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_FogStart(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_SecondTexture(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_Background(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_Planet(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_ForegroundName(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_Level(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_TerrainGenerate(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_TerrainWind(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_TerrainRelief(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_TerrainRandomRelief(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_TerrainResource(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_TerrainWater(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_TerrainLava(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_TerrainCloud(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_TerrainBlitz(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_TerrainInitTextures(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_TerrainInit(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_TerrainMaterial(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_TerrainLevel(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_TerrainCreate(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_BeginObject(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_LevelController(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_CreateObject(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_CreateFog(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_CreateLight(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_CreateSpot(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_GroundSpot(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_WaterColor(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_MapColor(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_MapZoom(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_MaxFlyingHeight(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_AddFlyingHeight(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_Camera(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_EndMissionTake(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_EndMissionDelay(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_EndMissionResearch(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_ObligatoryToken(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_ProhibitedToken(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_EnableBuild(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_EnableResearch(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_DoneResearch(CLevelParserLine* line, LevelLoadMode mode);
+    void HandleCommand_NewScript(CLevelParserLine* line, LevelLoadMode mode);
+
+private:
+    //! List of commands created by CLevelLoader::MakeCommand()
+    static std::map<std::string,std::shared_ptr<CLevelLoader::Command>> m_commands;
+
+    //! Information about scene which will be returned by CLevelLoader::LoadScene()
+    Result          m_result;
+
+    WarningCallback     m_warningCallback;
+};
+
+

--- a/src/level/robotmain.h
+++ b/src/level/robotmain.h
@@ -35,6 +35,8 @@
 
 #include "level/build_type.h"
 #include "level/level_category.h"
+#include "level/level_load_mode.h"
+#include "level/level_loader.h"
 #include "level/mainmovie.h"
 #include "level/research_type.h"
 
@@ -91,6 +93,7 @@ class CPlayerProfile;
 class CSettings;
 class COldObject;
 class CPauseManager;
+class CLevelLoader;
 struct ActivePause;
 
 namespace Gfx
@@ -149,14 +152,17 @@ struct MinMax
     int max = -1;
 };
 
+enum SatCom
+{
+    Huston     = 0,
+    Sat        = 1,
+    Object     = 2,
+    Loading    = 3,
+    Prog       = 4,
+    Solution   = 5,
+    MAX        = 6
+};
 
-const int SATCOM_HUSTON     = 0;
-const int SATCOM_SAT        = 1;
-const int SATCOM_OBJECT     = 2;
-const int SATCOM_LOADING    = 3;
-const int SATCOM_PROG       = 4;
-const int SATCOM_SOLUCE     = 5;
-const int SATCOM_MAX        = 6;
 
 /**
  * \brief Main class managing the game world
@@ -246,10 +252,10 @@ public:
     MainMovieType GetMainMovie();
 
     void        FlushDisplayInfo();
-    void        StartDisplayInfo(int index, bool movie);
+    void        StartDisplayInfo(SatCom index, bool movie);
     void        StartDisplayInfo(const std::string& filename, int index);
     void        StopDisplayInfo();
-    char*       GetDisplayInfoName(int index);
+    const std::string& GetDisplayInfoName(int index);
 
     void        StartSuspend();
     void        StopSuspend();
@@ -323,6 +329,7 @@ public:
     //@}
 
     int         CreateSpot(Math::Vector pos, Gfx::Color color);
+    int         CreateSpot(Math::Vector pos, Gfx::Color color, Gfx::EngineObjectType type);
 
     //! Find the currently selected object
     CObject*    GetSelect();
@@ -463,6 +470,13 @@ public:
     //! Check if crash sphere debug rendering is enabled
     bool GetDebugCrashSpheres();
 
+    // Reference colors used when recoloring textures, see ChangeColor()
+    static const Gfx::Color COLOR_REF_BOT;
+    static const Gfx::Color COLOR_REF_ALIEN;
+    static const Gfx::Color COLOR_REF_GREEN;
+
+    static const float UNIT; // default for g_unit
+
 protected:
     bool        EventFrame(const Event &event);
     bool        EventObject(const Event &event);
@@ -470,12 +484,12 @@ protected:
 
     void        ShowSaveIndicator(bool show);
 
-    void        CreateScene(bool soluce, bool fixScene, bool resetObject);
+    void        CreateScene(bool solutionEnabled, bool fixScene, LevelLoadMode mode);
     void        ResetCreate();
 
     void        LevelLoadingError(const std::string& error, const std::runtime_error& exception, Phase exitPhase = PHASE_LEVEL_LIST);
 
-    int         CreateLight(Math::Vector direction, Gfx::Color color);
+    int         CreateLight(Math::Vector direction, Gfx::Color color, Gfx::EngineObjectType type);
     void        HiliteClear();
     void        HiliteObject(Math::Point pos);
     void        HiliteFrame(float rTime);
@@ -616,7 +630,7 @@ protected:
     std::string     m_tooltipName;
     float           m_tooltipTime = 0.0f;
 
-    char            m_infoFilename[SATCOM_MAX][100] = {}; // names of text files
+    std::string     m_infoFilename[SatCom::MAX] = {}; // names of text files
     CObject*        m_infoObject = nullptr;
     int             m_infoUsed = 0;
     ActivePause*    m_satcomMoviePause = nullptr;
@@ -676,8 +690,6 @@ protected:
     std::map<int, Gfx::Color> m_colorNewBot;
     Gfx::Color      m_colorNewAlien;
     Gfx::Color      m_colorNewGreen;
-    Gfx::Color      m_colorNewWater;
-    float           m_colorShiftWater = 0.0f;
 
     bool            m_missionTimerEnabled = false;
     bool            m_missionTimerStarted = false;

--- a/src/object/auto/autofactory.cpp
+++ b/src/object/auto/autofactory.cpp
@@ -667,7 +667,7 @@ bool CAutoFactory::CreateVehicle()
         for (const std::string& name : m_main->GetNewScriptNames(m_type))
         {
             Program* prog = programStorage->AddProgram();
-            programStorage->ReadProgram(prog, InjectLevelPathsForCurrentLevel(name));
+            programStorage->ReadProgram(prog, InjectLevelPathsForCurrentLevel(name, m_main->GetLevelCategory(), m_main->GetLevelChap(), m_main->GetLevelRank()));
             prog->readOnly = true;
             prog->filename = name;
         }

--- a/src/object/object_manager.cpp
+++ b/src/object/object_manager.cpp
@@ -138,12 +138,9 @@ CObject* CObjectManager::CreateObject(ObjectCreateParams params)
         params.id = m_nextId;
         m_nextId++;
     }
-    else
+    else if (params.id >= m_nextId)
     {
-        if (params.id >= m_nextId)
-        {
-            m_nextId = params.id + 1;
-        }
+        m_nextId = params.id + 1;
     }
 
     assert(m_objects.find(params.id) == m_objects.end());

--- a/src/script/scriptfunc.cpp
+++ b/src/script/scriptfunc.cpp
@@ -1387,7 +1387,8 @@ bool CScriptFunctions::rProduce(CBotVar* var, CBotVar* result, int& exception, v
 
     if (!name.empty())
     {
-        std::string name2 = InjectLevelPathsForCurrentLevel(name, "ai");
+        std::string name2 = InjectLevelPathsForCurrentLevel(name, script->m_main->GetLevelCategory(), script->m_main->GetLevelChap(),
+                                                            script->m_main->GetLevelRank(), "ai");
         if (object->Implements(ObjectInterfaceType::Programmable))
         {
             CProgramStorageObject* programStorage = dynamic_cast<CProgramStorageObject*>(object);

--- a/src/ui/controls/edit.cpp
+++ b/src/ui/controls/edit.cpp
@@ -34,6 +34,7 @@
 #include "graphics/engine/engine.h"
 
 #include "level/parser/parser.h"
+#include "level/robotmain.h"
 
 #include "script/script.h"
 
@@ -762,7 +763,7 @@ void CEdit::HyperFlush()
 
 // Indicates which is the home page.
 
-void CEdit::HyperHome(std::string filename)
+void CEdit::HyperHome(const std::string& filename)
 {
     HyperFlush();
     HyperAdd(filename, 0);
@@ -778,7 +779,7 @@ void CEdit::HyperJump(std::string name, std::string marker)
     }
 
     std::string filename = name + std::string(".txt");
-    filename = InjectLevelPathsForCurrentLevel(filename, "help/%lng%");
+    filename = InjectLevelPathsForCurrentLevel(filename, m_main->GetLevelCategory(), m_main->GetLevelChap(), m_main->GetLevelRank(), "help/%lng%");
     boost::replace_all(filename, "\\", "/"); //TODO: Fix this in files
 
     if ( ReadText(filename) )
@@ -1126,11 +1127,11 @@ void CEdit::Draw()
 
 // Draw an image part.
 
-std::string PrepareImageFilename(std::string name)
+std::string CEdit::PrepareImageFilename(const std::string& name)
 {
     std::string filename;
     filename = name + ".png";
-    filename = InjectLevelPathsForCurrentLevel(filename, "icons");
+    filename = InjectLevelPathsForCurrentLevel(filename, m_main->GetLevelCategory(), m_main->GetLevelChap(), m_main->GetLevelRank(), "icons");
     boost::replace_all(filename, "\\", "/"); // TODO: Fix this in files
     return filename;
 }
@@ -1410,7 +1411,7 @@ void CEdit::FreeImage()
 
 // Read from a text file.
 
-bool CEdit::ReadText(std::string filename)
+bool CEdit::ReadText(const std::string& filename)
 {
     int         len, len2, i, j, n, font, iLines, iCount;
     char        iName[50];

--- a/src/ui/controls/edit.h
+++ b/src/ui/controls/edit.h
@@ -124,7 +124,7 @@ public:
     const std::string& GetText();
     int                GetTextLength();
 
-    bool        ReadText(std::string filename);
+    bool        ReadText(const std::string& filename);
     bool        WriteText(std::string filename);
 
     void        SetMaxChar(int max);
@@ -167,7 +167,7 @@ public:
     bool        Undo();
 
     void        HyperFlush();
-    void        HyperHome(std::string filename);
+    void        HyperHome(const std::string& filename);
     bool        HyperTest(EventType event);
     bool        HyperGo(EventType event);
 
@@ -188,6 +188,8 @@ protected:
 
     void        HyperJump(std::string name, std::string marker);
     bool        HyperAdd(std::string filename, int firstLine);
+
+    std::string PrepareImageFilename(const std::string& name);
 
     void        DrawImage(Math::Point pos, std::string name, float width, float offset, float height, int nbLine);
     void        DrawBack(Math::Point pos, Math::Point dim);

--- a/src/ui/displayinfo.cpp
+++ b/src/ui/displayinfo.cpp
@@ -125,11 +125,11 @@ bool CDisplayInfo::EventProcess(const Event &event)
 
         if ( event.type == EVENT_SATCOM_HUSTON )
         {
-            ChangeIndexButton(SATCOM_HUSTON);
+            ChangeIndexButton(SatCom::Huston);
         }
         if ( event.type == EVENT_SATCOM_SAT )
         {
-            ChangeIndexButton(SATCOM_SAT);
+            ChangeIndexButton(SatCom::Sat);
         }
 //?     if ( event.event == EVENT_SATCOM_OBJECT )
 //?     {
@@ -137,15 +137,15 @@ bool CDisplayInfo::EventProcess(const Event &event)
 //?     }
         if ( event.type == EVENT_SATCOM_LOADING )
         {
-            ChangeIndexButton(SATCOM_LOADING);
+            ChangeIndexButton(SatCom::Loading);
         }
         if ( event.type == EVENT_SATCOM_PROG )
         {
-            ChangeIndexButton(SATCOM_PROG);
+            ChangeIndexButton(SatCom::Prog);
         }
         if ( event.type == EVENT_SATCOM_SOLUCE )
         {
-            ChangeIndexButton(SATCOM_SOLUCE);
+            ChangeIndexButton(SatCom::Solution);
         }
 
         if ( event.type == EVENT_HYPER_HOME ||
@@ -655,7 +655,7 @@ void CDisplayInfo::ChangeIndexButton(int index)
 {
     Ui::CWindow*    pw;
     Ui::CEdit*      edit;
-    char*       filename;
+    std::string     filename;
 
     pw = static_cast<Ui::CWindow*>(m_interface->SearchControl(EVENT_WINDOW4));
     if ( pw == nullptr )  return;
@@ -683,9 +683,9 @@ void CDisplayInfo::UpdateIndexButton()
     Ui::CGroup*     group;
     Ui::CEdit*      edit;
     Math::Point     pos, dim;
-    char*       filename;
+    std::string     filename;
 
-    static int table[SATCOM_MAX] =
+    static int table[SatCom::MAX] =
     {
         0,  // SATCOM_HUSTON
         1,  // SATCOM_SAT
@@ -701,16 +701,16 @@ void CDisplayInfo::UpdateIndexButton()
     button = static_cast<Ui::CButton*>(pw->SearchControl(EVENT_SATCOM_HUSTON));
     if ( button != nullptr )
     {
-        button->SetState(STATE_CHECK, m_index==SATCOM_HUSTON);
-        filename = m_main->GetDisplayInfoName(SATCOM_HUSTON);
+        button->SetState(STATE_CHECK, m_index==SatCom::Huston);
+        filename = m_main->GetDisplayInfoName(SatCom::Huston);
         button->SetState(STATE_VISIBLE, filename[0]!=0);
     }
 
     button = static_cast<Ui::CButton*>(pw->SearchControl(EVENT_SATCOM_SAT));
     if ( button != nullptr )
     {
-        button->SetState(STATE_CHECK, m_index==SATCOM_SAT);
-        filename = m_main->GetDisplayInfoName(SATCOM_SAT);
+        button->SetState(STATE_CHECK, m_index == SatCom::Sat);
+        filename = m_main->GetDisplayInfoName(SatCom::Sat);
         button->SetState(STATE_VISIBLE, filename[0]!=0);
     }
 
@@ -725,24 +725,24 @@ void CDisplayInfo::UpdateIndexButton()
     button = static_cast<Ui::CButton*>(pw->SearchControl(EVENT_SATCOM_LOADING));
     if ( button != nullptr )
     {
-        button->SetState(STATE_CHECK, m_index==SATCOM_LOADING);
-        filename = m_main->GetDisplayInfoName(SATCOM_LOADING);
+        button->SetState(STATE_CHECK, m_index == SatCom::Loading);
+        filename = m_main->GetDisplayInfoName(SatCom::Loading);
         button->SetState(STATE_VISIBLE, filename[0]!=0);
     }
 
     button = static_cast<Ui::CButton*>(pw->SearchControl(EVENT_SATCOM_PROG));
     if ( button != nullptr )
     {
-        button->SetState(STATE_CHECK, m_index==SATCOM_PROG);
-        filename = m_main->GetDisplayInfoName(SATCOM_PROG);
+        button->SetState(STATE_CHECK, m_index == SatCom::Prog);
+        filename = m_main->GetDisplayInfoName(SatCom::Prog);
         button->SetState(STATE_VISIBLE, filename[0]!=0);
     }
 
     button = static_cast<Ui::CButton*>(pw->SearchControl(EVENT_SATCOM_SOLUCE));
     if ( button != nullptr )
     {
-        button->SetState(STATE_CHECK, m_index==SATCOM_SOLUCE);
-        filename = m_main->GetDisplayInfoName(SATCOM_SOLUCE);
+        button->SetState(STATE_CHECK, m_index == SatCom::Solution);
+        filename = m_main->GetDisplayInfoName(SatCom::Solution);
         button->SetState(STATE_VISIBLE, filename[0]!=0 && m_bSoluce);
     }
 

--- a/src/ui/screen/screen_level_list.cpp
+++ b/src/ui/screen/screen_level_list.cpp
@@ -28,6 +28,7 @@
 #include "level/player_profile.h"
 
 #include "level/parser/parser.h"
+#include "level/robotmain.h"
 
 #include "ui/maindialog.h"
 

--- a/src/ui/screen/screen_loading.cpp
+++ b/src/ui/screen/screen_loading.cpp
@@ -153,7 +153,7 @@ void CScreenLoading::SetProgress(float progress, const std::string& text, const 
     {
         SetBackground("textures/interface/interface.png");
         m_engine->SetBackForce(true);
-        m_app->RenderIfNeeded(60);
+        m_app->Render();
     }
 
     m_lastProgress = progress;

--- a/src/ui/studio.cpp
+++ b/src/ui/studio.cpp
@@ -185,12 +185,12 @@ bool CStudio::EventProcess(const Event &event)
     if ( event.type == EVENT_STUDIO_TOOL &&  // instructions?
          m_dialog == SD_NULL )
     {
-        m_main->StartDisplayInfo(SATCOM_HUSTON, false);
+        m_main->StartDisplayInfo(SatCom::Huston, false);
     }
     if ( event.type == EVENT_STUDIO_HELP &&  // help?
          m_dialog == SD_NULL )
     {
-        m_main->StartDisplayInfo(SATCOM_PROG, false);
+        m_main->StartDisplayInfo(SatCom::Prog, false);
     }
 
     if ( event.type == EVENT_STUDIO_COMPILE )  // compile?


### PR DESCRIPTION
https://colobot.info/forum/showthread.php?tid=658
`Split level loading code from CRobotMain`

My second attempt. Now `CLevelLoader` doesn't build scene itself, but only reads data from parser and returns data in convenient form to `CRobotMain`. I also fixed bug "first frame is very slow". Function `CEngine::UpdateGroundSpotTextures()` (called in `CEngine::Render()`) while first execution loads some textures. I made this function public and invoked before end of scene loading. Few issues can be unclear so I will try explain they :

- I added new class `CLevelReadOnlyParser` and function `CLevelParser::LoadFromText()` because they can help in writing unit tests, data doesn't have to be read from file.
- I changed `RenderIfNeeded()` to `Render()` in  `CScreenLoading::SetProgress()` because loading screen doesn't display properly, e.g. :
```
m_ui->GetLoadingScreen()->SetProgress(0.25f, "Calculating 2 + 2"); // Display "Calculating 2 + 2"
int a = 2 + 2; // Fast calculation
m_ui->GetLoadingScreen()->SetProgress(0.5f, "Calculating 143^1000"); // Skip this because "render isn't needed", user still sees "Calculating 2 + 2"
int b = pow(143, 1000); // Long calculation
// Result? User thinks that 2 + 2 takes that much time.
```
