### PR TITLE
Add generic debug rendering functions

### DIFF
--- a/src/graphics/engine/engine.cpp
+++ b/src/graphics/engine/engine.cpp
@@ -3639,7 +3639,8 @@ void CEngine::RenderDebugSphere(const Math::Sphere& sphere, const Math::Matrix& 
     static constexpr int NUM_LINE_STRIPS = 2 + LONGITUDE_DIVISIONS + LATITUDE_DIVISIONS;
     static constexpr int VERTS_IN_LINE_STRIP = 32;
 
-    static std::array<Math::Vector, NUM_LINE_STRIPS * VERTS_IN_LINE_STRIP> verticesTemplate = []{
+    static std::array<Math::Vector, NUM_LINE_STRIPS * VERTS_IN_LINE_STRIP> verticesTemplate = []
+    {
         std::array<Math::Vector, NUM_LINE_STRIPS * VERTS_IN_LINE_STRIP> vertices;
 
         auto SpherePoint = [&](float latitude, float longitude)

--- a/src/graphics/engine/engine.h
+++ b/src/graphics/engine/engine.h
@@ -1406,7 +1406,7 @@ protected:
 
     Texture         m_shadowMap;
 
-    struct
+    struct PendingDebugDraw
     {
         std::vector<VertexCol> vertices;
         std::vector<int> firsts;

--- a/src/graphics/engine/engine.h
+++ b/src/graphics/engine/engine.h
@@ -1161,8 +1161,8 @@ public:
     //! Updates the scene after a change of parameters
     void            ApplyChange();
 
-    void            ClearDisplayCrashSpheres();
-    void            AddDisplayCrashSpheres(const std::vector<Math::Sphere>& crashSpheres);
+    void            RenderDebugSphere(const Math::Sphere&, const Math::Matrix& transform = Math::Matrix{}, const Color& = Color{0.0f, 0.0f, 1.0f, 1.0f});
+    void            RenderDebugBox(const Math::Vector& mins, const Math::Vector& maxs, const Math::Matrix& transform = Math::Matrix{}, const Color& = Color{0.0f, 0.0f, 1.0f, 1.0f});
 
     void            SetDebugLights(bool debugLights);
     bool            GetDebugLights();
@@ -1228,7 +1228,7 @@ protected:
     void        DrawStats();
     //! Draw mission timer
     void        DrawTimer();
-    void        DrawCrashSpheres();
+    void        RenderPendingDebugDraws();
 
     //! Creates a new tier 2 object (texture)
     EngineBaseObjTexTier&  AddLevel2(EngineBaseObject& p1, const std::string& tex1Name, const std::string& tex2Name);
@@ -1406,6 +1406,13 @@ protected:
 
     Texture         m_shadowMap;
 
+    struct
+    {
+        std::vector<VertexCol> vertices;
+        std::vector<int> firsts;
+        std::vector<int> counts;
+    } m_pendingDebugDraws;
+
     //! Ranks of highlighted objects
     int             m_highlightRank[100];
     //! Highlight visible?
@@ -1479,7 +1486,6 @@ protected:
 
     std::unordered_map<std::string, int> m_staticMeshBaseObjects;
 
-    std::vector<Math::Sphere> m_displayCrashSpheres;
     std::vector<std::vector<VertexCol>> m_displayGoto;
     std::unique_ptr<CImage> m_displayGotoImage;
 

--- a/src/graphics/engine/engine.h
+++ b/src/graphics/engine/engine.h
@@ -1411,7 +1411,8 @@ protected:
         std::vector<VertexCol> vertices;
         std::vector<int> firsts;
         std::vector<int> counts;
-    } m_pendingDebugDraws;
+    }
+    m_pendingDebugDraws;
 
     //! Ranks of highlighted objects
     int             m_highlightRank[100];

--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -5949,18 +5949,14 @@ void CRobotMain::SetCodeBattleSpectatorMode(bool mode)
 
 void CRobotMain::UpdateDebugCrashSpheres()
 {
-    m_engine->ClearDisplayCrashSpheres();
     if (m_debugCrashSpheres)
     {
         for (CObject* obj : m_objMan->GetAllObjects())
         {
-            auto crashSpheres = obj->GetAllCrashSpheres();
-            std::vector<Math::Sphere> displaySpheres;
-            for (const auto& crashSphere : crashSpheres)
+            for (const auto& crashSphere : obj->GetAllCrashSpheres())
             {
-                displaySpheres.push_back(crashSphere.sphere);
+                m_engine->RenderDebugSphere(crashSphere.sphere, Math::Matrix{}, Gfx::Color{0.0f, 0.0f, 1.0f, 1.0f});
             }
-            m_engine->AddDisplayCrashSpheres(displaySpheres);
         }
     }
 }


### PR DESCRIPTION
Currently the engine can draw debug spheres to show crash sphere
positions. This extends this to draw arbitrary spheres and cuboids,
transformed arbitrarily. With these in place it's now very quick and
easy to create a debug visualisation - for example, it's a one-line code
change to render the bounding box or sphere of every EngineObject.