### PR TITLE
Fixes for #1203 and #1194

### DIFF
--- a/src/graphics/engine/engine.cpp
+++ b/src/graphics/engine/engine.cpp
@@ -4048,7 +4048,9 @@ void CEngine::UseMSAA(bool enable)
                 }
             }
 
-            framebuffer->Bind();
+            if (framebuffer != nullptr) {
+                framebuffer->Bind();
+            }
 
             m_device->SetRenderState(RENDER_STATE_DEPTH_TEST, true);
             m_device->SetRenderState(RENDER_STATE_DEPTH_WRITE, true);

--- a/src/object/old_object.cpp
+++ b/src/object/old_object.cpp
@@ -284,13 +284,19 @@ void COldObject::DeleteObject(bool bAll)
         if (m_power != nullptr)
         {
             if (m_power->Implements(ObjectInterfaceType::Old))
+            {
+                dynamic_cast<COldObject*>(m_power)->SetTransporter(nullptr);
                 dynamic_cast<COldObject*>(m_power)->DeleteObject(bAll);
+            }
             m_power = nullptr;
         }
         if (m_cargo != nullptr)
         {
             if (m_cargo->Implements(ObjectInterfaceType::Old))
+            {
+                dynamic_cast<COldObject*>(m_cargo)->SetTransporter(nullptr);
                 dynamic_cast<COldObject*>(m_cargo)->DeleteObject(bAll);
+            }
             m_cargo = nullptr;
         }
     }


### PR DESCRIPTION
Set `m_transporter` to `nullptr` before deletion to avoid SIGSEGV.