### PR TITLE
Fix PORTABLE_SAVES flag not working

### DIFF
--- a/src/common/system/system.cpp
+++ b/src/common/system/system.cpp
@@ -20,8 +20,6 @@
 
 #include "common/system/system.h"
 
-#include "common/config.h"
-
 #include "common/make_unique.h"
 
 #if defined(PLATFORM_WINDOWS)

--- a/src/common/system/system.h
+++ b/src/common/system/system.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include "common/config.h"
+
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Right now the PORTABLE_SAVES flag doesn't do anything as it's set in file `src/common/config.h.cmake` which is included in `src/common/system.cpp` but not in `src/common/system.h` so it does not exist in `src/common/system_windows.h`, `_linux.h` etc.