### PR TITLE
Add an appdata XML for Linux packaging (#1204)

### DIFF
--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -70,6 +70,12 @@ if(PLATFORM_GNU)
             DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications/
         )
 
+    # Install appdata
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/info.colobot.Colobot.appdata.xml
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/share/metainfo/
+        )
+
     # Install Icon
     install(
         FILES ${COLOBOT_ICON_FILE}

--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -72,7 +72,7 @@ if(PLATFORM_GNU)
 
     # Install appdata
     install(
-        FILES ${CMAKE_CURRENT_BINARY_DIR}/info.colobot.Colobot.appdata.xml
+        FILES info.colobot.Colobot.appdata.xml
             DESTINATION ${CMAKE_INSTALL_PREFIX}/share/metainfo/
         )
 

--- a/desktop/info.colobot.Colobot.appdata.xml
+++ b/desktop/info.colobot.Colobot.appdata.xml
@@ -22,8 +22,9 @@
   </screenshots>
 
   <url type="homepage">https://colobot.info/</url>
-  <url type="help">http://colobot.info/forum/</url>
   <url type="bugtracker">https://github.com/colobot/colobot/issues</url>
+  <url type="help">http://colobot.info/forum/</url>
+  <url type="donation">https://colobot.info/donate/</url>
 
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">moderate</content_attribute>

--- a/desktop/info.colobot.Colobot.appdata.xml
+++ b/desktop/info.colobot.Colobot.appdata.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component>
+  <id>info.colobot.Colobot</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <developer_name>TerranovaTeam</developer_name>
+  <update_contact>contact@colobot.info</update_contact>
+  <name>Colobot</name>
+  <summary>Colonize with bots</summary>
+
+  <description>
+    <p>Colobot (Colonize with Bots) is an educational game aiming to teach programming through entertainment. You are playing as an astronaut on a journey with robot helpers to find a planet for colonization. It features 3D real-time graphics and a C++ and Java-like, object-oriented language, CBOT, which can be used to program the robots available in the game.</p>
+  </description>
+
+  <launchable type="desktop-id">colobot.desktop</launchable>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>Alpha 0.1.5</caption>
+      <image type="source" height="600" width="800">https://colobot.info/wordpress/wp-content/uploads/alpha-0.1.5.png</image>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">https://colobot.info/</url>
+  <url type="help">http://colobot.info/forum/</url>
+  <url type="bugtracker">https://github.com/colobot/colobot/issues</url>
+
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">moderate</content_attribute>
+    <content_attribute id="violence-fantasy">moderate</content_attribute>
+    <content_attribute id="violence-bloodshed">mild</content_attribute>
+  </content_rating>
+
+  <releases>
+    <release date="2018-04-10" version="0.1.11.1"/>
+  </releases>
+</component>


### PR DESCRIPTION
This is just an example for how the required appdata XML could be built, and OARS and additional information might need cleaning up.

The releases can either be handled manually by adding release objects for every release, or just made to track the latest one by generating the file with CMake and using the current date or the tag date if the build is on a release tag.