### PR TITLE
Some CBot code optimizations

### DIFF
--- a/src/CBot/CBotClass.cpp
+++ b/src/CBot/CBotClass.cpp
@@ -192,7 +192,7 @@ bool CBotClass::AddItem(CBotVar* pVar)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-std::string  CBotClass::GetName()
+const std::string&  CBotClass::GetName()
 {
     return m_name;
 }

--- a/src/CBot/CBotClass.h
+++ b/src/CBot/CBotClass.h
@@ -173,7 +173,7 @@ public:
      * \brief GetName Gives the name of the class.
      * \return
      */
-    std::string GetName();
+    const std::string& GetName();
 
     /*!
      * \brief GetParent Gives the parent class (or nullptr).

--- a/src/CBot/CBotInstr/CBotFunction.cpp
+++ b/src/CBot/CBotInstr/CBotFunction.cpp
@@ -996,7 +996,7 @@ bool CBotFunction::CheckParam(CBotDefParam* pParam)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-std::string CBotFunction::GetName()
+const std::string& CBotFunction::GetName()
 {
     return  m_token.GetString();
 }

--- a/src/CBot/CBotInstr/CBotFunction.h
+++ b/src/CBot/CBotInstr/CBotFunction.h
@@ -207,7 +207,7 @@ public:
      * \brief GetName
      * \return
      */
-    std::string GetName();
+    const std::string& GetName();
 
     /*!
      * \brief GetParams

--- a/src/CBot/CBotToken.h
+++ b/src/CBot/CBotToken.h
@@ -120,7 +120,7 @@ public:
      * \brief Return the token string
      * \return The string associated with this token
      */
-    std::string GetString();
+    const std::string& GetString();
 
     /**
      * \brief Set the token string

--- a/src/CBot/CBotVar/CBotVar.cpp
+++ b/src/CBot/CBotVar/CBotVar.cpp
@@ -378,7 +378,7 @@ void CBotVar::SetInit(CBotVar::InitType initType)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-std::string CBotVar::GetName()
+const std::string& CBotVar::GetName()
 {
     return    m_token->GetString();
 }

--- a/src/CBot/CBotVar/CBotVar.cpp
+++ b/src/CBot/CBotVar/CBotVar.cpp
@@ -49,7 +49,7 @@ namespace CBot
 long CBotVar::m_identcpt = 0;
 
 ////////////////////////////////////////////////////////////////////////////////
-CBotVar::CBotVar( )
+CBotVar::CBotVar( ) : m_token(nullptr)
 {
     m_pMyThis = nullptr;
     m_pUserPtr = nullptr;
@@ -62,9 +62,17 @@ CBotVar::CBotVar( )
     m_mPrivate = ProtectionLevel::Public;
 }
 
-CBotVar::CBotVar(const CBotToken &name) : CBotVar()
+CBotVar::CBotVar(const CBotToken &name) : m_token(new CBotToken(name))
 {
-    m_token = new CBotToken(name);
+    m_pMyThis = nullptr;
+    m_pUserPtr = nullptr;
+    m_InitExpr = nullptr;
+    m_LimExpr = nullptr;
+    m_type  = -1;
+    m_binit = InitType::UNDEF;
+    m_ident = 0;
+    m_bStatic = false;
+    m_mPrivate = ProtectionLevel::Public;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/CBot/CBotVar/CBotVar.h
+++ b/src/CBot/CBotVar/CBotVar.h
@@ -650,7 +650,7 @@ public:
 
 protected:
     //! The corresponding token, defines the variable name
-    CBotToken* m_token;
+    CBotToken* const m_token;
     //! Type of value.
     CBotTypResult m_type;
     //! Initialization status

--- a/src/CBot/CBotVar/CBotVar.h
+++ b/src/CBot/CBotVar/CBotVar.h
@@ -170,7 +170,7 @@ public:
      * \brief Returns the name of the variable
      * \return The name of the variable, empty string if unknown
      */
