### PR TITLE
Compile with -Wmissing-declarations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 
     message(STATUS "Detected GCC version 4.7+")
 
-    set(NORMAL_CXX_FLAGS "-std=gnu++11 -Wall -Werror -Wold-style-cast -pedantic-errors")
+    set(NORMAL_CXX_FLAGS "-std=gnu++11 -Wall -Werror -Wold-style-cast -pedantic-errors -Wmissing-declarations")
     set(NORMAL_CXX_FLAGS "${NORMAL_CXX_FLAGS} -Wno-error=deprecated-declarations") # updated version of physfs is not available on some platforms so we keep using deprecated functions, see #958
     set(RELEASE_CXX_FLAGS "-O2")
     set(DEBUG_CXX_FLAGS "-g -O0")
@@ -145,7 +145,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 
     message(STATUS "Detected Clang version 3.1+")
 
-    set(NORMAL_CXX_FLAGS "-std=c++11 -Wall -Werror -Wold-style-cast -pedantic-errors")
+    set(NORMAL_CXX_FLAGS "-std=c++11 -Wall -Werror -Wold-style-cast -pedantic-errors -Wmissing-prototypes")
     set(NORMAL_CXX_FLAGS "${NORMAL_CXX_FLAGS} -Wno-error=deprecated-declarations") # updated version of physfs is not available on some platforms so we keep using deprecated functions, see #958
     set(RELEASE_CXX_FLAGS "-O2")
     set(DEBUG_CXX_FLAGS "-g -O0")

--- a/src/CBot/CBotInstr/CBotTwoOpExpr.cpp
+++ b/src/CBot/CBotInstr/CBotTwoOpExpr.cpp
@@ -114,7 +114,7 @@ static int  ListOp[] =
     0, // end of list
 };
 
-bool IsInList(int val, int* list, int& typeMask)
+static bool IsInList(int val, int* list, int& typeMask)
 {
     while (true)
     {
@@ -124,7 +124,7 @@ bool IsInList(int val, int* list, int& typeMask)
     }
 }
 
