### PR TITLE
Fix#1113 - a missing override keyword

### DIFF
--- a/src/object/old_object.h
+++ b/src/object/old_object.h
@@ -237,7 +237,7 @@ public:
     void        SetMagnifyDamage(float factor) override;
     float       GetMagnifyDamage() override;
 
-    void        SetDamaging(bool damaging);
+    void        SetDamaging(bool damaging) override;
     bool        IsDamaging()  override;
 
     void        SetDying(DeathType deathType) override;


### PR DESCRIPTION
just activated compilation option  -Wno-inconsistent-missing-override as described in #1113, like #958 fix.