### PR TITLE
Fix saving/loading "NewScript" programs for factory bots

### DIFF
--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -3633,7 +3633,7 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
 
             if (line->GetCommand() == "NewScript" && !resetObject)
             {
-                m_newScriptName.push_back(NewScriptName(line->GetParam("type")->AsObjectType(OBJECT_NULL), const_cast<char*>(line->GetParam("name")->AsPath("ai").c_str())));
+                m_newScriptName.push_back(NewScriptName(line->GetParam("type")->AsObjectType(OBJECT_NULL), line->GetParam("name")->AsString("")));
                 continue;
             }
 

--- a/src/object/auto/autofactory.cpp
+++ b/src/object/auto/autofactory.cpp
@@ -667,7 +667,7 @@ bool CAutoFactory::CreateVehicle()
         for (const std::string& name : m_main->GetNewScriptNames(m_type))
         {
             Program* prog = programStorage->AddProgram();
-            programStorage->ReadProgram(prog, InjectLevelPathsForCurrentLevel(name));
+            programStorage->ReadProgram(prog, InjectLevelPathsForCurrentLevel(name, "ai"));
             prog->readOnly = true;
             prog->filename = name;
         }


### PR DESCRIPTION
Fixes #797, Tested with Mission 6-3.

Existing saved games affected by #797 remain broken,
but can be fixed by editing ```data.sav``` file.