-    std::string GetName();
+    const std::string& GetName();
 
     /**
      * \brief SetName Changes the name of the variable

--- a/src/CBot/CBotVar/CBotVarArray.cpp
+++ b/src/CBot/CBotVar/CBotVarArray.cpp
@@ -31,12 +31,11 @@ namespace CBot
 {
 
 ////////////////////////////////////////////////////////////////////////////////
-CBotVarArray::CBotVarArray(const CBotToken& name, CBotTypResult& type)
+CBotVarArray::CBotVarArray(const CBotToken& name, CBotTypResult& type) : CBotVar(name)
 {
     if ( !type.Eq(CBotTypArrayPointer) &&
          !type.Eq(CBotTypArrayBody)) assert(0);
 
-    m_token        = new CBotToken(name);
     m_next        = nullptr;
     m_pMyThis    = nullptr;
     m_pUserPtr    = nullptr;

--- a/src/CBot/CBotVar/CBotVarClass.cpp
+++ b/src/CBot/CBotVar/CBotVarClass.cpp
@@ -36,7 +36,7 @@ namespace CBot
 std::set<CBotVarClass*> CBotVarClass::m_instances{};
 
 ////////////////////////////////////////////////////////////////////////////////
-CBotVarClass::CBotVarClass(const CBotToken& name, const CBotTypResult& type)
+CBotVarClass::CBotVarClass(const CBotToken& name, const CBotTypResult& type) : CBotVar(name)
 {
     if ( !type.Eq(CBotTypClass)        &&
          !type.Eq(CBotTypIntrinsic)    &&                // by convenience there accepts these types
@@ -44,7 +44,6 @@ CBotVarClass::CBotVarClass(const CBotToken& name, const CBotTypResult& type)
          !type.Eq(CBotTypArrayPointer) &&
          !type.Eq(CBotTypArrayBody)) assert(0);
 
-    m_token        = new CBotToken(name);
     m_next        = nullptr;
     m_pMyThis    = nullptr;
     m_pUserPtr    = OBJECTCREATED;//nullptr;

--- a/src/CBot/CBotVar/CBotVarPointer.cpp
+++ b/src/CBot/CBotVar/CBotVarPointer.cpp
@@ -32,14 +32,13 @@ namespace CBot
 {
 
 ////////////////////////////////////////////////////////////////////////////////
-CBotVarPointer::CBotVarPointer(const CBotToken& name, CBotTypResult& type)
+CBotVarPointer::CBotVarPointer(const CBotToken& name, CBotTypResult& type) : CBotVar(name)
 {
     if ( !type.Eq(CBotTypPointer) &&
          !type.Eq(CBotTypNullPointer) &&
          !type.Eq(CBotTypClass)   &&                    // for convenience accepts Class and Intrinsic
          !type.Eq(CBotTypIntrinsic) ) assert(0);
 
-    m_token        = new CBotToken(name);
     m_next        = nullptr;
     m_pMyThis    = nullptr;
     m_pUserPtr    = nullptr;


### PR DESCRIPTION
I just had a random idea to run CBot under a profiler to see what would happen and managed to reduce compilation times a bit with some trivial changes. It's probably not really noticeable unless you have some crazy huge programs or crazy slow CPU that would take a few seconds to compile anyway, but it's an improvement nevertheless. And there is still room for more if anybody has time to dig deeper into that.

Before:
```
╭─krzys_h@krzysh-laptop ~/Pulpit/colobot/build  ‹dev› 
╰─➤  for i in 64 128 256 512 1024 2048 4096; do echo -n "$i: "; python gentest.py $i | time ./CBot_console >/dev/null 2>&1; done
64: ./CBot_console > /dev/null 2>&1  0,02s user 0,00s system 87% cpu 0,027 total
128: ./CBot_console > /dev/null 2>&1  0,04s user 0,00s system 94% cpu 0,042 total
256: ./CBot_console > /dev/null 2>&1  0,08s user 0,01s system 96% cpu 0,089 total
512: ./CBot_console > /dev/null 2>&1  0,22s user 0,01s system 98% cpu 0,235 total
1024: ./CBot_console > /dev/null 2>&1  0,82s user 0,01s system 99% cpu 0,834 total
2048: ./CBot_console > /dev/null 2>&1  3,65s user 0,01s system 99% cpu 3,664 total
4096: ./CBot_console > /dev/null 2>&1  14,24s user 0,06s system 99% cpu 14,294 total
```

After:
```
╭─krzys_h@krzysh-laptop ~/Pulpit/colobot/build  ‹dev-cbot-optimizations› 
╰─➤  for i in 64 128 256 512 1024 2048 4096; do echo -n "$i: "; python gentest.py $i | time ./CBot_console >/dev/null 2>&1; done
64: ./CBot_console > /dev/null 2>&1  0,02s user 0,00s system 86% cpu 0,023 total
128: ./CBot_console > /dev/null 2>&1  0,03s user 0,00s system 91% cpu 0,038 total
256: ./CBot_console > /dev/null 2>&1  0,06s user 0,00s system 96% cpu 0,071 total
512: ./CBot_console > /dev/null 2>&1  0,19s user 0,00s system 99% cpu 0,196 total
1024: ./CBot_console > /dev/null 2>&1  0,71s user 0,02s system 99% cpu 0,731 total
2048: ./CBot_console > /dev/null 2>&1  2,86s user 0,03s system 99% cpu 2,893 total
4096: ./CBot_console > /dev/null 2>&1  11,10s user 0,06s system 99% cpu 11,158 total
```

Testing on Release build with the following input:
```python
import sys
import re

template = """
int fact_iter(?)(int n) {
	int r = 1;
	for(int i = 2; i <= n; i++) {
		r *= i;
	}
	return r;
}

int fact_rec(?)(int n) {
	if (n == 0) {
		return 1;
	} else {
		return n * fact_rec(?)(n-1);
	}
}

extern void test(?)() {
	message(""+(fact_iter(?)(10) == fact_rec(?)(10)));
}
"""

for i in range(int(sys.argv[1])):
	print(re.sub(r'\(\?\)', str(i), template))
```