### PR TITLE
Improve shadow quality and performance in gl33

### DIFF
--- a/src/graphics/opengl/shaders/gl33/fs_normal.glsl
+++ b/src/graphics/opengl/shaders/gl33/fs_normal.glsl
@@ -96,19 +96,15 @@ void main()
 
         if (uni_ShadowTextureEnabled)
         {
+            float value = texture(uni_ShadowTexture, data.ShadowCoord.xyz);
 #ifdef CONFIG_QUALITY_SHADOWS
-            float offset = 0.00025f;
-
-            float value = (1.0f / 5.0f) * (texture(uni_ShadowTexture, data.ShadowCoord.xyz)
-                    + texture(uni_ShadowTexture, data.ShadowCoord.xyz + vec3( offset,    0.0f, 0.0f))
-                    + texture(uni_ShadowTexture, data.ShadowCoord.xyz + vec3(-offset,    0.0f, 0.0f))
-                    + texture(uni_ShadowTexture, data.ShadowCoord.xyz + vec3(   0.0f,  offset, 0.0f))
-                    + texture(uni_ShadowTexture, data.ShadowCoord.xyz + vec3(   0.0f, -offset, 0.0f)));
-
-            shadow = mix(uni_ShadowColor, 1.0f, value);
-#else
-            shadow = mix(uni_ShadowColor, 1.0f, texture(uni_ShadowTexture, data.ShadowCoord.xyz));
+            value += textureOffset(uni_ShadowTexture, data.ShadowCoord.xyz, ivec2( 1, 0))
+                   + textureOffset(uni_ShadowTexture, data.ShadowCoord.xyz, ivec2(-1, 0))
+                   + textureOffset(uni_ShadowTexture, data.ShadowCoord.xyz, ivec2( 0, 1))
+                   + textureOffset(uni_ShadowTexture, data.ShadowCoord.xyz, ivec2( 0,-1));
+            value = value * (1.0f / 5.0f);
 #endif
+            shadow = mix(uni_ShadowColor, 1.0f, value);
         }
 
         vec4 result = uni_AmbientColor * ambient


### PR DESCRIPTION
If `CONFIG_QUALITY_SHADOWS` is defined (which it always is) then the
fragment shader code that samples the shadow map will take five samples
in a cross shape around the point to be sampled, to apply antialiasing.

Currently, the offset of these samples is hardcoded to 0.00025× the
shadow map resolution. This is very inconsistent: if the shadow map
resolution is 128×128, then these samples are 0.032 texels apart, which
is a waste of four texture samples, and essentially means that no
antialiasing is applied. If the shadow map resolution is 8192×8192, then
these samples are 2.048 texels apart, which causes visual artefacts
around shadow edges, instead of giving smoother shadows.

The correct thing to do is to always sample exactly one texel away from
the original position. This is easy in GLSL 3.30, as it includes a
textureOffset function which offsets a texture fetch by an exact number
of texels. This is faster than manually calculating an offset ourselves,
it fixes visual artefacts at high resolutions, and it properly applies
antialiasing at low resolutions.

Here's some comparison pictures.

-----

**Before, 128x128:** Shadows are very obviously blocky and pixellated.
![image](https://user-images.githubusercontent.com/908758/39535000-baf7883a-4e2a-11e8-8d12-5d0e4cd45062.png)

**After, 128x128:** Shadows are antialiased, which covers up the pixellation due to low resolution.
![image](https://user-images.githubusercontent.com/908758/39535051-dc32f552-4e2a-11e8-83bf-9573c96d8e76.png)

-----

**Before, 8192x8192:** Shadows have a strange pixellated penumbra band.
![image](https://user-images.githubusercontent.com/908758/39535190-3538ae08-4e2b-11e8-9d24-96e941d65d1b.png)

**After, 8192x8192:** Shadows are properly antialised and look quite slick.
![image](https://user-images.githubusercontent.com/908758/39535238-506527d8-4e2b-11e8-9823-fbd8b8087286.png)

