### PR TITLE
Fix -Wundefined-var-template warning

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -61,9 +61,6 @@
 #include <getopt.h>
 #include <localename.h>
 
-
-template<> CApplication* CSingleton<CApplication>::m_instance = nullptr;
-
 char CApplication::m_languageLocale[] = { 0 };
 
 

--- a/src/app/input.cpp
+++ b/src/app/input.cpp
@@ -32,9 +32,6 @@
 #include <boost/lexical_cast.hpp>
 #include <SDL_system.h>
 
-
-template<> CInput* CSingleton<CInput>::m_instance = nullptr;
-
 CInput::CInput()
     : m_keyPresses()
 {

--- a/src/app/pathman.cpp
+++ b/src/app/pathman.cpp
@@ -37,8 +37,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 
-template<> CPathManager* CSingleton<CPathManager>::m_instance = nullptr;
-
 CPathManager::CPathManager(CSystemUtils* systemUtils)
     : m_systemUtils(systemUtils)
 {

--- a/src/common/config_file.cpp
+++ b/src/common/config_file.cpp
@@ -34,9 +34,6 @@
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/regex.hpp>
 
-
-template<> CConfigFile* CSingleton<CConfigFile>::m_instance = nullptr;
-
 namespace bp = boost::property_tree;
 
 CConfigFile::CConfigFile()

--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -22,10 +22,6 @@
 
 #include <stdio.h>
 
-
-template<> CLogger* CSingleton<CLogger>::m_instance = nullptr;
-
-
 CLogger::CLogger()
 {
     #if DEV_BUILD

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -32,8 +32,6 @@
 
 #include "sound/sound.h"
 
-template<> CSettings* CSingleton<CSettings>::m_instance = nullptr;
-
 CSettings::CSettings()
 {
     m_tooltips       = true;

--- a/src/common/singleton.h
+++ b/src/common/singleton.h
@@ -73,3 +73,4 @@ private:
     CSingleton(const CSingleton<T> &) = delete;
 };
 
+template <typename T> T* CSingleton<T>::m_instance = nullptr;

--- a/src/graphics/engine/engine.cpp
+++ b/src/graphics/engine/engine.cpp
@@ -64,8 +64,6 @@
 #include <SDL_surface.h>
 #include <SDL_thread.h>
 
-template<> Gfx::CEngine* CSingleton<Gfx::CEngine>::m_instance = nullptr;
-
 // Graphics module namespace
 namespace Gfx
 {

--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -125,9 +125,6 @@ const Gfx::Color COLOR_REF_ALIEN = Gfx::Color(135.0f/256.0f, 170.0f/256.0f,  13.
 const Gfx::Color COLOR_REF_GREEN = Gfx::Color(135.0f/256.0f, 170.0f/256.0f,  13.0f/256.0f);  // green
 const Gfx::Color COLOR_REF_WATER = Gfx::Color( 25.0f/256.0f, 255.0f/256.0f, 240.0f/256.0f);  // cyan
 
-
-template<> CRobotMain* CSingleton<CRobotMain>::m_instance = nullptr;
-
 //! Constructor of robot application
 CRobotMain::CRobotMain()
 {

--- a/src/object/object_manager.cpp
+++ b/src/object/object_manager.cpp
@@ -36,10 +36,6 @@
 
 #include <algorithm>
 
-
-template<> CObjectManager* CSingleton<CObjectManager>::m_instance = nullptr;
-
-
 CObjectManager::CObjectManager(Gfx::CEngine* engine,
                                Gfx::CTerrain* terrain,
                                Gfx::COldModelManager* oldModelManager,


### PR DESCRIPTION
This avoids specializing `CSingleton<T>::m_instance` for each type, and instead just defines it once in the header. This is allowed by the standard, multiple definitions are merged in the same way that inline functions are.

This fixes the build under `clang-5.0`, and doesn't break it under any other Clang or GCC versions I tested. I haven't tested this under MSVC, but I've found references to people using this technique fine with MSVC.