### PR TITLE
Smooth shadows in gl21

### DIFF
--- a/src/graphics/opengl/gl21device.cpp
+++ b/src/graphics/opengl/gl21device.cpp
@@ -408,6 +408,7 @@ bool CGL21Device::Create()
         uni.fogColor = glGetUniformLocation(m_normalProgram, "uni_FogColor");
 
         uni.shadowColor = glGetUniformLocation(m_normalProgram, "uni_ShadowColor");
+        uni.shadowTexelSize = glGetUniformLocation(m_normalProgram, "uni_ShadowTexelSize");
         uni.lightCount = glGetUniformLocation(m_normalProgram, "uni_LightCount");
 
         uni.ambientColor = glGetUniformLocation(m_normalProgram, "uni_Material.ambient");
@@ -457,6 +458,7 @@ bool CGL21Device::Create()
         glUniform4f(uni.fogColor, 0.8f, 0.8f, 0.8f, 1.0f);
 
         glUniform1f(uni.shadowColor, 0.5f);
+        glUniform1f(uni.shadowTexelSize, 0.5f);
 
         glUniform1i(uni.lightCount, 0);
     }
@@ -1439,6 +1441,7 @@ void CGL21Device::SetRenderState(RenderState state, bool enabled)
     }
     else if (state == RENDER_STATE_SHADOW_MAPPING)
     {
+        glUniform1f(m_uniforms[m_mode].shadowTexelSize, 1.0/m_currentTextures[TEXTURE_SHADOW].size.x);
         SetTextureEnabled(TEXTURE_SHADOW, enabled);
 
         return;

--- a/src/graphics/opengl/glutil.h
+++ b/src/graphics/opengl/glutil.h
@@ -193,6 +193,8 @@ struct UniformLocations
 
     //! Shadow color
     GLint shadowColor = -1;
+    //! Shadow texel size
+    GLint shadowTexelSize = -1;
 
     // Number of enabled lights
     GLint lightCount = -1;

--- a/src/graphics/opengl/shaders/gl21/fs_normal.glsl
+++ b/src/graphics/opengl/shaders/gl21/fs_normal.glsl
@@ -35,6 +35,7 @@ uniform vec2 uni_FogRange;
 uniform vec4 uni_FogColor;
 
 uniform float uni_ShadowColor;
+uniform float uni_ShadowTexelSize;
 
 struct LightParams
 {
@@ -97,13 +98,11 @@ void main()
         if (uni_TextureEnabled[2])
         {
 #ifdef CONFIG_QUALITY_SHADOWS
-            float offset = 0.00025f;
-
             float value = (1.0f / 5.0f) * (shadow2D(uni_ShadowTexture, pass_TexCoord2).x
-                    + shadow2D(uni_ShadowTexture, pass_TexCoord2 + vec3( offset,    0.0f, 0.0f)).x
-                    + shadow2D(uni_ShadowTexture, pass_TexCoord2 + vec3(-offset,    0.0f, 0.0f)).x
-                    + shadow2D(uni_ShadowTexture, pass_TexCoord2 + vec3(   0.0f,  offset, 0.0f)).x
-                    + shadow2D(uni_ShadowTexture, pass_TexCoord2 + vec3(   0.0f, -offset, 0.0f)).x);
+                    + shadow2D(uni_ShadowTexture, pass_TexCoord2 + vec3( uni_ShadowTexelSize,    0.0f, 0.0f)).x
+                    + shadow2D(uni_ShadowTexture, pass_TexCoord2 + vec3(-uni_ShadowTexelSize,    0.0f, 0.0f)).x
+                    + shadow2D(uni_ShadowTexture, pass_TexCoord2 + vec3(   0.0f,  uni_ShadowTexelSize, 0.0f)).x
+                    + shadow2D(uni_ShadowTexture, pass_TexCoord2 + vec3(   0.0f, -uni_ShadowTexelSize, 0.0f)).x);
 
             shadow = mix(uni_ShadowColor, 1.0f, value);
 #else


### PR DESCRIPTION
Fixes the issue mentioned in #1152 for the gl21 shaders. Instead of using 0.00025f as offset, the texel size will be precomputed and sent to the shader. This change shouldn't have any performance impact.