### PR TITLE
Fix global sounds being positioned at camera

### DIFF
--- a/src/sound/oalsound/alsound.cpp
+++ b/src/sound/oalsound/alsound.cpp
@@ -314,10 +314,15 @@ bool CALSound::SearchFreeBuffer(SoundType sound, int &channel, bool &alreadyLoad
 
 int CALSound::Play(SoundType sound, float amplitude, float frequency, bool loop)
 {
-    return Play(sound, m_eye, amplitude, frequency, loop);
+    return Play(sound, Math::Vector{}, true, amplitude, frequency, loop);
 }
 
 int CALSound::Play(SoundType sound, const Math::Vector &pos, float amplitude, float frequency, bool loop)
+{
+    return Play(sound, pos, false, amplitude, frequency, loop);
+}
+
+int CALSound::Play(SoundType sound, const Math::Vector &pos, bool relativeToListener, float amplitude, float frequency, bool loop)
 {
     if (!m_enabled)
     {
@@ -347,7 +352,7 @@ int CALSound::Play(SoundType sound, const Math::Vector &pos, float amplitude, fl
 
     CChannel* chn = m_channels[channel].get();
 
-    chn->SetPosition(pos);
+    chn->SetPosition(pos, relativeToListener);
     chn->SetVolumeAtrib(1.0f);
 
     // setting initial values

--- a/src/sound/oalsound/alsound.h
+++ b/src/sound/oalsound/alsound.h
@@ -116,6 +116,7 @@ public:
 
 private:
     void CleanUp();
+    int Play(SoundType sound, const Math::Vector &pos, bool relativeToListener, float amplitude, float frequency, bool loop);
     int GetPriority(SoundType);
     bool SearchFreeBuffer(SoundType sound, int &channel, bool &alreadyLoaded);
     bool CheckChannel(int &channel);

--- a/src/sound/oalsound/channel.cpp
+++ b/src/sound/oalsound/channel.cpp
@@ -94,7 +94,7 @@ bool CChannel::Pause()
     return true;
 }
 
-bool CChannel::SetPosition(const Math::Vector &pos)
+bool CChannel::SetPosition(const Math::Vector &pos, bool relativeToListener)
 {
     if (!m_ready || m_buffer == nullptr)
     {
@@ -102,6 +102,7 @@ bool CChannel::SetPosition(const Math::Vector &pos)
     }
 
     alSource3f(m_source, AL_POSITION, pos.x, pos.y, pos.z);
+    alSourcei(m_source, AL_SOURCE_RELATIVE, relativeToListener);
     if (CheckOpenALError())
     {
         GetLogger()->Debug("Could not set sound position. Code: %d\n", GetOpenALErrorCode());

--- a/src/sound/oalsound/channel.h
+++ b/src/sound/oalsound/channel.h
@@ -59,7 +59,7 @@ public:
     bool Pause();
     bool Stop();
 
-    bool SetPosition(const Math::Vector &pos);
+    bool SetPosition(const Math::Vector &pos, bool relativeToListener = false);
 
     bool SetFrequency(float freq);
     float GetFrequency();


### PR DESCRIPTION
Certain sounds - such as those coming from the UI - aren't supposed to
sound as if they're coming from a given position. This is currently
accomplished by positioning the OpenAL source at the camera position.
This works, but if the camera position drastically moves during the
sound being played then it's possible to hear the sound fade out.

This pull request makes camera movement no longer affect global sounds,
by specifying their position as being (0, 0, 0) relative to the listener
position.

The easiest way to test this is to start a mission, press E to grab when
there's nothing in front of you, and scroll the mouse wheel quickly.
Pressing E will show the nothing-to-grab message which plays a beep
sound, and scrolling will quickly move the camera. Prior to this pull
request, the sound will fade, after this pull request it won't.

Fixes #1087.