### PR TITLE
When game speed is 2 or higher, run multiple ticks.

### DIFF
--- a/src/app/app.h
+++ b/src/app/app.h
@@ -289,7 +289,7 @@ protected:
     //! If applicable, creates a virtual event to match the changed state as of new event
     Event       CreateVirtualEvent(const Event& sourceEvent);
     //! Prepares a simulation update event
-    TEST_VIRTUAL Event CreateUpdateEvent();
+    TEST_VIRTUAL Event CreateUpdateEvent(SystemTimeStamp *newTimeStamp);
     //! Logs debug data for event
     void        LogEvent(const Event& event);
 

--- a/src/common/system/system.h
+++ b/src/common/system/system.h
@@ -116,6 +116,9 @@ public:
     //! Copies the time stamp from \a src to \a dst
     TEST_VIRTUAL void CopyTimeStamp(SystemTimeStamp *dst, SystemTimeStamp *src);
 
+    //! Interpolates between two timestamps. If i=0 then dst=a. If i=1 then dst=b. If i=0.5 then dst is halfway between.
+    virtual void InterpolateTimeStamp(SystemTimeStamp *dst, SystemTimeStamp *a, SystemTimeStamp *b, float i) = 0;
+
     //! Returns a time stamp associated with current time
     virtual void GetCurrentTimeStamp(SystemTimeStamp *stamp) = 0;
 

--- a/src/common/system/system_linux.cpp
+++ b/src/common/system/system_linux.cpp
@@ -83,6 +83,19 @@ SystemDialogResult CSystemUtilsLinux::SystemDialog(SystemDialogType type, const 
     return result;
 }
 
+void CSystemUtilsLinux::InterpolateTimeStamp(SystemTimeStamp *dst, SystemTimeStamp *a, SystemTimeStamp *b, float i)
+{
+    long long delta = TimeStampExactDiff(a, b);
+    delta *= i; // truncates
+    dst->clockTime.tv_sec = a->clockTime.tv_sec + delta / 1000000000;
+    dst->clockTime.tv_nsec = a->clockTime.tv_nsec + delta % 1000000000;
+    if(dst->clockTime.tv_nsec >= 1000000000)
+    {
+        dst->clockTime.tv_nsec -= 1000000000;
+        dst->clockTime.tv_sec++;
+    }
+}
+
 void CSystemUtilsLinux::GetCurrentTimeStamp(SystemTimeStamp *stamp)
 {
     clock_gettime(CLOCK_MONOTONIC_RAW, &stamp->clockTime);

--- a/src/common/system/system_linux.h
+++ b/src/common/system/system_linux.h
@@ -40,6 +40,7 @@ public:
 
     SystemDialogResult SystemDialog(SystemDialogType type, const std::string& title, const std::string& message) override;
 
+    void InterpolateTimeStamp(SystemTimeStamp *dst, SystemTimeStamp *a, SystemTimeStamp *b, float i) override;
     void GetCurrentTimeStamp(SystemTimeStamp *stamp) override;
     long long TimeStampExactDiff(SystemTimeStamp *before, SystemTimeStamp *after) override;
 

--- a/src/common/system/system_other.cpp
+++ b/src/common/system/system_other.cpp
@@ -34,6 +34,11 @@ void CSystemUtilsOther::GetCurrentTimeStamp(SystemTimeStamp* stamp)
     stamp->sdlTicks = SDL_GetTicks();
 }
 
+void CSystemUtilsOther::InterpolateTimeStamp(SystemTimeStamp *dst, SystemTimeStamp *a, SystemTimeStamp *b, float i)
+{
+    dst->sdlTicks = a->sdlTicks + static_cast<Uint32>((b->sdlTicks - a->sdlTicks) * i);
+}
+
 long long int CSystemUtilsOther::TimeStampExactDiff(SystemTimeStamp* before, SystemTimeStamp* after)
 {
     return (after->sdlTicks - before->sdlTicks) * 1000000ll;

--- a/src/common/system/system_other.h
+++ b/src/common/system/system_other.h
@@ -46,6 +46,7 @@ public:
     void Init() override;
     SystemDialogResult SystemDialog(SystemDialogType type, const std::string& title, const std::string& message) override;
 
+    void InterpolateTimeStamp(SystemTimeStamp *dst, SystemTimeStamp *a, SystemTimeStamp *b, float i) override;
     void GetCurrentTimeStamp(SystemTimeStamp *stamp) override;
     long long TimeStampExactDiff(SystemTimeStamp *before, SystemTimeStamp *after) override;
 

--- a/src/common/system/system_windows.cpp
+++ b/src/common/system/system_windows.cpp
@@ -83,6 +83,11 @@ void CSystemUtilsWindows::GetCurrentTimeStamp(SystemTimeStamp* stamp)
     stamp->counterValue = value.QuadPart;
 }
 
