### PR TITLE
Fix another GCC 8.2.0 warning

### DIFF
--- a/src/graphics/model/model_io_structs.h
+++ b/src/graphics/model/model_io_structs.h
@@ -188,7 +188,7 @@ struct OldModelTriangleV1
     Vertex p2;
     Vertex p3;
     Material material;
-    char texName[20] = {};
+    char texName[21] = {'\0'};
     float min = 0;
     float max = 0;
 };
@@ -207,7 +207,7 @@ struct OldModelTriangleV2
     Vertex p2;
     Vertex p3;
     Material material;
-    char texName[20] = {};
+    char texName[21] = {'\0'};
     float min = 0.0f;
     float max = 0.0f;
     long state = 0;
@@ -231,7 +231,7 @@ struct OldModelTriangleV3
     VertexTex2 p2;
     VertexTex2 p3;
     Material   material;
-    char texName[20] = {};
+    char texName[21] = {'\0'};
     float min = 0.0f;
     float max = 0.0f;
     long state = 0;


### PR DESCRIPTION
Fixes #1195 and #1180 
Since the code is marked as deprecated I tried to change as little as possible.

What changed:
- Texture name buffers are now size 21 instead of 20 to prevent a possible lack of null character.
- Buffers are now initialized to a null character.
- All `strcpy` behaviour was left unchanged. They still copy 20 characters, therefore the 21st one is guaranteed to be always null.

Are there any tests I can run locally to make sure I didn't break anything (the game itself runs)? It's hard to find information about that.