-bool TypeOk(int type, int test)
+static bool TypeOk(int type, int test)
 {
     while (true)
     {
@@ -304,12 +304,12 @@ CBotInstr* CBotTwoOpExpr::Compile(CBotToken* &p, CBotCStack* pStack, int* pOpera
 }
 
 
-bool VarIsNAN(const CBotVar* var)
+static bool VarIsNAN(const CBotVar* var)
 {
     return var->GetInit() > CBotVar::InitType::DEF;
 }
 
-bool IsNan(CBotVar* left, CBotVar* right, CBotError* err = nullptr)
+static bool IsNan(CBotVar* left, CBotVar* right, CBotError* err = nullptr)
 {
     if ( VarIsNAN(left) || VarIsNAN(right) )
     {

--- a/src/CBot/CBotProgram.cpp
+++ b/src/CBot/CBotProgram.cpp
@@ -292,7 +292,7 @@ bool CBotProgram::ClassExists(std::string name)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-CBotTypResult cSizeOf( CBotVar* &pVar, void* pUser )
+static CBotTypResult cSizeOf( CBotVar* &pVar, void* pUser )
 {
     if ( pVar == nullptr ) return CBotTypResult( CBotErrLowParam );
     if ( pVar->GetType() != CBotTypArrayPointer )
@@ -300,7 +300,7 @@ CBotTypResult cSizeOf( CBotVar* &pVar, void* pUser )
     return CBotTypResult( CBotTypInt );
 }
 
-bool rSizeOf( CBotVar* pVar, CBotVar* pResult, int& ex, void* pUser )
+static bool rSizeOf( CBotVar* pVar, CBotVar* pResult, int& ex, void* pUser )
 {
     if ( pVar == nullptr ) { ex = CBotErrLowParam; return true; }
 

--- a/src/CBot/stdlib/FileFunctions.cpp
+++ b/src/CBot/stdlib/FileFunctions.cpp
@@ -33,8 +33,6 @@ namespace
 std::unique_ptr<CBotFileAccessHandler> g_fileHandler;
 std::unordered_map<int, std::unique_ptr<CBotFile>> g_files;
 int g_nextFileId = 1;
-}
-
 
 bool FileClassOpenFile(CBotVar* pThis, CBotVar* pVar, CBotVar* pResult, int& Exception)
 {
@@ -358,6 +356,7 @@ bool rDeleteFile(CBotVar* var, CBotVar* result, int& exception, void* user)
     return g_fileHandler->DeleteFile(filename);
 }
 
+} // namespace
 
 void InitFileFunctions()
 {

--- a/src/CBot/stdlib/MathFunctions.cpp
+++ b/src/CBot/stdlib/MathFunctions.cpp
@@ -26,6 +26,8 @@
 
 namespace CBot
 {
+namespace
+{
 const float PI = 3.14159265358979323846f;
 
 // Instruction "sin(degrees)".
@@ -192,6 +194,8 @@ bool rTrunc(CBotVar* var, CBotVar* result, int& exception, void* user)
     result->SetValFloat(trunc(value));
     return true;
 }
+
+} // namespace
 
 void InitMathFunctions()
 {

--- a/src/CBot/stdlib/StringFunctions.cpp
+++ b/src/CBot/stdlib/StringFunctions.cpp
@@ -27,6 +27,8 @@
 
 namespace CBot
 {
+namespace
+{
 
 ////////////////////////////////////////////////////////////////////////////////
 bool rStrLen( CBotVar* pVar, CBotVar* pResult, int& ex, void* pUser )
@@ -282,7 +284,7 @@ bool rStrLower( CBotVar* pVar, CBotVar* pResult, int& ex, void* pUser )
     return true;
 }
 
-
+} // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 void InitStringFunctions()

--- a/src/app/pausemanager.cpp
+++ b/src/app/pausemanager.cpp
@@ -42,7 +42,7 @@ struct ActivePause
     PauseMusic music;
 };
 
-std::string GetPauseName(PauseType type)
+static std::string GetPauseName(PauseType type)
 {
     std::vector<std::string> x;
     if ((type & PAUSE_ENGINE) != 0) x.push_back("engine");

--- a/src/app/signal_handlers.cpp
+++ b/src/app/signal_handlers.cpp
@@ -62,7 +62,7 @@ void CSignalHandlers::SignalHandler(int sig)
 #include <cstdlib>
 #include <memory>
 #include <cxxabi.h>
-std::string demangle(const char* name)
+static std::string demangle(const char* name)
 {
     int status;
     std::unique_ptr<char[], void(*)(void*)> result {
@@ -75,7 +75,7 @@ std::string demangle(const char* name)
 #else
 // For MSVC and others
 // In MSVC typeinfo(e).name() should be already demangled
-std::string demangle(const char* name)
+static std::string demangle(const char* name)
 {
     return name;
 }

--- a/src/common/image.cpp
+++ b/src/common/image.cpp
@@ -70,7 +70,6 @@
 namespace
 {
 std::string PNG_ERROR = "";
-}
 
 void PNGUserError(png_structp ctx, png_const_charp str)
 {
@@ -146,6 +145,8 @@ bool PNGSaveSurface(const char *filename, SDL_Surface *surf)
 
     return true;
 }
+
+} // namespace
 
 /* <---------------------------------------------------------------> */
 

--- a/src/common/regex_utils.cpp
+++ b/src/common/regex_utils.cpp
@@ -19,7 +19,7 @@
 
 #include "common/regex_utils.h"
 
-std::string FormatAssertRegexMatchError(const std::string& text,
+static std::string FormatAssertRegexMatchError(const std::string& text,
                                         const std::string& pattern)
 {
     return "Text \"" + text + "\" did not match regex \"" + pattern + "\"";

--- a/src/graphics/engine/camera.cpp
+++ b/src/graphics/engine/camera.cpp
@@ -53,7 +53,7 @@ namespace Gfx
 const float MOUSE_EDGE_MARGIN = 0.01f;
 
 //! Changes the level of transparency of an object and objects transported (battery & cargo)
-void SetTransparency(CObject* obj, float value)
+static void SetTransparency(CObject* obj, float value)
 {
     obj->SetTransparency(value);
 

--- a/src/graphics/engine/engine.cpp
+++ b/src/graphics/engine/engine.cpp
@@ -2383,7 +2383,7 @@ bool CEngine::LoadAllTextures()
     return ok;
 }
 
-bool IsExcludeColor(Math::Point *exclude, int x, int y)
+static bool IsExcludeColor(Math::Point *exclude, int x, int y)
 {
     int i = 0;
     while ( exclude[i+0].x != 0.0f || exclude[i+0].y != 0.0f ||

--- a/src/graphics/engine/particle.cpp
+++ b/src/graphics/engine/particle.cpp
@@ -57,7 +57,7 @@ const float FOG_HINF    = 100.0f;
 
 
 //! Check if an object is a destroyable enemy
-bool IsAlien(ObjectType type)
+static bool IsAlien(ObjectType type)
 {
     return ( type == OBJECT_ANT      ||
              type == OBJECT_SPIDER   ||
@@ -138,7 +138,7 @@ void CParticle::FlushParticle(int sheet)
 
 
 //! Returns file name of the effect effectNN.png, with NN = number
-void NameParticle(std::string &name, int num)
+static void NameParticle(std::string &name, int num)
 {
          if (num == 1)  name = "effect00.png";
     else if (num == 2)  name = "effect01.png";
@@ -148,7 +148,7 @@ void NameParticle(std::string &name, int num)
 }
 
 //! Returns random letter for use as virus particle
-char RandomLetter()
+static char RandomLetter()
 {
     static std::vector<char> chars;
     if (chars.empty())
@@ -3205,7 +3205,7 @@ void CParticle::DrawParticleSphere(int i)
 }
 
 //! Returns the height depending on the progress
-float ProgressCylinder(float progress)
+static float ProgressCylinder(float progress)
 {
     if (progress < 0.5f)
         return 1.0f - (powf(1.0f-progress*2.0f, 2.0f));

--- a/src/level/parser/parserexceptions.cpp
+++ b/src/level/parser/parserexceptions.cpp
@@ -24,7 +24,7 @@
 #include <boost/lexical_cast.hpp>
 
 
-std::string FormatMissingParamError(CLevelParserParam* thisParam) NOEXCEPT
+static std::string FormatMissingParamError(CLevelParserParam* thisParam) NOEXCEPT
 {
     auto paramName = thisParam->GetName();
     auto lineNumber = boost::lexical_cast<std::string>(thisParam->GetLine()->GetLineNumber());
@@ -37,7 +37,7 @@ CLevelParserExceptionMissingParam::CLevelParserExceptionMissingParam(CLevelParse
 {
 }
 
-std::string FormatBadParamError(CLevelParserParam* thisParam, std::string requestedType) NOEXCEPT
+static std::string FormatBadParamError(CLevelParserParam* thisParam, std::string requestedType) NOEXCEPT
 {
     auto paramName = thisParam->GetName();
     auto paramValue = thisParam->GetValue();

--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -2260,7 +2260,7 @@ void CRobotMain::AbortMovie()
 }
 
 
-std::string TimeFormat(float time)
+static std::string TimeFormat(float time)
 {
     int minutes = static_cast<int>(floor(time/60));
     double time2 = fmod(time, 60);

--- a/src/object/auto/autofactory.cpp
+++ b/src/object/auto/autofactory.cpp
@@ -168,7 +168,7 @@ void CAutoFactory::SetProgram(const std::string& program)
     m_program = program;
 }
 
-ObjectType ObjectTypeFromFactoryButton(EventType eventType)
+static ObjectType ObjectTypeFromFactoryButton(EventType eventType)
 {
     if ( eventType == EVENT_OBJECT_FACTORYwa )  return OBJECT_MOBILEwa;
     if ( eventType == EVENT_OBJECT_FACTORYta )  return OBJECT_MOBILEta;

--- a/src/object/auto/autoportico.cpp
+++ b/src/object/auto/autoportico.cpp
@@ -50,7 +50,7 @@ const float PORTICO_TIME_OPEN   = 12.0f;
 // Si progress=0, return a.
 // Si progress=1, return b.
 
-float Progress(float a, float b, float progress)
+static float Progress(float a, float b, float progress)
 {
     return a+(b-a)*progress;
 }

--- a/src/object/task/taskmanip.cpp
+++ b/src/object/task/taskmanip.cpp
@@ -263,28 +263,6 @@ void CTaskManip::InitAngle()
     }
 }
 
-
-// Tests whether an object is compatible with the operation TMA_OTHER.
-
-bool TestFriend(ObjectType oType, ObjectType fType)
-{
-    if ( oType == OBJECT_ENERGY )
-    {
-        return ( fType == OBJECT_METAL );
-    }
-    if ( oType == OBJECT_LABO )
-    {
-        return ( fType == OBJECT_BULLET );
-    }
-    if ( oType == OBJECT_NUCLEAR )
-    {
-        return ( fType == OBJECT_URANIUM );
-    }
-
-    return ( fType == OBJECT_POWER  ||
-             fType == OBJECT_ATOMIC );
-}
-
 // Assigns the goal was achieved.
 
 Error CTaskManip::Start(TaskManipOrder order, TaskManipArm arm)

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -479,7 +479,7 @@ bool CScript::GetCursor(int &cursor1, int &cursor2)
 
 // Put of the variables in a list.
 
-void PutList(const std::string& baseName, bool bArray, CBot::CBotVar *var, Ui::CList *list, int &rankList, std::set<CBot::CBotVar*>& previous)
+static void PutList(const std::string& baseName, bool bArray, CBot::CBotVar *var, Ui::CList *list, int &rankList, std::set<CBot::CBotVar*>& previous)
 {
     if ( var == nullptr && !baseName.empty() )
     {
@@ -591,7 +591,7 @@ void CScript::UpdateList(Ui::CList* list)
 
 // Colorize a string literal with escape sequences also colored
 
-void HighlightString(Ui::CEdit* edit, const std::string& s, int start)
+static void HighlightString(Ui::CEdit* edit, const std::string& s, int start)
 {
     edit->SetFormat(start, start + 1, Gfx::FONT_HIGHLIGHT_STRING);
 
@@ -716,7 +716,7 @@ void CScript::ColorizeScript(Ui::CEdit* edit, int rangeStart, int rangeEnd)
 // Returns the index of the start of the token found, or -1.
 
 
-int SearchToken(char* script, const char* token)
+static int SearchToken(char* script, const char* token)
 {
     int     lScript, lToken, i, iFound;
     int     found[100];
@@ -741,7 +741,7 @@ int SearchToken(char* script, const char* token)
 
 // Removes a token in a script.
 
-void DeleteToken(char* script, int pos, int len)
+static void DeleteToken(char* script, int pos, int len)
 {
     while ( true )
     {
@@ -752,7 +752,7 @@ void DeleteToken(char* script, int pos, int len)
 
 // Inserts a token in a script.
 
-void InsertToken(char* script, int pos, const char* token)
+static void InsertToken(char* script, int pos, const char* token)
 {
     int     lScript, lToken, i;
 

--- a/src/script/scriptfunc.cpp
+++ b/src/script/scriptfunc.cpp
@@ -81,7 +81,7 @@ CBotTypResult CScriptFunctions::cClassOneFloat(CBotVar* thisclass, CBotVar* &var
 
 // Compile a parameter of type "point".
 
-CBotTypResult cPoint(CBotVar* &var, void* user)
+static CBotTypResult cPoint(CBotVar* &var, void* user)
 {
     if ( var == nullptr )  return CBotTypResult(CBotErrLowParam);
 
@@ -120,22 +120,9 @@ CBotTypResult CScriptFunctions::cOnePoint(CBotVar* &var, void* user)
     return CBotTypResult(CBotTypFloat);
 }
 
-// Seeking value in an array of integers.
-
-bool FindList(CBotVar* array, int type)
-{
-    while ( array != nullptr )
-    {
-        if ( type == array->GetValInt() )  return true;
-        array = array->GetNext();
-    }
-    return false;
-}
-
-
 // Gives a parameter of type "point".
 
-bool GetPoint(CBotVar* &var, int& exception, Math::Vector& pos)
+static bool GetPoint(CBotVar* &var, int& exception, Math::Vector& pos)
 {
     CBotVar     *pX, *pY, *pZ;
 
@@ -702,7 +689,7 @@ bool CScriptFunctions::rDelete(CBotVar* var, CBotVar* result, int& exception, vo
     return false;
 }
 
-CBotTypResult compileSearch(CBotVar* &var, void* user, CBotTypResult returnValue)
+static CBotTypResult compileSearch(CBotVar* &var, void* user, CBotTypResult returnValue)
 {
     if ( var == nullptr )  return CBotTypResult(CBotErrLowParam);
     if ( var->GetType() == CBotTypArrayPointer )
@@ -746,7 +733,7 @@ CBotTypResult CScriptFunctions::cSearchAll(CBotVar* &var, void* user)
     return compileSearch(var, user, CBotTypResult(CBotTypArrayPointer, CBotTypResult(CBotTypPointer, "object")));
 }
 
-bool runSearch(CBotVar* var, Math::Vector pos, int& exception, std::function<bool(std::vector<ObjectType>, Math::Vector, float, float, bool, RadarFilter)> code)
+static bool runSearch(CBotVar* var, Math::Vector pos, int& exception, std::function<bool(std::vector<ObjectType>, Math::Vector, float, float, bool, RadarFilter)> code)
 {
     CBotVar*    array;
     RadarFilter filter;
@@ -865,7 +852,7 @@ bool CScriptFunctions::rSearchAll(CBotVar* var, CBotVar* result, int& exception,
 }
 
 
-CBotTypResult compileRadar(CBotVar* &var, void* user, CBotTypResult returnValue)
+static CBotTypResult compileRadar(CBotVar* &var, void* user, CBotTypResult returnValue)
 {
     CBotVar*    array;
 
@@ -912,7 +899,7 @@ CBotTypResult CScriptFunctions::cRadar(CBotVar* &var, void* user)
     return compileRadar(var, user, CBotTypResult(CBotTypPointer, "object"));
 }
 
-bool runRadar(CBotVar* var, std::function<bool(std::vector<ObjectType>, float, float, float, float, bool, RadarFilter)> code)
+static bool runRadar(CBotVar* var, std::function<bool(std::vector<ObjectType>, float, float, float, float, bool, RadarFilter)> code)
 {
     CBotVar*    array;
     RadarFilter filter;

--- a/src/tools/convert_model.cpp
+++ b/src/tools/convert_model.cpp
@@ -29,15 +29,8 @@
 
 using namespace Gfx;
 
-
-bool EndsWith(std::string const &fullString, std::string const &ending)
+namespace
 {
-    if (fullString.length() >= ending.length())
-        return (0 == fullString.compare (fullString.length() - ending.length(), ending.length(), ending));
-    else
-        return false;
-}
-
 
 struct Args
 {
@@ -217,6 +210,8 @@ void DumpInfo(const CModel& model)
     std::cerr << " variable tex2: " << variableTexs2 << " / " << total << std::endl;
     std::cerr << std::endl;
 }
+
+} // namespace
 
 int main(int argc, char *argv[])
 {

--- a/src/ui/controls/edit.cpp
+++ b/src/ui/controls/edit.cpp
@@ -46,7 +46,8 @@
 
 namespace Ui
 {
-
+namespace
+{
 const float MARGX           = (3.75f/640.0f);
 const float MARGY           = (3.75f/480.0f);
 const float MARGYS          = (2.75f/480.0f);
@@ -95,6 +96,8 @@ bool IsDelimiter(char c)
 {
     return IsSpace( c ) || IsBreaker( c );
 }
+
+} // namespace
 
 //! Object's constructor.
 CEdit::CEdit()
@@ -1156,7 +1159,7 @@ void CEdit::Draw()
 
 // Draw an image part.
 
-std::string PrepareImageFilename(std::string name)
+static std::string PrepareImageFilename(std::string name)
 {
     std::string filename;
     filename = name + ".png";
@@ -1398,7 +1401,7 @@ int CEdit::GetTextLength()
 // Returns a name in a command.
 // \x nom1 nom2 nom3;
 
-std::string GetNameParam(std::string cmd, int rank)
+static std::string GetNameParam(std::string cmd, int rank)
 {
     std::vector<std::string> results;
     boost::split(results, cmd, boost::is_any_of(" ;"));
@@ -1414,7 +1417,7 @@ std::string GetNameParam(std::string cmd, int rank)
 // Returns a number of a command.
 // \x nom n1 n2;
 
-int GetValueParam(std::string cmd, int rank)
+static int GetValueParam(std::string cmd, int rank)
 {
     std::vector<std::string> results;
     boost::split(results, cmd, boost::is_any_of(" ;"));

--- a/src/ui/mainui.cpp
+++ b/src/ui/mainui.cpp
@@ -416,7 +416,7 @@ void CMainUserInterface::GlintMove()
 
 // Returns the position for a sound.
 
-Math::Vector SoundPos(Math::Point pos)
+static Math::Vector SoundPos(Math::Point pos)
 {
     Math::Vector    s;
 
@@ -429,7 +429,7 @@ Math::Vector SoundPos(Math::Point pos)
 
 // Returns a random position for a sound.
 
-Math::Vector SoundRand()
+static Math::Vector SoundRand()
 {
     Math::Vector    s;
 

--- a/src/ui/screen/screen_apperance.cpp
+++ b/src/ui/screen/screen_apperance.cpp
@@ -457,7 +457,7 @@ float CScreenApperance::GetPersoAngle()
 
 // Tests whether two colors are equal or nearly are.
 
-bool EqColor(const Gfx::Color &c1, const Gfx::Color &c2)
+static bool EqColor(const Gfx::Color &c1, const Gfx::Color &c2)
 {
     return (fabs(c1.r-c2.r) < 0.01f &&
             fabs(c1.g-c2.g) < 0.01f &&

--- a/src/ui/screen/screen_io.cpp
+++ b/src/ui/screen/screen_io.cpp
@@ -193,7 +193,7 @@ void CScreenIO::IODeleteScene()
 }
 
 // clears filename only to leave letter or numbers
-std::string clearName(std::string name)
+static std::string clearName(std::string name)
 {
     std::string ret;
     for (int i = 0; i < static_cast<int>(name.size()); i++)

--- a/src/ui/screen/screen_setup_display.cpp
+++ b/src/ui/screen/screen_setup_display.cpp
@@ -161,12 +161,12 @@ bool CScreenSetupDisplay::EventProcess(const Event &event)
 
 // Updates the list of modes.
 
-int GCD(int a, int b)
+static int GCD(int a, int b)
 {
     return (b == 0) ? a : GCD(b, a%b);
 }
 
-Math::IntPoint AspectRatio(Math::IntPoint resolution)
+static Math::IntPoint AspectRatio(Math::IntPoint resolution)
 {
     int gcd = GCD(resolution.x, resolution.y);
     return Math::IntPoint(static_cast<float>(resolution.x) / gcd, static_cast<float>(resolution.y) / gcd);

--- a/src/ui/studio.cpp
+++ b/src/ui/studio.cpp
@@ -312,7 +312,7 @@ bool CStudio::EventProcess(const Event &event)
 
 // Evolves value with time elapsed.
 
-float Evolution(float final, float actual, float time)
+static float Evolution(float final, float actual, float time)
 {
     float   value;
 
@@ -425,7 +425,7 @@ bool CStudio::EventFrame(const Event &event)
 
 // Indicates whether a character is part of a word.
 
-bool IsToken(char c)
+static bool IsToken(char c)
 {
     return ( isalnum(c) || c == '_' );
 }

--- a/test/cbot/console.cpp
+++ b/test/cbot/console.cpp
@@ -26,6 +26,9 @@
 
 using namespace CBot;
 
+namespace
+{
+
 CBotTypResult cMessage(CBotVar* &var, void* user)
 {
     if ( var == nullptr )  return CBotTypResult(CBotErrLowParam);
@@ -45,6 +48,8 @@ bool rMessage(CBotVar* var, CBotVar* result, int& exception, void* user)
 
     return true;
 }
+
+} // namespace
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
-Wmissing-declarations enforces that every function (except for static
functions) must be declared separately before it's defined. This
essentially enforces that every function must be either static, or
declared in a header elsewhere.

This helps the optimizer, as it can do a better job of inlining if it
knows that a function won't be used outside of a given file. It also
helps -Wunused-function (which is enabled by -Wall) find more unused
functions.

Note that Clang spells this option -Wmissing-prototypes, which
confusingly is the name of a related but different warning option under
GCC.