### PR TITLE
Don't create a color renderbuffer for shadow map

### DIFF
--- a/src/graphics/core/framebuffer.h
+++ b/src/graphics/core/framebuffer.h
@@ -41,10 +41,15 @@ struct FramebufferParams
     int depth = 16;
     //! Requested number of samples for multisampling
     int samples = 1;
-    //! true requests color texture
-    bool colorTexture = false;
-    //! true requests depth texture
-    bool depthTexture = false;
+
+    enum class AttachmentType
+    {
+        Texture,
+        Renderbuffer,
+        None,
+    };
+    AttachmentType colorAttachment = AttachmentType::Renderbuffer;
+    AttachmentType depthAttachment = AttachmentType::Renderbuffer;
 
     //! Loads default values
     void LoadDefault()

--- a/src/graphics/engine/engine.cpp
+++ b/src/graphics/engine/engine.cpp
@@ -3786,7 +3786,8 @@ void CEngine::RenderShadowMap()
             FramebufferParams params;
             params.width = params.height = width;
             params.depth = depth = 32;
-            params.depthTexture = true;
+            params.colorAttachment = FramebufferParams::AttachmentType::None;
+            params.depthAttachment = FramebufferParams::AttachmentType::Texture;
 
             CFramebuffer *framebuffer = m_device->CreateFramebuffer("shadow", params);
             if (framebuffer == nullptr)

--- a/src/graphics/opengl/glframebuffer.cpp
+++ b/src/graphics/opengl/glframebuffer.cpp
@@ -55,7 +55,7 @@ bool CGLFramebuffer::Create()
     glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
 
     // create color texture
-    if (m_params.colorTexture)
+    if (m_params.colorAttachment == FramebufferParams::AttachmentType::Texture)
     {
         GLint previous;
         glGetIntegerv(GL_TEXTURE_BINDING_2D, &previous);
@@ -76,7 +76,7 @@ bool CGLFramebuffer::Create()
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_colorTexture, 0);
     }
     // create color renderbuffer
-    else
+    else if (m_params.colorAttachment == FramebufferParams::AttachmentType::Renderbuffer)
     {
         glGenRenderbuffers(1, &m_colorRenderbuffer);
         glBindRenderbuffer(GL_RENDERBUFFER, m_colorRenderbuffer);
@@ -92,6 +92,10 @@ bool CGLFramebuffer::Create()
         glFramebufferRenderbuffer(GL_FRAMEBUFFER,
                 GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_colorRenderbuffer);
     }
+    else
+    {
+        glDrawBuffer(GL_NONE);
+    }
 
     GLuint depthFormat = 0;
 
@@ -104,7 +108,7 @@ bool CGLFramebuffer::Create()
     }
 
     // create depth texture
-    if (m_params.depthTexture)
+    if (m_params.depthAttachment == FramebufferParams::AttachmentType::Texture)
     {
         GLint previous;
         glGetIntegerv(GL_TEXTURE_BINDING_2D, &previous);
@@ -132,7 +136,7 @@ bool CGLFramebuffer::Create()
                 GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, m_depthTexture, 0);
     }
     // create depth renderbuffer
-    else
+    else if (m_params.depthAttachment == FramebufferParams::AttachmentType::Renderbuffer)
     {
         glGenRenderbuffers(1, &m_depthRenderbuffer);
         glBindRenderbuffer(GL_RENDERBUFFER, m_depthRenderbuffer);
@@ -323,7 +327,7 @@ bool CGLFramebufferEXT::Create()
     glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, m_fbo);
 
     // create color texture
-    if (m_params.colorTexture)
+    if (m_params.colorAttachment == FramebufferParams::AttachmentType::Texture)
     {
         GLint previous;
         glGetIntegerv(GL_TEXTURE_BINDING_2D, &previous);
@@ -346,7 +350,7 @@ bool CGLFramebufferEXT::Create()
                 GL_COLOR_ATTACHMENT0_EXT, GL_TEXTURE_2D, m_colorTexture, 0);
     }
     // create color renderbuffer
-    else
+    else if (m_params.colorAttachment == FramebufferParams::AttachmentType::Renderbuffer)
     {
         glGenRenderbuffersEXT(1, &m_colorRenderbuffer);
         glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, m_colorRenderbuffer);
@@ -363,6 +367,10 @@ bool CGLFramebufferEXT::Create()
         glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT,
                 GL_COLOR_ATTACHMENT0_EXT, GL_RENDERBUFFER_EXT, m_colorRenderbuffer);
     }
+    else
+    {
+        glDrawBuffer(GL_NONE);
+    }
 
     GLuint depthFormat = 0;
 
@@ -375,7 +383,7 @@ bool CGLFramebufferEXT::Create()
     }
 
     // create depth texture
-    if (m_params.depthTexture)
+    if (m_params.depthAttachment == FramebufferParams::AttachmentType::Texture)
     {
         GLint previous;
         glGetIntegerv(GL_TEXTURE_BINDING_2D, &previous);
@@ -403,7 +411,7 @@ bool CGLFramebufferEXT::Create()
                 GL_DEPTH_ATTACHMENT_EXT, GL_TEXTURE_2D, m_depthTexture, 0);
     }
     // create depth renderbuffer
-    else
+    else if (m_params.depthAttachment == FramebufferParams::AttachmentType::Renderbuffer)
     {
         glGenRenderbuffersEXT(1, &m_depthRenderbuffer);
         glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, m_depthRenderbuffer);


### PR DESCRIPTION
When rendering the shadow map offscreen using framebuffer objects, it's
not necessary to create a color renderbuffer. Currently
FramebufferParams only lets you choose between a renderbuffer and a
texture for both color and depth attachments. This changes that, and now
you can ask for a texture, a renderbuffer, or nothing.

This improves performance. On my computer, with an 8192x8192 shadow map,
this improves overall frame time by 8.0%.