### PR TITLE
Tweak strncpy() usage in ModelOutput::WriteOldModel

### DIFF
--- a/src/graphics/model/model_output.cpp
+++ b/src/graphics/model/model_output.cpp
@@ -328,7 +328,10 @@ void ModelOutput::WriteOldModel(const CModel& model, std::ostream &stream)
         t.material.ambient = triangle.ambient;
         t.material.diffuse = triangle.diffuse;
         t.material.specular = triangle.specular;
-        strncpy(t.texName, triangle.tex1Name.c_str(), 20);
+
+        strncpy(t.texName, triangle.tex1Name.c_str(), sizeof(t.texName)-1);
+        t.texName[sizeof(t.texName)-1] = '\0';
+
         t.min = 0.0f;
         t.max = 1000000.0f;
         t.state = ConvertToOldState(triangle);


### PR DESCRIPTION
The code in said function uses `strncpy(dest, src, size)`, with the `size` being equal to the destination buffer size. If the source buffer is larger than the dest buffer, the resulting string won't be properly NUL-terminated. This changeset fixes that.