### PR TITLE
Fix Linux savegame path issue, closes #1212

### DIFF
--- a/src/common/system/system_linux.cpp
+++ b/src/common/system/system_linux.cpp
@@ -99,7 +99,7 @@ std::string CSystemUtilsLinux::GetSaveDir()
     std::string savegameDir;
 
     // Determine savegame dir according to XDG Base Directory Specification
-    char *envXDG_DATA_HOME = getenv("XDG_CONFIG_DATA");
+    char *envXDG_DATA_HOME = getenv("XDG_DATA_HOME");
     if (envXDG_DATA_HOME == nullptr)
     {
         char *envHOME = getenv("HOME");


### PR DESCRIPTION
`XDG_CONFIG_DATA` seems to be a common mistake seeing how many results it returns on a google search, `XDG_DATA_HOME` is the correct XDG variable for the data directory.