### PR TITLE
Fix building under clang-7

### DIFF
--- a/src/level/scene_conditions.h
+++ b/src/level/scene_conditions.h
@@ -85,7 +85,7 @@ protected:
  * \class CSceneEndCondition
  * \brief Scene end condition
  */
-class CSceneEndCondition : public CSceneCondition
+class CSceneEndCondition final : public CSceneCondition
 {
 public:
     int winTeam = 0;
@@ -109,7 +109,7 @@ public:
  * \class CAudioChangeCondition
  * \brief Audio change condition
  */
-class CAudioChangeCondition : public CSceneCondition
+class CAudioChangeCondition final : public CSceneCondition
 {
 public:
     std::string music = "";

--- a/src/level/scoreboard.h
+++ b/src/level/scoreboard.h
@@ -78,7 +78,7 @@ public:
      * \brief Scoreboard rule for destroying other objects
      * \see CScoreboard::AddKillRule()
      */
-    class CScoreboardKillRule : public CScoreboardRule, public CObjectCondition
+    class CScoreboardKillRule final : public CScoreboardRule, public CObjectCondition
     {
     public:
         //! Read from line in scene file
@@ -90,7 +90,7 @@ public:
      * \brief Scoreboard rule for EndMissionTake rewards
      * \see CScoreboard::AddEndTakeRule()
      */
-    class CScoreboardEndTakeRule : public CScoreboardRule
+    class CScoreboardEndTakeRule final : public CScoreboardRule
     {
     public:
         int team = 0;


### PR DESCRIPTION
Currently the build fails because of `-Wdelete-non-virtual-dtor` warnings.
This catches when an object is destructed, has a non-virtual destructor,
and is an abstract base class or a non-final class with virtual
functions. The warning happens inside `unique_ptr<T>::~unique_ptr`.

The warning is to prevent somebody writing code like this:

```C++
class MySceneEndCondition : public CSceneEndCondition {
    ~MySceneEndCondition() { /* some complex logic */ }
};
// this won't call MySceneEndCondition's destructor, potentially
// leading to leaks or segfaults:
std::unique_ptr<CSceneEndCondition> p{new MySceneEndCondition()};
```