+void CSystemUtilsWindows::InterpolateTimeStamp(SystemTimeStamp *dst, SystemTimeStamp *a, SystemTimeStamp *b, float i)
+{
+    dst->counterValue = a->counterValue + static_cast<long long>((b->counterValue - a->counterValue) * static_cast<double>(i));
+}
+
 long long int CSystemUtilsWindows::TimeStampExactDiff(SystemTimeStamp* before, SystemTimeStamp* after)
 {
     float floatValue = static_cast<double>(after->counterValue - before->counterValue) * (1e9 / static_cast<double>(m_counterFrequency));

--- a/src/common/system/system_windows.h
+++ b/src/common/system/system_windows.h
@@ -38,6 +38,7 @@ public:
 
     SystemDialogResult SystemDialog(SystemDialogType type, const std::string& title, const std::string& message) override;
 
+    void InterpolateTimeStamp(SystemTimeStamp *dst, SystemTimeStamp *a, SystemTimeStamp *b, float i) override;
     void GetCurrentTimeStamp(SystemTimeStamp *stamp) override;
     long long TimeStampExactDiff(SystemTimeStamp *before, SystemTimeStamp *after) override;
 

--- a/test/unit/app/app_test.cpp
+++ b/test/unit/app/app_test.cpp
@@ -55,9 +55,9 @@ public:
         SDL_Quit();
     }
 
-    Event CreateUpdateEvent() override
+    Event CreateUpdateEvent(SystemTimeStamp *timestamp) override
     {
-        return CApplication::CreateUpdateEvent();
+        return CApplication::CreateUpdateEvent(timestamp);
     }
 };
 
@@ -157,7 +157,9 @@ void CApplicationUT::TestCreateUpdateEvent(long long relTimeExact, long long abs
                                            float relTime, float absTime,
                                            long long relTimeReal, long long absTimeReal)
 {
-    Event event = m_app->CreateUpdateEvent();
+    SystemTimeStamp *now = CreateTimeStamp();
+    GetCurrentTimeStamp(now);
+    Event event = m_app->CreateUpdateEvent(now);
     EXPECT_EQ(EVENT_FRAME, event.type);
     EXPECT_FLOAT_EQ(relTime, event.rTime);
     EXPECT_FLOAT_EQ(relTime, m_app->GetRelTime());
@@ -172,7 +174,11 @@ void CApplicationUT::TestCreateUpdateEvent(long long relTimeExact, long long abs
 TEST_F(CApplicationUT, UpdateEventTimeCalculation_SimulationSuspended)
 {
     m_app->SuspendSimulation();
-    Event event = m_app->CreateUpdateEvent();
+
+    SystemTimeStamp *now = CreateTimeStamp();
+    GetCurrentTimeStamp(now);
+    Event event = m_app->CreateUpdateEvent(now);
+
     EXPECT_EQ(EVENT_NULL, event.type);
 }
 
@@ -224,7 +230,9 @@ TEST_F(CApplicationUT, UpdateEventTimeCalculation_NegativeTimeOperation)
 
     NextInstant(-1111);
 
-    Event event = m_app->CreateUpdateEvent();
+    SystemTimeStamp *now = CreateTimeStamp();
+    GetCurrentTimeStamp(now);
+    Event event = m_app->CreateUpdateEvent(now);
     EXPECT_EQ(EVENT_NULL, event.type);
 }
 


### PR DESCRIPTION
This is still not deterministic, but it should fix all the odd glitches caused by very high timesteps.

Fixes #939
Fixes #1164