### PR TITLE
Replace sprintf() with snprinf() call in screen_io.cpp

### DIFF
--- a/src/ui/screen/screen_io.cpp
+++ b/src/ui/screen/screen_io.cpp
@@ -58,7 +58,7 @@ void CScreenIO::IOReadName()
     CEdit*      pe;
     std::string resume;
     char        line[100];
-    char        name[100];
+    char        name[256];
     time_t      now;
 
     pw = static_cast<CWindow*>(m_interface->SearchControl(EVENT_WINDOW5));
@@ -80,8 +80,8 @@ void CScreenIO::IOReadName()
     }
 
     time(&now);
-    strftime(line, 99, "%y.%m.%d %H:%M", localtime(&now));
-    sprintf(name, "%s - %s %d", line, resume.c_str(), m_main->GetLevelRank());
+    strftime(line, sizeof(line), "%y.%m.%d %H:%M", localtime(&now));
+    snprintf(name, sizeof(name), "%s - %s %d", line, resume.c_str(), m_main->GetLevelRank());
 
     pe->SetText(name);
     pe->SetCursor(strlen(name), 0);


### PR DESCRIPTION
This PR contains the following changes:

1) The magic number `99` in the `strftime()` call is changed to `sizeof(line)`. There is no `-1`, because, to quote the function's _man page_: 
> Provided that the result string, including the terminating  null  byte, does  not  exceed  max  bytes,  strftime()  returns the number of bytes (excluding the terminating null byte) placed in the array  s.   If  the length of the result string (including the terminating null byte) would exceed max bytes, then strftime() returns 0, and the  contents  of  the array are undefined.    

Which means that a successful call does not put more than `sizeof(line)` characters, including the null terminator, in `line`.

2) Changes the `sprintf()` call to `snprintf()` to guard against a buffer overflow.

3) Increases the `name` buffer size so it always has enough size to contain `$line -  `. Alternatively, this could be done by reducing the size of `line` - do we really need 100 bytes to hold the date string?