### PR TITLE
 Improve object visibility culling with tighter bounding spheres

### DIFF
--- a/src/graphics/engine/engine.h
+++ b/src/graphics/engine/engine.h
@@ -246,8 +246,8 @@ struct EngineBaseObject
     Math::Vector           bboxMin;
     //! bounding box max (origin 0,0,0 always included)
     Math::Vector           bboxMax;
-    //! Radius of the sphere at the origin
-    float                  radius = 0.0f;
+    //! A bounding sphere that contains all the vertices in this EngineBaseObject
+    Math::Sphere           boundingSphere;
     //! Next tier (Tex)
     std::vector<EngineBaseObjTexTier> next;
 

--- a/src/math/sphere.h
+++ b/src/math/sphere.h
@@ -44,4 +44,11 @@ inline float DistanceBetweenSpheres(const Sphere& sphere1, const Sphere& sphere2
     return Math::Distance(sphere1.pos, sphere2.pos) - sphere1.radius - sphere2.radius;
 }
 
+inline Sphere BoundingSphereForBox(Vector mins, Vector maxs)
+{
+    auto centroid = (maxs + mins) / 2.0f;
+    auto halfExtent = (maxs - centroid);
+    return Sphere{centroid, halfExtent.Length()};
+}
+
 } // namespace Math


### PR DESCRIPTION
This pull request improves rendering performance by doing a better job of
checking whether an object is visible via its bounding sphere or not.

The engine maintains a bounding box for each EngineBaseObject that's
exactly large enough to fit every vertex. From this, it computes a
bounding sphere, and only draws objects if the sphere is within the view
frustum. Previously, the bounding sphere was always centered on the
EngineBaseObject's origin, even for models where the bounding box center
is significantly offset from the origin. Now, the bounding sphere is
always the tightest sphere which fits the bounding box.

Here are some debug rendering pictures I created. In all of these, the red sphere is the bounding sphere that was previous used for visibility culling, and the green sphere is the sphere that this pull request uses instead.

![screenshot from 2018-04-29 14-54-16](https://user-images.githubusercontent.com/908758/39409073-71465044-4bd8-11e8-8692-08b8d35cb9cf.png)

![screenshot from 2018-04-29 14-50-46](https://user-images.githubusercontent.com/908758/39409080-9e61d06c-4bd8-11e8-98de-74d8c4f7b9a7.png)

![screenshot from 2018-04-29 14-52-44](https://user-images.githubusercontent.com/908758/39409075-82211566-4bd8-11e8-8f55-5776c5752bcf.png)

![screenshot from 2018-04-29 14-49-42](https://user-images.githubusercontent.com/908758/39409085-b6a1ec2a-4bd8-11e8-9f94-545da592a0fc.png)

![screenshot from 2018-04-29 14-43-43](https://user-images.githubusercontent.com/908758/39409090-ce4ea11a-4bd8-11e8-92ec-15856a85f5d7.png)
