### PR TITLE
MacOS build: missed xmlstarlet dependency

### DIFF
--- a/INSTALL-MacOSX.md
+++ b/INSTALL-MacOSX.md
@@ -8,7 +8,7 @@ After installing Developer Command Line Tools, you should have basic tools like 
 ```
 And then:
 ```bash
-  brew install cmake sdl2 sdl2_image sdl2_ttf boost glew physfs flac libsndfile libvorbis vorbis-tools gettext libicns librsvg wget
+  brew install cmake sdl2 sdl2_image sdl2_ttf boost glew physfs flac libsndfile libvorbis vorbis-tools gettext libicns librsvg wget xmlstarlet
 ```
 Gettext is installed in separate directory without adding the files to system path, so in order to get it working normally, you should call also:
 ```bash


### PR DESCRIPTION
hi there,

following [these instructions](https://github.com/colobot/colobot/blob/master/INSTALL-MacOSX.md) hit this bug on `make package` step:

```
CPack: Create package
CPack Error: Error copying build/desktop/Colobot.icns to build/_CPack_Packages/Darwin/Bundle/colobot-0.1.10-alpha/Colobot.app/Contents/Resources/Colobot.icns
CPack Error: Error copying bundle icon.  Check the value of CPACK_BUNDLE_ICON.
CPack Error: Problem compressing the directory
CPack Error: Error when generating package: colobot
make: *** [package] Error 1
```

previously (on `cmake` step) i saw the following warming:

```
CMake Warning at desktop/CMakeLists.txt:13 (message):
  xmlstarlet not found; desktop icons will not be generated
```

that issue was fixed by command `brew install xmlstarlet`.