### PR TITLE
Add a minimum & maximum game speed limit

### DIFF
--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -60,6 +60,7 @@
 #include "level/parser/parser.h"
 
 #include "math/const.h"
+#include "math/func.h"
 #include "math/geometry.h"
 
 #include "object/object.h"
@@ -5362,18 +5363,10 @@ void CRobotMain::UpdateChapterPassed()
     return m_ui->UpdateChapterPassed();
 }
 
-
 //! Changes game speed
 void CRobotMain::SetSpeed(float speed)
 {
-    if(speed < MIN_SPEED) 
-    {
-        speed = MIN_SPEED;
-    }
-    else if(speed > MAX_SPEED)
-    {
-        speed = MAX_SPEED;
-    }
+    speed = Math::Clamp(speed, MIN_SPEED, MAX_SPEED);
 
     m_app->SetSimulationSpeed(speed);
     UpdateSpeedLabel();

--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -119,6 +119,10 @@
 const float UNIT = 4.0f;    // default for g_unit
 float   g_unit;             // conversion factor
 
+// Min/max values for the game speed.
+const float MIN_SPEED = 1/8.0f;
+const float MAX_SPEED = 256.0f;
+
 // Reference colors used when recoloring textures, see ChangeColor()
 const Gfx::Color COLOR_REF_BOT   = Gfx::Color( 10.0f/256.0f, 166.0f/256.0f, 254.0f/256.0f);  // blue
 const Gfx::Color COLOR_REF_ALIEN = Gfx::Color(135.0f/256.0f, 170.0f/256.0f,  13.0f/256.0f);  // green
@@ -5362,6 +5366,15 @@ void CRobotMain::UpdateChapterPassed()
 //! Changes game speed
 void CRobotMain::SetSpeed(float speed)
 {
+    if(speed < MIN_SPEED) 
+    {
+        speed = MIN_SPEED;
+    }
+    else if(speed > MAX_SPEED)
+    {
+        speed = MAX_SPEED;
+    }
+
     m_app->SetSimulationSpeed(speed);
     UpdateSpeedLabel();
 }


### PR DESCRIPTION
Currently it is possible to use the in-game keybinds to set the game speed to ludicrous values, like x65536. On my machine, the game crashes once x1048576 is reached.

This patch puts a minimum and maximum limit on what speed can the player set the game to.