### PR TITLE
Compile with -Wsuggest-override under GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 
     set(NORMAL_CXX_FLAGS "-std=gnu++11 -Wall -Werror -Wold-style-cast -pedantic-errors")
     set(NORMAL_CXX_FLAGS "${NORMAL_CXX_FLAGS} -Wno-error=deprecated-declarations") # updated version of physfs is not available on some platforms so we keep using deprecated functions, see #958
+
+    if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+        set(NORMAL_CXX_FLAGS "${NORMAL_CXX_FLAGS} -Wsuggest-override")
+    endif()
+
     set(RELEASE_CXX_FLAGS "-O2")
     set(DEBUG_CXX_FLAGS "-g -O0")
     set(TEST_CXX_FLAGS "-pthread")

--- a/src/object/auto/autokid.cpp
+++ b/src/object/auto/autokid.cpp
@@ -51,14 +51,6 @@ CAutoKid::~CAutoKid()
 }
 
 
-// Destroys the object.
-
-void CAutoKid::DeleteObject(bool all)
-{
-    CAuto::DeleteObject(all);
-}
-
-
 // Initialize the object.
 
 void CAutoKid::Init()
@@ -196,12 +188,4 @@ bool CAutoKid::EventProcess(const Event &event)
     }
 
     return true;
-}
-
-
-// Returns an error due the state of the automation.
-
-Error CAutoKid::GetError()
-{
-    return ERR_OK;
 }

--- a/src/object/auto/autokid.h
+++ b/src/object/auto/autokid.h
@@ -27,13 +27,10 @@ class CAutoKid : public CAuto
 {
 public:
     CAutoKid(COldObject* object);
-    ~CAutoKid();
+    ~CAutoKid() override;
 
-    void        DeleteObject(bool all = false);
-
-    void        Init();
-    bool        EventProcess(const Event &event);
-    Error       GetError();
+    void        Init() override;
+    bool        EventProcess(const Event &event) override;
 
 protected:
     float       m_speed = 0.0f;

--- a/src/object/task/task.h
+++ b/src/object/task/task.h
@@ -96,7 +96,7 @@ class CForegroundTask : public CTask
 public:
     CForegroundTask(COldObject* object) : CTask(object) {}
 
-    bool IsBackground() final { return false; }
+    bool IsBackground() override final { return false; }
     bool IsPilot() override { return false; }
 };
 
@@ -105,6 +105,6 @@ class CBackgroundTask : public CTask
 public:
     CBackgroundTask(COldObject* object) : CTask(object) {}
 
-    bool IsBackground() final { return true; }
-    bool IsPilot() final { return true; }
+    bool IsBackground() override final { return true; }
+    bool IsPilot() override final { return true; }
 };

--- a/src/script/scriptfunc.cpp
+++ b/src/script/scriptfunc.cpp
@@ -3106,7 +3106,7 @@ public:
         }
     }
 
-    ~CBotFileColobot()
+    ~CBotFileColobot() override
     {
         if (Opened())
         {

--- a/test/unit/CBot/CBotToken_test.cpp
+++ b/test/unit/CBot/CBotToken_test.cpp
@@ -27,12 +27,12 @@ using namespace CBot;
 class CBotTokenUT : public testing::Test
 {
 public:
-    void SetUp()
+    CBotTokenUT()
     {
         CBotProgram::Init();
     }
 
-    void TearDown()
+    ~CBotTokenUT()
     {
         CBotProgram::Free();
     }

--- a/test/unit/CBot/CBot_test.cpp
+++ b/test/unit/CBot/CBot_test.cpp
@@ -27,14 +27,14 @@ using namespace CBot;
 class CBotUT : public testing::Test
 {
 public:
-    void SetUp()
+    CBotUT()
     {
         CBotProgram::Init();
         CBotProgram::AddFunction("FAIL", rFail, cFail);
         CBotProgram::AddFunction("ASSERT", rAssert, cAssert);
     }
 
-    void TearDown()
+    ~CBotUT()
     {
         CBotProgram::Free();
     }


### PR DESCRIPTION
Clang by default compiles with -Winconsistent-missing-override, which
warns when a class declares virtual functions that override those in the
base class, and some but not all of them are explicitly declared
`override`.

GCC doesn't support this option, but has a stronger version,
-Wsuggest-override. In combination with -Werror, this means that any
virtual function that overrides another *must* be explicitly declared as
`override`.

This commit enables -Wsuggest-override where available. This means that
GCC users can't break the Clang build with inconsistent overrides (see
 #1113 and #1114) and consequently that any build that passes the pull
request CI build on Jenkins won't break because of inconsistent
overrides.