### PR TITLE
Fix #477 #1003 - permit UTF8 inputs

### DIFF
--- a/src/CBot/CBotCStack.cpp
+++ b/src/CBot/CBotCStack.cpp
@@ -33,7 +33,7 @@ namespace CBot
 ////////////////////////////////////////////////////////////////////////////////
 CBotProgram* CBotCStack::m_prog    = nullptr;            // init the static variable
 CBotError CBotCStack::m_error   = CBotNoErr;
-int CBotCStack::m_end      = 0;
+std::size_t CBotCStack::m_end      = 0;
 CBotTypResult CBotCStack::m_retTyp  = CBotTypResult(0);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -120,7 +120,7 @@ CBotFunction* CBotCStack::ReturnFunc(CBotFunction* inst, CBotCStack* pfils)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-CBotError CBotCStack::GetError(int& start, int& end)
+CBotError CBotCStack::GetError(std::size_t& start, std::size_t& end) const
 {
     start = m_start;
     end      = m_end;
@@ -214,14 +214,14 @@ bool CBotCStack::IsOk()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void CBotCStack::SetStartError( int pos )
+void CBotCStack::SetStartError(const std::size_t pos)
 {
     if ( m_error != 0) return;            // does not change existing error
     m_start = pos;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void CBotCStack::SetError(CBotError n, int pos)
+void CBotCStack::SetError(const CBotError n, const std::size_t pos)
 {
     if ( n!= 0 && m_error != 0) return;    // does not change existing error
     m_error = n;
@@ -238,7 +238,7 @@ void CBotCStack::SetError(CBotError n, CBotToken* p)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void CBotCStack::ResetError(CBotError n, int start, int end)
+void CBotCStack::ResetError(const CBotError n, const std::size_t start, const std::size_t end)
 {
     m_error = n;
     m_start    = start;

--- a/src/CBot/CBotCStack.h
+++ b/src/CBot/CBotCStack.h
@@ -65,7 +65,7 @@ public:
      * \param end
      * \return
      */
-    CBotError GetError(int& start, int& end);
+    CBotError GetError(std::size_t& start, std::size_t& end) const;
 
     /*!
      * \brief SetType Set the type of instruction on the stack.
@@ -176,14 +176,19 @@ public:
      * \brief SetStartError
      * \param pos
      */
-    void SetStartError(int pos);
+    void SetStartError(const std::size_t pos);
 
     /*!
      * \brief SetError
      * \param n
      * \param pos
      */
-    void SetError(CBotError n, int pos);
+    void SetError(const CBotError n, const std::size_t pos);
+    void SetError(const CBotError n, const int pos)
+    {
+        // added func to avoid "ambiguous" error on SetError(n, 0); (and also avoid cast need)
+        SetError(n, static_cast<std::size_t>(pos));
+    }
 
     /*!
      * \brief SetError
@@ -198,7 +203,7 @@ public:
      * \param start
      * \param end
      */
-    void ResetError(CBotError n, int start, int end);
+    void ResetError(const CBotError n, const std::size_t start, const std::size_t end);
 
     /*!
      * \brief SetRetType
@@ -253,8 +258,8 @@ private:
     CBotCStack* m_prev;
 
     static CBotError m_error;
-    static int m_end;
-    int m_start;
+    static std::size_t m_end;
+    std::size_t m_start;
 
     //! Result of the operations.
     CBotVar* m_var;

--- a/src/CBot/CBotInstr/CBotExprLitString.cpp
+++ b/src/CBot/CBotInstr/CBotExprLitString.cpp
@@ -48,7 +48,7 @@ CBotInstr* CBotExprLitString::Compile(CBotToken* &p, CBotCStack* pStack)
     if (++it != s.cend())
     {
         int pos = p->GetStart();
-        std::string valstring = "";
+        std::string valstring = "", plomp;
         while (it != s.cend() && *it != '\"')
         {
             pStk->SetStartError(++pos);
@@ -133,9 +133,10 @@ CBotInstr* CBotExprLitString::Compile(CBotToken* &p, CBotCStack* pStack)
                                 }
                                 else if (maxlen == hex.length()) // unicode character
                                 {
-                                    if (val < 0xD800 || (0xDFFF < val && val < 0x110000))
+                                    plomp = CodePointToUTF8(val);
+                                    if (plomp.size())
                                     {
-                                        valstring += CodePointToUTF8(val);
+                                        valstring += plomp;
                                         continue;
                                     }
                                     pStk->SetError(CBotErrUnicodeName, pos + 1);

--- a/src/CBot/CBotInstr/CBotExpression.cpp
+++ b/src/CBot/CBotInstr/CBotExpression.cpp
@@ -146,7 +146,7 @@ CBotInstr* CBotExpression::Compile(CBotToken* &p, CBotCStack* pStack)
     }
 
     delete inst;
-    int start, end;
+    std::size_t start = 0, end = 0;
     CBotError error = pStack->GetError(start, end);
 
     p = pp;                                        // returns to the top

--- a/src/CBot/CBotInstr/CBotFunction.cpp
+++ b/src/CBot/CBotInstr/CBotFunction.cpp
@@ -83,7 +83,7 @@ bool CBotFunction::IsExtern()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-bool CBotFunction::GetPosition(int& start, int& stop, CBotGet modestart, CBotGet modestop)
+bool CBotFunction::GetPosition(std::size_t& start, std::size_t& stop, CBotGet modestart, CBotGet modestop) const
 {
     start = m_extern.GetStart();
     stop = m_closeblk.GetEnd();
@@ -230,7 +230,7 @@ CBotFunction* CBotFunction::Compile(CBotToken* &p, CBotCStack* pStack, CBotFunct
                 {
                     if (!func->m_retTyp.Eq(CBotTypVoid) && !func->HasReturn())
                     {
-                        int errPos = func->m_closeblk.GetStart();
+                        std::size_t errPos = func->m_closeblk.GetStart();
                         pStk->ResetError(CBotErrNoReturn, errPos, errPos);
                         goto bad;
                     }

--- a/src/CBot/CBotInstr/CBotFunction.h
+++ b/src/CBot/CBotInstr/CBotFunction.h
@@ -235,9 +235,9 @@ public:
      * \param modestop
      * \return
      */
-    bool GetPosition(int& start, int& stop,
+    bool GetPosition(std::size_t& start, std::size_t& stop,
                      CBotGet modestart,
-                     CBotGet modestop);
+                     CBotGet modestop) const;
 
     /*!
      * \brief Check if the function has a return statment that will execute.

--- a/src/CBot/CBotProgram.cpp
+++ b/src/CBot/CBotProgram.cpp
@@ -166,7 +166,8 @@ bool CBotProgram::Start(const std::string& name)
     return true; // we are ready for Run()
 }
 
-bool CBotProgram::GetPosition(const std::string& name, int& start, int& stop, CBotGet modestart, CBotGet modestop)
+bool CBotProgram::GetPosition(const std::string& name, std::size_t& start, std::size_t& stop,
+                              CBotGet modestart, CBotGet modestop) const
 {
     auto it = std::find_if(m_functions.begin(), m_functions.end(), [&name](CBotFunction* x) { return x->GetName() == name; });
     if (it == m_functions.end()) return false;
@@ -225,7 +226,7 @@ void CBotProgram::Stop()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-bool CBotProgram::GetRunPos(std::string& functionName, int& start, int& end)
+bool CBotProgram::GetRunPos(std::string& functionName, std::size_t& start, std::size_t& end) const
 {
     functionName = "";
     start = end = 0;
@@ -256,8 +257,7 @@ CBotError CBotProgram::GetError()
     return m_error;
 }
 
-
-bool CBotProgram::GetError(CBotError& code, int& start, int& end)
+bool CBotProgram::GetError(CBotError& code, std::size_t& start, std::size_t& end) const
 {
     code  = m_error;
     start = m_errorStart;
@@ -265,8 +265,8 @@ bool CBotProgram::GetError(CBotError& code, int& start, int& end)
     return code > 0;
 }
 
-
-bool CBotProgram::GetError(CBotError& code, int& start, int& end, CBotProgram*& pProg)
+bool CBotProgram::GetError(CBotError& code, std::size_t& start, std::size_t& end,
+                           const CBotProgram*& pProg) const
 {
     code    = m_error;
     start   = m_errorStart;

--- a/src/CBot/CBotProgram.h
+++ b/src/CBot/CBotProgram.h
@@ -68,7 +68,7 @@ class CBotExternalCallList;
  * if (!ok)
  * {
  *     CBotError error;
- *     int cursor1, cursor2;
+ *     std::size_t cursor1, cursor2;
  *     program->GetError(error, cursor1, cursor2);
  *     // Handle the error
  * }
@@ -135,7 +135,7 @@ public:
     /**
      * \brief Returns the last error
      * \return Error code
-     * \see GetError(CBotError&, int&, int&) for error location in the code
+     * \see GetError(CBotError&, std::size_t&, std::size_t&) for error location in the code
      */
     CBotError GetError();
 
@@ -146,7 +146,7 @@ public:
      * \param[out] end Ending position in the code string of this error
      * \return false if no error has occurred
      */
-    bool GetError(CBotError& code, int& start, int& end);
+    bool GetError(CBotError& code, std::size_t& start, std::size_t& end) const;
 
     /**
      * \brief Returns the last error
@@ -156,7 +156,7 @@ public:
      * \param[out] pProg Program that caused the error (TODO: This always returns "this"... what?)
      * \return false if no error has occurred
      */
-    bool GetError(CBotError& code, int& start, int& end, CBotProgram*& pProg);
+    bool GetError(CBotError& code, std::size_t& start, std::size_t& end, const CBotProgram*& pProg) const;
 
     /**
      * \brief Starts the program using given function as an entry point. The function must be declared as "extern"
@@ -185,7 +185,7 @@ public:
      * \param[out] end Ending position in the code string of currently executed instruction
      * \return false if it is not running (program completion)
      */
-    bool GetRunPos(std::string& functionName, int& start, int& end);
+    bool GetRunPos(std::string& functionName, std::size_t& start, std::size_t& end) const;
 
     /**
      * \brief Provides the pointer to the variables on the execution stack
@@ -319,10 +319,10 @@ public:
      * \return
      */
     bool GetPosition(const std::string& name,
-                     int& start,
-                     int& stop,
+                     std::size_t& start,
+                     std::size_t& stop,
                      CBotGet modestart = GetPosExtern,
-                     CBotGet modestop = GetPosBloc);
+                     CBotGet modestop  = GetPosBloc) const;
 
     /**
      * \brief Returns the list of all user-defined functions in this program as instances of CBotFunction
@@ -361,8 +361,8 @@ private:
     friend class CBotDebug;
 
     CBotError m_error = CBotNoErr;
-    int m_errorStart = 0;
-    int m_errorEnd = 0;
+    std::size_t m_errorStart = 0;
+    std::size_t m_errorEnd = 0;
 };
 
 } // namespace CBot

--- a/src/CBot/CBotStack.cpp
+++ b/src/CBot/CBotStack.cpp
@@ -44,9 +44,9 @@ int         CBotStack::m_initimer = DEFAULT_TIMER;
 int         CBotStack::m_timer = 0;
 CBotVar*    CBotStack::m_retvar = nullptr;
 CBotError   CBotStack::m_error = CBotNoErr;
-int         CBotStack::m_start = 0;
-int         CBotStack::m_end   = 0;
-std::string  CBotStack::m_labelBreak="";
+std::size_t CBotStack::m_start = 0;
+std::size_t CBotStack::m_end   = 0;
+std::string CBotStack::m_labelBreak="";
 void*       CBotStack::m_pUser = nullptr;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -438,7 +438,7 @@ void CBotStack::SetError(CBotError n, CBotToken* token)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void CBotStack::ResetError(CBotError n, int start, int end)
+void CBotStack::ResetError(CBotError n, std::size_t start, std::size_t end)
 {
     m_error = n;
     m_start    = start;
@@ -604,14 +604,13 @@ void CBotStack::RestoreCall(long& nIdent, CBotToken* token, CBotVar** ppVar)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void CBotStack::GetRunPos(std::string& functionName, int& start, int& end)
+void CBotStack::GetRunPos(std::string& functionName, std::size_t& start, std::size_t& end) const
 {
     CBotProgram*    prog = m_prog;                        // Current program
 
     CBotInstr*        funct = nullptr;                        // function found
     CBotInstr*        instr = nullptr;                        // the highest intruction
-
-    CBotStack*        p = this;
+    const CBotStack*  p     = this;
 
     while (p->m_next != nullptr)
     {

--- a/src/CBot/CBotStack.h
+++ b/src/CBot/CBotStack.h
@@ -94,14 +94,22 @@ public:
      * \param[out] end Ending position in code of the error
      * \return Error number
      */
-    CBotError GetError(int& start, int& end) { start = m_start; end = m_end; return m_error; }
+    CBotError GetError(std::size_t& start, std::size_t& end) const
+    {
+        start = m_start;
+        end = m_end;
+        return m_error;
+    }
 
     /**
      * \brief Get last error
      * \return Error number
-     * \see GetError(int&, int&) for error position in code
+     * \see GetError(std::size_t&, std::size_t&) for error position in code
      */
-    CBotError GetError() { return m_error; }
+    CBotError GetError() const
+    {
+        return m_error;
+    }
 
     /**
      * \brief Check if there was an error
@@ -132,7 +140,7 @@ public:
      *
      * \see SetError() to set error only if it is not set already
      */
-    void            ResetError(CBotError n, int start, int end);
+    void            ResetError(CBotError n, std::size_t start, std::size_t end);
     /**
      * \todo Document
      *
@@ -458,7 +466,7 @@ public:
      * \param[out] start Start position of currently executed token
      * \param[out] end End position of currently executed token
      */
-    void            GetRunPos(std::string& functionName, int& start, int& end);
+    void            GetRunPos(std::string& functionName, std::size_t& start, std::size_t& end) const;
 
     /**
      * \brief Get local variables at the given stack level
@@ -477,8 +485,8 @@ private:
     int               m_state;
     int               m_step;
     static CBotError  m_error;
-    static int        m_start;
-    static int        m_end;
+    static std::size_t m_start;
+    static std::size_t m_end;
     static CBotVar*   m_retvar;                    // result of a return
 
     CBotVar*        m_var;                        // result of the operations

--- a/src/CBot/CBotToken.cpp
+++ b/src/CBot/CBotToken.cpp
@@ -152,7 +152,7 @@ CBotToken::CBotToken()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-CBotToken::CBotToken(const std::string& text, const std::string& sep, int start, int end)
+CBotToken::CBotToken(const std::string& text, const std::string& sep, std::size_t start, std::size_t end)
 {
     m_text  = text;
     m_sep   = sep;
@@ -233,19 +233,19 @@ void CBotToken::SetString(const std::string& name)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-int CBotToken::GetStart()
+std::size_t CBotToken::GetStart() const
 {
     return m_start;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-int CBotToken::GetEnd()
+std::size_t CBotToken::GetEnd() const
 {
     return m_end;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void CBotToken::SetPos(int start, int end)
+void CBotToken::SetPos(const std::size_t start, const std::size_t end)
 {
     m_start = start;
     m_end   = end;
@@ -413,8 +413,7 @@ std::unique_ptr<CBotToken> CBotToken::CompileTokens(const std::string& program)
 {
     CBotToken       *nxt, *prv, *tokenbase;
     const char*     p = program.c_str();
-    int             pos = 0;
-
+    std::size_t     pos = 0;
     prv = tokenbase = NextToken(p, true);
 
     if (tokenbase == nullptr) return nullptr;

--- a/src/CBot/CBotToken.h
+++ b/src/CBot/CBotToken.h
@@ -98,8 +98,8 @@ public:
      */
     CBotToken(const std::string& text,
               const std::string& sep = "",
-              int start = 0,
-              int end = 0);
+              std::size_t start = 0,
+              std::size_t end = 0);
 
     /**
      * \brief Destructor
@@ -131,19 +131,19 @@ public:
     /**
      * \brief Return the beginning location of this token in the original program string
      */
-    int GetStart();
+    std::size_t GetStart() const;
 
     /**
      * \brief Return the ending location of this token in the original program string
      */
-    int GetEnd();
+    std::size_t GetEnd() const;
 
     /**
      * \brief SetPos Set the token position in the CBot program
      * \param start The start position of the token
      * \param end The end position of the token
      */
-    void SetPos(int start, int end);
+    void SetPos(const std::size_t start, const std::size_t end);
 
     /**
      * \brief Get the keyword id
@@ -201,9 +201,9 @@ private:
     std::string m_sep = "";
 
     //! The strat position of the token in the CBotProgram
-    int m_start = 0;
+    std::size_t m_start = 0;
     //! The end position of the token in the CBotProgram
-    int m_end = 0;
+    std::size_t m_end = 0;
 
     //! Map of all defined constants (see DefineNum())
     static std::map<std::string, long> m_defineNum;

--- a/src/CBot/CBotUtils.cpp
+++ b/src/CBot/CBotUtils.cpp
@@ -250,6 +250,12 @@ bool CharInList(const char c, const char* list)
 
 std::string CodePointToUTF8(unsigned int val)
 {
+    // nota : similare with StrUtils::UnicodeCharToUtf8 (with traces but CBotErrUnicodeName)
+    //  memo UTF8:
+    // 1 byte  : 00000000 -- 0000007F:  0xxxxxxx
+    // 2 bytes : 00000080 -- 000007FF:  110xxxxx 10xxxxxx
+    // 3 bytes : 00000800 -- 0000FFFF:  1110xxxx 10xxxxxx 10xxxxxx
+    // 4 bytes : 00010000 -- 001FFFFF:  11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
     std::string s = "";
 
     if (val < 0xD800 || (0xDFFF < val && val < 0x110000))
@@ -260,21 +266,21 @@ std::string CodePointToUTF8(unsigned int val)
         }
         else if (val < 0x800)
         {
-            s.push_back(0xC0 + (val >> 6));
-            s.push_back(0x80 + (val & 0x3F));
+            s.push_back(0xC0 | ((val & 0x07C0) >> 6));
+            s.push_back(0x80 | (val & 0x3F));
         }
         else if (val < 0x10000)
         {
-            s.push_back(0xE0 + (val >> 12));
-            s.push_back(0x80 + ((val >> 6) & 0x3F));
-            s.push_back(0x80 + (val & 0x3F));
+            s.push_back(0xE0 | ((val & 0xF000) >> 12));
+            s.push_back(0x80 | ((val & 0x07C0) >> 6));
+            s.push_back(0x80 | (val & 0x3F));
         }
         else
         {
-            s.push_back(0xF0 + (val >> 18));
-            s.push_back(0x80 + ((val >> 12) & 0x3F));
-            s.push_back(0x80 + ((val >> 6) & 0x3F));
-            s.push_back(0x80 + (val & 0x3F));
+            s.push_back(0xF0 | (val >> 18));
+            s.push_back(0x80 | ((val >> 12) & 0x3F));
+            s.push_back(0x80 | ((val >> 6) & 0x3F));
+            s.push_back(0x80 | (val & 0x3F));
         }
     }
 

--- a/src/CBot/CBotVar/CBotVarClass.cpp
+++ b/src/CBot/CBotVar/CBotVarClass.cpp
@@ -383,7 +383,7 @@ void CBotVarClass::DecrementUse()
             // m_error is static in the stack
             // saves the value for return
             CBotError err;
-            int start, end;
+            std::size_t start, end;
             CBotStack*    pile = nullptr;
             err = pile->GetError(start,end);    // stack == nullptr it does not bother!
 

--- a/src/common/stringutils.cpp
+++ b/src/common/stringutils.cpp
@@ -154,10 +154,11 @@ unsigned int StrUtils::Utf8CharToUnicode(const std::string &ch)
 std::wstring StrUtils::Utf8StringToUnicode(const std::string &str)
 {
     std::wstring result;
-    unsigned int pos = 0;
+    std::size_t pos = 0;
+    unsigned short len;
     while (pos < str.size())
     {
-        int len = StrUtils::Utf8CharSizeAt(str, pos);
+        len = StrUtils::Utf8CharSizeAt(str, pos);
         if (len == 0)
             break;
 
@@ -168,7 +169,7 @@ std::wstring StrUtils::Utf8StringToUnicode(const std::string &str)
     return result;
 }
 
-int StrUtils::Utf8CharSizeAt(const std::string &str, unsigned int pos)
+unsigned short StrUtils::Utf8CharSizeAt(const std::string &str, const std::size_t pos)
 {
     if (pos >= str.size())
         return 0;
@@ -186,7 +187,7 @@ int StrUtils::Utf8CharSizeAt(const std::string &str, unsigned int pos)
 std::size_t StrUtils::Utf8StringLength(const std::string &str)
 {
     std::size_t result = 0;
-    unsigned int i = 0;
+    std::size_t i = 0;
     while (i < str.size())
     {
         i += Utf8CharSizeAt(str, i);

--- a/src/common/stringutils.cpp
+++ b/src/common/stringutils.cpp
@@ -315,7 +315,7 @@ void StrUtils::Utf8Log(const char*const invit, const char*const str, const std::
         else
         {
             char plomp[7];
-            std::memset(plomp,0,9);
+            std::memset(plomp,0,7);
             for(unsigned short i=0 ; i<len && pos+i<size ; ++i)
                 plomp[i]=str[pos+i];
             GetLogger()->Warn("%s len %d <%s>\n", invit, len, plomp);

--- a/src/common/stringutils.h
+++ b/src/common/stringutils.h
@@ -82,10 +82,9 @@ unsigned int Utf8CharToUnicode(const std::string &ch);
 std::wstring Utf8StringToUnicode(const std::string &str);
 
 //! Returns the size in bytes of UTF-8 character at given \a pos in a UTF-8 \a str
-int Utf8CharSizeAt(const std::string &str, unsigned int pos);
+unsigned short Utf8CharSizeAt(const std::string &str, const std::size_t pos);
 
 //! Returns the length in characters of UTF-8 string \a str
 std::size_t Utf8StringLength(const std::string &str);
 
 } // namespace StrUtil
-

--- a/src/common/stringutils.h
+++ b/src/common/stringutils.h
@@ -82,7 +82,32 @@ unsigned int Utf8CharToUnicode(const std::string &ch);
 std::wstring Utf8StringToUnicode(const std::string &str);
 
 //! Returns the size in bytes of UTF-8 character at given \a pos in a UTF-8 \a str
-unsigned short Utf8CharSizeAt(const std::string &str, const std::size_t pos);
+unsigned short Utf8CharSizeAt(const char*const str, const std::size_t pos, const std::size_t size);
+inline unsigned short Utf8CharSizeAt(const std::string& str, const std::size_t pos)
+{
+    return Utf8CharSizeAt(str.c_str(), pos, str.size());
+}
+
+//! warning log function to display eventual problematic chars
+void Utf8Log(const char*const invit, const char*const str, const std::size_t pos,
+             const std::size_t size, const bool bLogStd=false);
+inline void Utf8Log(const char*const invit, const std::string& str, const std::size_t pos,
+             const bool bLogStd=false)
+{
+    Utf8Log(invit, str.c_str(), pos, str.size(), bLogStd);
+}
+
+//! utf8 checks & log (Utf8CharSizeAt control)
+bool Utf8CheckWarnup(const char*const invit ,const char*const str, const std::size_t pos,
+                     const bool doInsideCheck, short nbBytes /*= -1*/, const std::size_t size);
+bool Utf8CheckWarnup(const char*const invit ,const char*const str, const std::size_t pos,
+                     const bool doInsideCheck);
+    // return Utf8CheckWarnup(invit, str, pos, doInsideCheck, -1, strlen(str) );
+inline bool Utf8CheckWarnup(const char*const invit ,const std::string& str, const std::size_t pos,
+                     const bool doInsideCheck, short nbBytes = -1)
+{
+    return Utf8CheckWarnup(invit, str.c_str(), pos, doInsideCheck, nbBytes, str.size());
+}
 
 //! Returns the length in characters of UTF-8 string \a str
 std::size_t Utf8StringLength(const std::string &str);

--- a/src/graphics/engine/text.cpp
+++ b/src/graphics/engine/text.cpp
@@ -419,18 +419,19 @@ float CText::GetStringWidth(const std::string &text,
                             std::vector<FontMetaChar>::iterator format,
                             std::vector<FontMetaChar>::iterator end, float size)
 {
-    float width = 0.0f;
-    unsigned int index = 0;
-    unsigned int fmtIndex = 0;
+    float width          = 0.0f;
+    std::size_t index    = 0;
+    std::size_t fmtIndex = 0;
+    FontType font = FONT_COMMON;
+    unsigned short len;
     while (index < text.length())
     {
-        FontType font = FONT_COMMON;
         if (format + fmtIndex != end)
             font = static_cast<FontType>(*(format + fmtIndex) & FONT_MASK_FONT);
-
+        else
+            font = FONT_COMMON;
         UTF8Char ch;
-
-        int len = StrUtils::Utf8CharSizeAt(text, index);
+        len = StrUtils::Utf8CharSizeAt(text, index);
         if (len >= 1)
             ch.c1 = text[index];
         if (len >= 2)
@@ -553,19 +554,20 @@ int CText::Justify(const std::string &text, std::vector<FontMetaChar>::iterator 
                    std::vector<FontMetaChar>::iterator end,
                    float size, float width)
 {
-    float pos = 0.0f;
-    int cut = 0;
-    unsigned int index = 0;
-    unsigned int fmtIndex = 0;
+    float       pos      = 0.0f;
+    std::size_t cut      = 0;
+    std::size_t index    = 0;
+    std::size_t fmtIndex = 0;
+    unsigned short len;
+    FontType font = FONT_COMMON;
     while (index < text.length())
     {
-        FontType font = FONT_COMMON;
         if (format + fmtIndex != end)
             font = static_cast<FontType>(*(format + fmtIndex) & FONT_MASK_FONT);
-
+        else
+            font = FONT_COMMON;
         UTF8Char ch;
-
-        int len = StrUtils::Utf8CharSizeAt(text, index);
+        len = StrUtils::Utf8CharSizeAt(text, index);
         if (len >= 1)
             ch.c1 = text[index];
         if (len >= 2)
@@ -599,14 +601,14 @@ int CText::Justify(const std::string &text, FontType font, float size, float wid
 {
     assert(font != FONT_BUTTON);
 
-    float pos = 0.0f;
-    int cut = 0;
-    unsigned int index = 0;
+    float       pos   = 0.0f;
+    std::size_t cut   = 0;
+    std::size_t index = 0;
+    unsigned short len;
     while (index < text.length())
     {
         UTF8Char ch;
-
-        int len = StrUtils::Utf8CharSizeAt(text, index);
+        len = StrUtils::Utf8CharSizeAt(text, index);
         if (len >= 1)
             ch.c1 = text[index];
         if (len >= 2)
@@ -638,9 +640,10 @@ int CText::Detect(const std::string &text, std::vector<FontMetaChar>::iterator f
                   std::vector<FontMetaChar>::iterator end,
                   float size, float offset)
 {
-    float pos = 0.0f;
-    unsigned int index = 0;
-    unsigned int fmtIndex = 0;
+    float pos            = 0.0f;
+    std::size_t index    = 0;
+    std::size_t fmtIndex = 0;
+    unsigned short len;
     while (index < text.length())
     {
         FontType font = FONT_COMMON;
@@ -652,8 +655,7 @@ int CText::Detect(const std::string &text, std::vector<FontMetaChar>::iterator f
         //if (font == FONT_BUTTON) continue;
 
         UTF8Char ch;
-
-        int len = StrUtils::Utf8CharSizeAt(text, index);
+        len = StrUtils::Utf8CharSizeAt(text, index);
         if (len >= 1)
             ch.c1 = text[index];
         if (len >= 2)
@@ -681,12 +683,12 @@ int CText::Detect(const std::string &text, FontType font, float size, float offs
     assert(font != FONT_BUTTON);
 
     float pos = 0.0f;
-    unsigned int index = 0;
+    std::size_t index = 0;
+    unsigned short len;
     while (index < text.length())
     {
         UTF8Char ch;
-
-        int len = StrUtils::Utf8CharSizeAt(text, index);
+        len = StrUtils::Utf8CharSizeAt(text, index);
         if (len >= 1)
             ch.c1 = text[index];
         if (len >= 2)
@@ -772,9 +774,8 @@ void CText::DrawString(const std::string &text, std::vector<FontMetaChar>::itera
 {
     m_engine->SetWindowCoordinates();
 
-    int start = pos.x;
-
-    unsigned int fmtIndex = 0;
+    int start            = pos.x;
+    std::size_t fmtIndex = 0;
 
     std::vector<UTF8Char> chars;
     StringToUTFCharList(text, chars, format, end);
@@ -864,13 +865,13 @@ void CText::DrawString(const std::string &text, std::vector<FontMetaChar>::itera
 
 void CText::StringToUTFCharList(const std::string &text, std::vector<UTF8Char> &chars)
 {
-    unsigned int index = 0;
-    unsigned int totalLength = text.length();
+    std::size_t index       = 0;
+    std::size_t totalLength = text.length();
+    unsigned short len;
     while (index < totalLength)
     {
         UTF8Char ch;
-
-        int len = StrUtils::Utf8CharSizeAt(text, index);
+        len = StrUtils::Utf8CharSizeAt(text, index);
         if (len >= 1)
             ch.c1 = text[index];
         if (len >= 2)
@@ -888,18 +889,17 @@ void CText::StringToUTFCharList(const std::string &text, std::vector<UTF8Char> &
                                 std::vector<FontMetaChar>::iterator format,
                                 std::vector<FontMetaChar>::iterator end)
 {
-    unsigned int index = 0;
-    unsigned int totalLength = text.length();
+    std::size_t index       = 0;
+    std::size_t totalLength = text.length();
+    unsigned short len;
+    FontType font = FONT_COMMON;
     while (index < totalLength)
     {
         UTF8Char ch;
-
-        FontType font = FONT_COMMON;
         if (format + index != end)
             font = static_cast<FontType>(*(format + index) & FONT_MASK_FONT);
-
-        int len;
-
+        else
+            font = FONT_COMMON;
         if(font == FONT_BUTTON)
         {
             len = 1;

--- a/src/graphics/engine/text.cpp
+++ b/src/graphics/engine/text.cpp
@@ -167,6 +167,41 @@ private:
     EngineRenderState m_renderState{};
 };
 
+/**
+ * Init from a given UTF8 character iif 0<size<4 (standards UTF8)
+ *     provide a warning trace in other cases
+ * @param  text          input data
+ * @param  index         wanted character position
+ * @param  optCallOrigin optional description trace from origin
+ * @return               size of the given UTF8 character
+ */
+unsigned short UTF8Char::Init(const std::string &text,
+                              const std::size_t index,
+                              const char*optCallOrigin)
+{
+    c1='\0';
+    c2='\0';
+    c3='\0';
+    c4='\0';
+    unsigned short len = StrUtils::Utf8CharSizeAt(text, index);
+    if (0==len)   //warning & do skip all : Risk of infinite loop !!
+        GetLogger()->Warn("Risk of infinite loop %s !!\nat %d <%s>\n",
+            optCallOrigin ? optCallOrigin : "",
+            index,text.c_str());
+    else if (5<=len)   // warning & do skip it
+        GetLogger()->Warn("long UTF8, len>=5, ignored !!\n");
+    else
+    {
+        c1 = text[index];
+        if (2<=len)
+            c2 = text[index+1];
+        if (3<=len)
+            c3 = text[index+2];
+        if (4<=len)
+            c4 = text[index+3];
+    }
+    return len;
+}
 
 CText::CText(CEngine* engine)
 {
@@ -236,7 +271,7 @@ void CText::SetDevice(CDevice* device)
     m_device = device;
 }
 
-std::string CText::GetError()
+std::string CText::GetError() const
 {
     return m_error;
 }
@@ -264,20 +299,25 @@ void CText::FlushCache()
     m_lastFontSize = 0;
 }
 
-int CText::GetTabSize()
+int CText::GetTabSize() const
 {
     return m_tabSize;
 }
 
-void CText::SetTabSize(int tabSize)
+void CText::SetTabSize(const int tabSize)
 {
     m_tabSize = tabSize;
 }
 
-void CText::DrawText(const std::string &text, std::vector<FontMetaChar>::iterator format,
-                     std::vector<FontMetaChar>::iterator end,
-                     float size, Math::Point pos, float width, TextAlign align,
-                     int eol, Color color)
+void CText::DrawText(const std::string &text,
+                     const std::vector<FontMetaChar>::iterator format,
+                     const std::vector<FontMetaChar>::iterator end,
+                     const float size,
+                     Math::Point pos,
+                     const float width,
+                     const TextAlign align,
+                     const int eol,
+                     const Color color)
 {
     float sw = 0.0f;
 
@@ -299,9 +339,14 @@ void CText::DrawText(const std::string &text, std::vector<FontMetaChar>::iterato
     DrawString(text, format, end, size, intPos, intWidth, eol, color);
 }
 
-void CText::DrawText(const std::string &text, FontType font,
-                     float size, Math::Point pos, float width, TextAlign align,
-                     int eol, Color color)
+void CText::DrawText(const std::string &text,
+                     const FontType font,
+                     const float size,
+                     Math::Point pos,
+                     const float width,
+                     const TextAlign align,
+                     const int eol,
+                     const Color color)
 {
     float sw = 0.0f;
 
@@ -323,9 +368,12 @@ void CText::DrawText(const std::string &text, FontType font,
     DrawString(text, font, size, intPos, intWidth, eol, color);
 }
 
-void CText::SizeText(const std::string &text, std::vector<FontMetaChar>::iterator format,
-                     std::vector<FontMetaChar>::iterator endFormat,
-                     float size, Math::Point pos, TextAlign align,
+void CText::SizeText(const std::string &text,
+                     const std::vector<FontMetaChar>::iterator format,
+                     const std::vector<FontMetaChar>::iterator endFormat,
+                     const float size,
+                     const Math::Point pos,
+                     const TextAlign align,
                      Math::Point &start, Math::Point &end)
 {
     start = end = pos;
@@ -347,9 +395,13 @@ void CText::SizeText(const std::string &text, std::vector<FontMetaChar>::iterato
     end.y   += GetAscent(FONT_COMMON, size);
 }
 
-void CText::SizeText(const std::string &text, FontType font,
-                     float size, Math::Point pos, TextAlign align,
-                     Math::Point &start, Math::Point &end)
+void CText::SizeText(const std::string &text,
+                     const FontType font,
+                     const float size,
+                     const Math::Point pos,
+                     const TextAlign align,
+                     Math::Point &start,
+                     Math::Point &end)
 {
     start = end = pos;
 
@@ -370,7 +422,7 @@ void CText::SizeText(const std::string &text, FontType font,
     end.y   += GetAscent(font, size);
 }
 
-float CText::GetAscent(FontType font, float size)
+float CText::GetAscent(const FontType font, const float size)
 {
     assert(font != FONT_BUTTON);
 
@@ -382,7 +434,7 @@ float CText::GetAscent(FontType font, float size)
     return ifSize.y;
 }
 
-float CText::GetDescent(FontType font, float size)
+float CText::GetDescent(const FontType font, const float size)
 {
     assert(font != FONT_BUTTON);
 
@@ -394,7 +446,7 @@ float CText::GetDescent(FontType font, float size)
     return ifSize.y;
 }
 
-float CText::GetHeight(FontType font, float size)
+float CText::GetHeight(const FontType font, const float size)
 {
     assert(font != FONT_BUTTON);
 
@@ -406,7 +458,7 @@ float CText::GetHeight(FontType font, float size)
     return ifSize.y;
 }
 
-int CText::GetHeightInt(FontType font, float size)
+int CText::GetHeightInt(const FontType font, const float size)
 {
     assert(font != FONT_BUTTON);
 
@@ -416,8 +468,9 @@ int CText::GetHeightInt(FontType font, float size)
 }
 
 float CText::GetStringWidth(const std::string &text,
-                            std::vector<FontMetaChar>::iterator format,
-                            std::vector<FontMetaChar>::iterator end, float size)
+                            const std::vector<FontMetaChar>::iterator format,
+                            const std::vector<FontMetaChar>::iterator end,
+                            const float size)
 {
     float width          = 0.0f;
     std::size_t index    = 0;
@@ -431,24 +484,20 @@ float CText::GetStringWidth(const std::string &text,
         else
             font = FONT_COMMON;
         UTF8Char ch;
-        len = StrUtils::Utf8CharSizeAt(text, index);
-        if (len >= 1)
-            ch.c1 = text[index];
-        if (len >= 2)
-            ch.c2 = text[index+1];
-        if (len >= 3)
-            ch.c3 = text[index+2];
-
-        width += GetCharWidth(ch, font, size, width);
-
+        len = ch.Init(text, index,"1 -CText::GetStringWidth");
+        if(0==len)  //Risk of infinite loop !!
+            break;
         index += len;
+        if(5<=len)  //Warning done, skip
+            continue;
+        width += GetCharWidth(ch, font, size, width);
         fmtIndex++;
     }
 
     return width;
 }
 
-float CText::GetStringWidth(std::string text, FontType font, float size)
+float CText::GetStringWidth(std::string text, const FontType font, const float size)
 {
     assert(font != FONT_BUTTON);
 
@@ -467,7 +516,7 @@ float CText::GetStringWidth(std::string text, FontType font, float size)
     return ifSize.x;
 }
 
-float CText::GetCharWidth(UTF8Char ch, FontType font, float size, float offset)
+float CText::GetCharWidth(UTF8Char ch, const FontType font, const float size, const float offset)
 {
     if (font == FONT_BUTTON)
     {
@@ -501,7 +550,7 @@ float CText::GetCharWidth(UTF8Char ch, FontType font, float size, float offset)
     {
         Math::IntPoint wndSize;
         std::string text;
-        text.append({ch.c1, ch.c2, ch.c3});
+        text.append({ch.c1, ch.c2, ch.c3, ch.c4});
         TTF_SizeUTF8(cf->font, text.c_str(), &wndSize.x, &wndSize.y);
         charSize = m_engine->WindowToInterfaceSize(wndSize);
     }
@@ -509,7 +558,7 @@ float CText::GetCharWidth(UTF8Char ch, FontType font, float size, float offset)
     return charSize.x * width;
 }
 
-int CText::GetCharWidthInt(UTF8Char ch, FontType font, float size, float offset)
+int CText::GetCharWidthInt(UTF8Char ch, const FontType font, const float size, const float offset)
 {
     if (font == FONT_BUTTON)
     {
@@ -542,7 +591,7 @@ int CText::GetCharWidthInt(UTF8Char ch, FontType font, float size, float offset)
     else
     {
         std::string text;
-        text.append({ch.c1, ch.c2, ch.c3});
+        text.append({ch.c1, ch.c2, ch.c3, ch.c4});
         TTF_SizeUTF8(cf->font, text.c_str(), &charSize.x, &charSize.y);
     }
 
@@ -550,9 +599,11 @@ int CText::GetCharWidthInt(UTF8Char ch, FontType font, float size, float offset)
 }
 
 
-int CText::Justify(const std::string &text, std::vector<FontMetaChar>::iterator format,
-                   std::vector<FontMetaChar>::iterator end,
-                   float size, float width)
+int CText::Justify(const std::string &text,
+                   const std::vector<FontMetaChar>::iterator format,
+                   const std::vector<FontMetaChar>::iterator end,
+                   const float size,
+                   const float width)
 {
     float       pos      = 0.0f;
     std::size_t cut      = 0;
@@ -567,14 +618,14 @@ int CText::Justify(const std::string &text, std::vector<FontMetaChar>::iterator 
         else
             font = FONT_COMMON;
         UTF8Char ch;
-        len = StrUtils::Utf8CharSizeAt(text, index);
-        if (len >= 1)
-            ch.c1 = text[index];
-        if (len >= 2)
-            ch.c2 = text[index+1];
-        if (len >= 3)
-            ch.c3 = text[index+2];
-
+        len = ch.Init(text, index,"2 -CText::Justify");
+        if(0==len)  //Risk of infinite loop !!
+            break;
+        if(5<=len)  //Warning done, skip
+        {
+            index += len;
+            continue;
+        }
         if (font != FONT_BUTTON)
         {
             if (ch.c1 == '\n')
@@ -597,7 +648,10 @@ int CText::Justify(const std::string &text, std::vector<FontMetaChar>::iterator 
     return index;
 }
 
-int CText::Justify(const std::string &text, FontType font, float size, float width)
+int CText::Justify(const std::string &text,
+                   const FontType font,
+                   const float size,
+                   const float width)
 {
     assert(font != FONT_BUTTON);
 
@@ -608,14 +662,14 @@ int CText::Justify(const std::string &text, FontType font, float size, float wid
     while (index < text.length())
     {
         UTF8Char ch;
-        len = StrUtils::Utf8CharSizeAt(text, index);
-        if (len >= 1)
-            ch.c1 = text[index];
-        if (len >= 2)
-            ch.c2 = text[index+1];
-        if (len >= 3)
-            ch.c3 = text[index+2];
-
+        len = ch.Init(text, index,"3 -CText::Justify 2");
+        if(0==len)  //Risk of infinite loop !!
+            break;
+        if(5<=len)  //Warning done, skip
+        {
+            index += len;
+            continue;
+        }
         if (ch.c1 == '\n')
         {
             return index+1;
@@ -636,9 +690,11 @@ int CText::Justify(const std::string &text, FontType font, float size, float wid
     return index;
 }
 
-int CText::Detect(const std::string &text, std::vector<FontMetaChar>::iterator format,
-                  std::vector<FontMetaChar>::iterator end,
-                  float size, float offset)
+int CText::Detect(const std::string &text,
+                  const std::vector<FontMetaChar>::iterator format,
+                  const std::vector<FontMetaChar>::iterator end,
+                  const float size,
+                  const float offset)
 {
     float pos            = 0.0f;
     std::size_t index    = 0;
@@ -653,16 +709,15 @@ int CText::Detect(const std::string &text, std::vector<FontMetaChar>::iterator f
 
         // TODO: if (font == FONT_BUTTON)
         //if (font == FONT_BUTTON) continue;
-
         UTF8Char ch;
-        len = StrUtils::Utf8CharSizeAt(text, index);
-        if (len >= 1)
-            ch.c1 = text[index];
-        if (len >= 2)
-            ch.c2 = text[index+1];
-        if (len >= 3)
-            ch.c3 = text[index+2];
-
+        len = ch.Init(text, index,"4 -CText::Detect");
+        if(0==len)  //Risk of infinite loop !!
+            break;
+        if(5<=len)  //Warning done, skip
+        {
+            index += len;
+            continue;
+        }
         if (ch.c1 == '\n')
             return index;
 
@@ -678,7 +733,10 @@ int CText::Detect(const std::string &text, std::vector<FontMetaChar>::iterator f
     return index;
 }
 
-int CText::Detect(const std::string &text, FontType font, float size, float offset)
+int CText::Detect(const std::string &text,
+                  const FontType font,
+                  const float size,
+                  const float offset)
 {
     assert(font != FONT_BUTTON);
 
@@ -688,16 +746,12 @@ int CText::Detect(const std::string &text, FontType font, float size, float offs
     while (index < text.length())
     {
         UTF8Char ch;
-        len = StrUtils::Utf8CharSizeAt(text, index);
-        if (len >= 1)
-            ch.c1 = text[index];
-        if (len >= 2)
-            ch.c2 = text[index+1];
-        if (len >= 3)
-            ch.c3 = text[index+2];
-
+        len = ch.Init(text, index,"5 -CText::Detect 2");
+        if(0==len)  //Risk of infinite loop !!
+            break;
         index += len;
-
+        if(5<=len)  //Warning done, skip
+            continue;
         if (ch.c1 == '\n')
             return index;
 
@@ -711,16 +765,16 @@ int CText::Detect(const std::string &text, FontType font, float size, float offs
     return index;
 }
 
-UTF8Char CText::TranslateSpecialChar(int specialChar)
+UTF8Char CText::TranslateSpecialChar(const char specialChar) const
 {
     UTF8Char ch;
-
+    ch.c2 = 0;
+    ch.c3 = 0;
+    ch.c4 = 0;
     switch (specialChar)
     {
         case CHAR_TAB:
             ch.c1 = ':';
-            ch.c2 = 0;
-            ch.c3 = 0;
             break;
 
         case CHAR_NEWLINE:
@@ -760,17 +814,17 @@ UTF8Char CText::TranslateSpecialChar(int specialChar)
 
         default:
             ch.c1 = '?';
-            ch.c2 = 0;
-            ch.c3 = 0;
             break;
     }
 
     return ch;
 }
 
-void CText::DrawString(const std::string &text, std::vector<FontMetaChar>::iterator format,
+void CText::DrawString(const std::string &text,
+                       std::vector<FontMetaChar>::iterator format,
                        std::vector<FontMetaChar>::iterator end,
-                       float size, Math::IntPoint pos, int width, int eol, Color color)
+                       float size, Math::IntPoint pos,
+                       int width, int eol, Color color)
 {
     m_engine->SetWindowCoordinates();
 
@@ -850,6 +904,8 @@ void CText::DrawString(const std::string &text, std::vector<FontMetaChar>::itera
             fmtIndex++;
         if ( ch.c3 != 0 )
             fmtIndex++;
+        if ( ch.c4 != 0 )
+            fmtIndex++;
     }
 
     if (eol != 0)
@@ -871,21 +927,18 @@ void CText::StringToUTFCharList(const std::string &text, std::vector<UTF8Char> &
     while (index < totalLength)
     {
         UTF8Char ch;
-        len = StrUtils::Utf8CharSizeAt(text, index);
-        if (len >= 1)
-            ch.c1 = text[index];
-        if (len >= 2)
-            ch.c2 = text[index+1];
-        if (len >= 3)
-            ch.c3 = text[index+2];
-
+        len = ch.Init(text, index,"6 -CText::StringToUTFCharList");
+        if(0==len)  //Risk of infinite loop !!
+            break;
         index += len;
-
+        if(5<=len)  //Warning done, skip
+            continue;
         chars.push_back(ch);
     }
 }
 
-void CText::StringToUTFCharList(const std::string &text, std::vector<UTF8Char> &chars,
+void CText::StringToUTFCharList(const std::string &text,
+                                std::vector<UTF8Char> &chars,
                                 std::vector<FontMetaChar>::iterator format,
                                 std::vector<FontMetaChar>::iterator end)
 {
@@ -903,21 +956,17 @@ void CText::StringToUTFCharList(const std::string &text, std::vector<UTF8Char> &
         if(font == FONT_BUTTON)
         {
             len = 1;
+            ch=UTF8Char(text[index]);
         }
         else
         {
-            len = StrUtils::Utf8CharSizeAt(text, index);
+            len = ch.Init(text, index,"7 -CText::StringToUTFCharList 2");
         }
-
-        if (len >= 1)
-            ch.c1 = text[index];
-        if (len >= 2)
-            ch.c2 = text[index+1];
-        if (len >= 3)
-            ch.c3 = text[index+2];
-
+        if(0==len)  //Risk of infinite loop !!
+            break;
         index += len;
-
+        if(5<=len)  //Warning done, skip
+            continue;
         chars.push_back(ch);
     }
 }
@@ -995,7 +1044,7 @@ void CText::DrawHighlight(FontMetaChar hl, Math::IntPoint pos, Math::IntPoint si
     m_device->SetTextureEnabled(0, true);
 }
 
-void CText::DrawCharAndAdjustPos(UTF8Char ch, FontType font, float size, Math::IntPoint &pos, Color color)
+void CText::DrawCharAndAdjustPos(UTF8Char ch, const FontType font, const float size, Math::IntPoint &pos, Color color)
 {
     if (font == FONT_BUTTON)
     {
@@ -1042,14 +1091,16 @@ void CText::DrawCharAndAdjustPos(UTF8Char ch, FontType font, float size, Math::I
     else
     {
         int width = 1;
-        if (ch.c1 > 0 && ch.c1 < 32)
+        if (ch.c1 > 0 && ch.c1 < 32
+            && ch.c2=='\0'
+            && ch.c3=='\0'
+            && ch.c4=='\0')
         {
             if (ch.c1 == '\t')
             {
                 color = Color(1.0f, 0.0f, 0.0f, 1.0f);
                 width = m_tabSize;
             }
-
             ch = TranslateSpecialChar(ch.c1);
         }
 
@@ -1079,8 +1130,12 @@ void CText::DrawCharAndAdjustPos(UTF8Char ch, FontType font, float size, Math::I
     }
 }
 
-CachedFont* CText::GetOrOpenFont(FontType font, float size)
+CachedFont* CText::GetOrOpenFont(const FontType font, const float size)
 {
+    // Nota: due to this optionnal loading, transforming getters of this class to const func
+    //  GetHeight, GetCharWidth & 2 Detect
+    //  would imply mutables for : m_error, m_lastFontType, m_lastFontSize & m_lastCachedFont
+
     Math::IntPoint windowSize = m_engine->GetWindowSize();
     int pointSize = static_cast<int>(size * (windowSize.Length() / REFERENCE_SIZE.Length()));
 
@@ -1129,7 +1184,7 @@ CachedFont* CText::GetOrOpenFont(FontType font, float size)
     return m_lastCachedFont;
 }
 
-CharTexture CText::GetCharTexture(UTF8Char ch, FontType font, float size)
+CharTexture CText::GetCharTexture(const UTF8Char ch, const FontType font, const float size)
 {
     CachedFont* cf = GetOrOpenFont(font, size);
 
@@ -1154,7 +1209,7 @@ CharTexture CText::GetCharTexture(UTF8Char ch, FontType font, float size)
     return tex;
 }
 
-Math::IntPoint CText::GetFontTextureSize()
+Math::IntPoint CText::GetFontTextureSize() const
 {
     return FONT_TEXTURE_SIZE;
 }
@@ -1165,7 +1220,7 @@ CharTexture CText::CreateCharTexture(UTF8Char ch, CachedFont* font)
 
     SDL_Surface* textSurface = nullptr;
     SDL_Color white = {255, 255, 255, 0};
-    char str[] = { ch.c1, ch.c2, ch.c3, '\0' };
+    char str[] = { ch.c1, ch.c2, ch.c3, '\0' };  //note: ch.c4 not to add there
     textSurface = TTF_RenderUTF8_Blended(font->font, str, white);
 
     if (textSurface == nullptr)

--- a/src/graphics/engine/text.h
+++ b/src/graphics/engine/text.h
@@ -159,17 +159,31 @@ enum FontMask
  * \struct UTF8Char
  * \brief UTF-8 character in font cache
  *
- * Only 3-byte chars are supported
+ * 4-bytes chars are supported
  */
 struct UTF8Char
 {
-    char c1, c2, c3;
-    // Padding for 4-byte alignment
-    // It also seems to fix some problems reported by valgrind
-    char pad;
+    char c1, c2, c3, c4;    // note: 4-byte alignment
+    // Padding for 4-byte alignment also seems to fix some problems reported by valgrind
 
-    explicit UTF8Char(char ch1 = '\0', char ch2 = '\0', char ch3 = '\0')
-        : c1(ch1), c2(ch2), c3(ch3), pad('\0') {}
+    explicit UTF8Char(const char ch1 = '\0',
+                      const char ch2 = '\0',
+                      const char ch3 = '\0',
+                      const char ch4 = '\0')
+        : c1(ch1), c2(ch2), c3(ch3), c4(ch4)
+    {
+    }
+
+    explicit UTF8Char(const std::string &text,
+                      const std::size_t index,
+                      const char*optCallOrigin="")
+    {
+        Init(text, index, optCallOrigin);
+    }
+
+    unsigned short Init(const std::string &text,
+                        const std::size_t index,
+                        const char*optCallOrigin="");
 
     inline bool operator<(const UTF8Char &other) const
     {
@@ -183,12 +197,18 @@ struct UTF8Char
         else if (c2 > other.c2)
             return false;
 
-        return c3 < other.c3;
+        if (c3 < other.c3)
+            return true;
+        else if (c3 > other.c3)
+            return false;
+
+        return c4 < other.c4;
     }
 
     inline bool operator==(const UTF8Char &other) const
     {
-        return c1 == other.c1 && c2 == other.c2 && c3 == other.c3;
+        return c1 == other.c1 && c2 == other.c2
+            && c3 == other.c3 && c4 == other.c4;
     }
 };
 
@@ -247,7 +267,7 @@ public:
     void        SetDevice(CDevice *device);
 
     //! Returns the last encountered error
-    std::string GetError();
+    std::string GetError() const;
 
     //! Initializes the font engine; must be called after SetDevice()
     bool        Create();
@@ -259,69 +279,97 @@ public:
 
     //@{
     //! Tab size management
-    void        SetTabSize(int tabSize);
-    int         GetTabSize();
+    void        SetTabSize(const int tabSize);
+    int         GetTabSize() const;
     //@}
 
     //! Draws text (multi-format)
-    void        DrawText(const std::string &text, std::vector<FontMetaChar>::iterator format,
-                         std::vector<FontMetaChar>::iterator end,
-                         float size, Math::Point pos, float width, TextAlign align,
-                         int eol, Color color = Color(0.0f, 0.0f, 0.0f, 1.0f));
+    void        DrawText(const std::string &text,
+                         const std::vector<FontMetaChar>::iterator format,
+                         const std::vector<FontMetaChar>::iterator end,
+                         const float size,
+                         Math::Point pos,
+                         const float width,
+                         const TextAlign align,
+                         const int eol,
+                         const Color color = Color(0.0f, 0.0f, 0.0f, 1.0f));
     //! Draws text (one font)
-    void        DrawText(const std::string &text, FontType font,
-                         float size, Math::Point pos, float width, TextAlign align,
-                         int eol, Color color = Color(0.0f, 0.0f, 0.0f, 1.0f));
+    void        DrawText(const std::string &text,
+                         const FontType font,
+                         const float size,
+                         Math::Point pos,
+                         const float width,
+                         const TextAlign align,
+                         const int eol,
+                         const Color color = Color(0.0f, 0.0f, 0.0f, 1.0f));
 
     //! Calculates dimensions for text (multi-format)
-    void        SizeText(const std::string &text, std::vector<FontMetaChar>::iterator format,
-                         std::vector<FontMetaChar>::iterator endFormat,
-                         float size, Math::Point pos, TextAlign align,
+    void        SizeText(const std::string &text,
+                         const std::vector<FontMetaChar>::iterator format,
+                         const std::vector<FontMetaChar>::iterator endFormat,
+                         const float size,
+                         const Math::Point pos,
+                         const TextAlign align,
                          Math::Point &start, Math::Point &end);
     //! Calculates dimensions for text (one font)
-    void        SizeText(const std::string &text, FontType font,
-                         float size, Math::Point pos, TextAlign align,
-                         Math::Point &start, Math::Point &end);
+    void        SizeText(const std::string &text,
+                         const FontType font,
+                         const float size,
+                         const Math::Point pos,
+                         const TextAlign align,
+                         Math::Point &start,
+                         Math::Point &end);
 
     //! Returns the ascent font metric
-    float       GetAscent(FontType font, float size);
+    float       GetAscent(const FontType font, const float size);
     //! Returns the descent font metric
-    float       GetDescent(FontType font, float size);
+    float       GetDescent(const FontType font, const float size);
     //! Returns the height font metric
-    float       GetHeight(FontType font, float size);
-    int GetHeightInt(FontType font, float size);
+    float       GetHeight(const FontType font, const float size);
+    int         GetHeightInt(const FontType font, const float size);
 
     //! Returns width of string (multi-format)
     TEST_VIRTUAL float GetStringWidth(const std::string& text,
-                                      std::vector<FontMetaChar>::iterator format,
-                                      std::vector<FontMetaChar>::iterator end, float size);
+                                      const std::vector<FontMetaChar>::iterator format,
+                                      const std::vector<FontMetaChar>::iterator end,
+                                      const float size);
     //! Returns width of string (single font)
-    TEST_VIRTUAL float GetStringWidth(std::string text, FontType font, float size);
+    TEST_VIRTUAL float GetStringWidth(std::string text, const FontType font, const float size);
     //! Returns width of single character
-    TEST_VIRTUAL float GetCharWidth(UTF8Char ch, FontType font, float size, float offset);
-    int GetCharWidthInt(UTF8Char ch, FontType font, float size, float offset);
+    TEST_VIRTUAL float GetCharWidth(UTF8Char ch, const FontType font, const float size, const float offset);
+    int GetCharWidthInt(UTF8Char ch, const FontType font, const float size, const float offset);
 
     //! Justifies a line of text (multi-format)
-    int         Justify(const std::string &text, std::vector<FontMetaChar>::iterator format,
-                        std::vector<FontMetaChar>::iterator end,
-                        float size, float width);
+    int         Justify(const std::string &text,
+                        const std::vector<FontMetaChar>::iterator format,
+                        const std::vector<FontMetaChar>::iterator end,
+                        const float size,
+                        const float width);
     //! Justifies a line of text (one font)
-    int         Justify(const std::string &text, FontType font, float size, float width);
+    int         Justify(const std::string &text,
+                        const FontType font,
+                        const float size,
+                        const float width);
 
     //! Returns the most suitable position to a given offset (multi-format)
-    int         Detect(const std::string &text, std::vector<FontMetaChar>::iterator format,
-                       std::vector<FontMetaChar>::iterator end,
-                       float size, float offset);
+    int         Detect(const std::string &text,
+                       const std::vector<FontMetaChar>::iterator format,
+                       const std::vector<FontMetaChar>::iterator end,
+                       const float size,
+                       const float offset);
     //! Returns the most suitable position to a given offset (one font)
-    int         Detect(const std::string &text, FontType font, float size, float offset);
+    int         Detect(const std::string &text,
+                       const FontType font,
+                       const float size,
+                       const float offset);
 
-    UTF8Char    TranslateSpecialChar(int specialChar);
+    UTF8Char    TranslateSpecialChar(const char specialChar) const;
 
-    CharTexture GetCharTexture(UTF8Char ch, FontType font, float size);
-    Math::IntPoint GetFontTextureSize();
+    CharTexture GetCharTexture(const UTF8Char ch, const FontType font, const float size);
+    Math::IntPoint GetFontTextureSize() const;
 
 protected:
-    CachedFont* GetOrOpenFont(FontType font, float size);
+    CachedFont* GetOrOpenFont(const FontType font, const float size);
     CharTexture CreateCharTexture(UTF8Char ch, CachedFont* font);
     FontTexture* GetOrCreateFontTexture(Math::IntPoint tileSize);
     FontTexture CreateFontTexture(Math::IntPoint tileSize);
@@ -333,7 +381,7 @@ protected:
     void        DrawString(const std::string &text, FontType font,
                            float size, Math::IntPoint pos, int width, int eol, Color color);
     void        DrawHighlight(FontMetaChar hl, Math::IntPoint pos, Math::IntPoint size);
-    void        DrawCharAndAdjustPos(UTF8Char ch, FontType font, float size, Math::IntPoint &pos, Color color);
+    void        DrawCharAndAdjustPos(UTF8Char ch, const FontType font, const float size, Math::IntPoint &pos, Color color);
     void        StringToUTFCharList(const std::string &text, std::vector<UTF8Char> &chars);
     void        StringToUTFCharList(const std::string &text, std::vector<UTF8Char> &chars, std::vector<FontMetaChar>::iterator format, std::vector<FontMetaChar>::iterator end);
 

--- a/src/math/func.h
+++ b/src/math/func.h
@@ -110,18 +110,11 @@ inline float Norm(float a)
     return a;
 }
 
-//! Swaps two integers
-inline void Swap(int &a, int &b)
+//! Swaps two integers or real numbers (float, int, size_t...)
+    template<typename T>
+inline void Swap(T& a, T& b)
 {
-    int c = a;
-    a = b;
-    b = c;
-}
-
-//! Swaps two real numbers
-inline void Swap(float &a, float &b)
-{
-    float c = a;
+    T c = a;
     a = b;
     b = c;
 }

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -76,9 +76,9 @@ public:
     void        Stop();
     bool        IsRunning();
     bool        IsContinue();
-    bool        GetCursor(int &cursor1, int &cursor2);
+    bool        GetCursor(std::size_t& cursor1, std::size_t& cursor2) const;
     void        UpdateList(Ui::CList* list);
-    static void ColorizeScript(Ui::CEdit* edit, int rangeStart = 0, int rangeEnd = std::numeric_limits<int>::max());
+    static void ColorizeScript(Ui::CEdit* edit, std::size_t rangeStart = 0, std::size_t rangeEnd = SIZE_MAX); //std::numeric_limits<std::size_t>::max()
     bool        IntroduceVirus();
 
     int         GetError();
@@ -113,7 +113,7 @@ protected:
 
     int     m_ipf = 0;          // number of instructions/second
     int     m_errMode = 0;      // what to do in case of error
-    int     m_len = 0;          // length of the script (without <0>)
+    std::size_t m_len = 0;          // length of the script (without <0>)
     std::unique_ptr<char[]> m_script;       // script ends with <0>
     bool    m_bRun = false;         // program during execution?
     bool    m_bStepMode = false;        // step by step
@@ -125,7 +125,7 @@ protected:
     std::string m_token = "";        // missing instruction
     int m_tokenUsed = 0, m_tokenAllowed = 0;
     CBot::CBotError m_error = CBot::CBotNoErr;        // error (0=ok)
-    int     m_cursor1 = 0;
-    int     m_cursor2 = 0;
+    std::size_t m_cursor1 = 0;
+    std::size_t m_cursor2 = 0;
     boost::optional<float> m_returnValue = boost::none;
 };

--- a/src/ui/controls/edit.h
+++ b/src/ui/controls/edit.h
@@ -121,7 +121,7 @@ public:
 
     void        SetText(const std::string& text, bool bNew=true);
     std::string GetText(std::size_t max) const;
-    const std::string& GetText();
+    const std::string& GetText() const;
     std::size_t GetTextLength() const;
 
     bool        ReadText(std::string filename);
@@ -201,10 +201,16 @@ protected:
     void        MoveChar(int move, bool bWord, bool bSelect);
     void        MoveLine(int move, bool bWord, bool bSelect);
     void        MoveHome(bool bWord, bool bSelect);
-    void        MoveEnd(bool bWord, bool bSelect);
+    void        MoveEnd(bool bEof, bool bSelect);
     void        ColumnFix();
     void        Insert(char character);
     void        InsertOne(char character);
+    // Inserts a string (ended by a null char)
+    void InsertTxt(const char* str);
+    inline void InsertTxt(const std::string& str)
+    {
+        InsertTxt(str.c_str());
+    }
     void        Delete(int dir);
     void        DeleteOne(int dir);
     void        DeleteWord(int dir);

--- a/src/ui/controls/edit.h
+++ b/src/ui/controls/edit.h
@@ -45,11 +45,11 @@ struct EditUndo
     //! original text
     std::string text;
     //! length of the text
-    int     len = 0;
+    std::size_t len = 0;
     //! offset cursor
-    int     cursor1 = 0;
+    std::size_t cursor1 = 0;
     //! offset cursor
-    int     cursor2 = 0;
+    std::size_t cursor2 = 0;
     //! the first line displayed.
     int     lineFirst = 0;
 
@@ -90,7 +90,7 @@ struct HyperMarker
     //! name of the marker
     std::string    name;
     //! position in the text
-    int pos = 0;
+    std::size_t    pos = 0;
 };
 
 struct HyperHistory
@@ -119,16 +119,16 @@ public:
     bool        EventProcess(const Event &event) override;
     void        Draw() override;
 
-    void               SetText(const std::string& text, bool bNew=true);
-    std::string        GetText(int max);
+    void        SetText(const std::string& text, bool bNew=true);
+    std::string GetText(std::size_t max) const;
     const std::string& GetText();
-    int                GetTextLength();
+    std::size_t GetTextLength() const;
 
     bool        ReadText(std::string filename);
     bool        WriteText(std::string filename);
 
-    void        SetMaxChar(int max);
-    int         GetMaxChar();
+    void        SetMaxChar(const std::size_t max);
+    std::size_t GetMaxChar() const;
 
     void        SetEditCap(bool bMode);
     bool        GetEditCap();
@@ -148,8 +148,8 @@ public:
     void        SetAutoIndent(bool bMode);
     bool        GetAutoIndent();
 
-    void        SetCursor(int cursor1, int cursor2);
-    void        GetCursor(int &cursor1, int &cursor2);
+    void        SetCursor(std::size_t cursor1, std::size_t cursor2);
+    void        GetCursor(std::size_t &cursor1, std::size_t &cursor2) const;
 
     void        SetFirstLine(int rank);
     int         GetFirstLine();
@@ -174,7 +174,7 @@ public:
     void        SetFontSize(float size) override;
 
     bool        ClearFormat();
-    bool        SetFormat(int cursor1, int cursor2, int format);
+    bool        SetFormat(const std::size_t cursor1, const std::size_t cursor2, const int format);
 
 protected:
     void        SendModifEvent();
@@ -183,7 +183,7 @@ protected:
     void        MouseClick(Math::Point mouse);
     void        MouseMove(Math::Point mouse);
     void        MouseRelease(Math::Point mouse);
-    int         MouseDetect(Math::Point mouse);
+    std::size_t MouseDetect(Math::Point mouse);
     void        MoveAdjust();
 
     void        HyperJump(std::string name, std::string marker);
@@ -196,7 +196,7 @@ protected:
     void        DrawColor(Math::Point pos, Math::Point dim, Gfx::Color color);
 
     void        FreeImage();
-    void        Scroll(int pos, bool bAdjustCursor);
+    void        Scroll(const std::size_t pos, const bool bAdjustCursor);
     void        Scroll();
     void        MoveChar(int move, bool bWord, bool bSelect);
     void        MoveLine(int move, bool bWord, bool bSelect);
@@ -214,7 +214,7 @@ protected:
     bool        Shift(bool bLeft);
     bool        MinMaj(bool bMaj);
     void        Justif();
-    int         GetCursorLine(int cursor);
+    int         GetCursorLine(const std::size_t cursor) const;
 
     void        UndoFlush();
     void        UndoMemorize(OperUndo oper);
@@ -225,17 +225,17 @@ protected:
     void        SetFocus(CControl* control) override;
     void        UpdateFocus();      // Start/stop text input mode, this toggles the on-screen keyboard
 
-    void        GetIndentedText(std::ostream& stream, unsigned int start, unsigned int end);
+    void        GetIndentedText(std::ostream& stream, const std::size_t start, const std::size_t end);
 
 protected:
     std::unique_ptr<CScroll> m_scroll;           // vertical scrollbar on the right
 
-    int m_maxChar;
+    std::size_t m_maxChar;
     std::string m_text;             // text (without zero terminator)
     std::vector<Gfx::FontMetaChar> m_format;           // format characters
-    int     m_len;              // length used in m_text
-    int     m_cursor1;          // offset cursor
-    int     m_cursor2;          // offset cursor
+    std::size_t m_len;              // length used in m_text
+    std::size_t m_cursor1;          // offset cursor
+    std::size_t m_cursor2;          // offset cursor
 
     bool        m_bMulti;           // true -> multi-line
     bool        m_bEdit;            // true -> editable
@@ -252,7 +252,7 @@ protected:
     int     m_lineVisible;          // total number of viewable lines
     int     m_lineFirst;            // the first line displayed
     int     m_lineTotal;            // number lines used (in m_lineOffset)
-    std::vector<int> m_lineOffset;
+    std::vector<std::size_t> m_lineOffset;
     std::vector<char> m_lineIndent;
     std::vector<ImageLine> m_image;
     std::vector<HyperLink> m_link;

--- a/src/ui/displayinfo.cpp
+++ b/src/ui/displayinfo.cpp
@@ -784,8 +784,7 @@ void CDisplayInfo::UpdateCopyButton()
     Ui::CWindow*    pw;
     Ui::CButton*    button;
     Ui::CEdit*      edit;
-    int         c1, c2;
-
+    std::size_t     c1, c2;
 //? if ( m_index != SATCOM_LOADING )  return;
 
     pw = static_cast<Ui::CWindow*>(m_interface->SearchControl(EVENT_WINDOW4));
@@ -851,8 +850,7 @@ void CDisplayInfo::StopDisplayInfo()
 
 
 // Specifies the position.
-
-void CDisplayInfo::SetPosition(int pos)
+void CDisplayInfo::SetPosition(const std::size_t pos)
 {
     Ui::CWindow*        pw;
     Ui::CEdit*          edit;
@@ -867,8 +865,7 @@ void CDisplayInfo::SetPosition(int pos)
 }
 
 // Returns the position.
-
-int CDisplayInfo::GetPosition()
+std::size_t CDisplayInfo::GetPosition() const
 {
     Ui::CWindow*        pw;
     Ui::CEdit*          edit;

--- a/src/ui/displayinfo.h
+++ b/src/ui/displayinfo.h
@@ -54,8 +54,8 @@ public:
     void        StartDisplayInfo(std::string filename, int index, bool bSoluce);
     void        StopDisplayInfo();
 
-    void        SetPosition(int pos);
-    int         GetPosition();
+    void        SetPosition(const std::size_t pos);
+    std::size_t GetPosition() const;
 
 protected:
     bool        EventFrame(const Event &event);

--- a/src/ui/studio.cpp
+++ b/src/ui/studio.cpp
@@ -338,7 +338,7 @@ bool CStudio::EventFrame(const Event &event)
     CEdit*      edit;
     CList*      list;
     float       time;
-    int         cursor1, cursor2, iCursor1, iCursor2;
+    std::size_t cursor1, cursor2, iCursor1, iCursor2;
 
     m_time += event.rTime;
     m_fixInfoTextTime -= event.rTime;
@@ -435,24 +435,23 @@ static bool IsToken(char c)
 void CStudio::SearchToken(CEdit* edit)
 {
     ObjectType  type;
-    int         len, cursor1, cursor2, i, character, level;
     std::string text;
     std::string token( 100, '\0');
 
     text = edit->GetText();
-    len  = edit->GetTextLength();
+    std::size_t len  = edit->GetTextLength();
+    std::size_t cursor1, cursor2;
     edit->GetCursor(cursor1, cursor2);
-
-    i = cursor1;
+    std::size_t i = cursor1;
     if ( i > 0 )
     {
-        character = static_cast< unsigned char > (text[i-1]);
-        if ( !IsToken(character) )
+        if ( !IsToken(text[i-1]) )
         {
-            level = 1;
+            int level = 1;
+            char character;
             while ( i > 0 )
             {
-                character = static_cast< unsigned char > (text[i-1]);
+                character = text[i-1];
                 if ( character == ')' )
                 {
                     level ++;
@@ -462,7 +461,7 @@ void CStudio::SearchToken(CEdit* edit)
                     level --;
                     if ( level == 0 )  break;
                 }
-                i --;
+                --i;
             }
             if ( level > 0 )
             {
@@ -472,26 +471,26 @@ void CStudio::SearchToken(CEdit* edit)
             }
             while ( i > 0 )
             {
-                character = static_cast< unsigned char > (text[i-1]);
-                if ( IsToken(character) )  break;
-                i --;
+                if ( IsToken(text[i-1]) )
+                    break;
+                --i;
             }
         }
     }
 
     while ( i > 0 )
     {
-        character = static_cast< unsigned char > (text[i-1]);
-        if ( !IsToken(character) )  break;
-        i --;
+        if ( !IsToken(text[i-1]) )
+            break;
+        --i;
     }
     cursor2 = i;
 
     while ( i < len )
     {
-        character = static_cast< unsigned char > (text[i]);
-        if ( !IsToken(character) )  break;
-        i ++;
+        if ( !IsToken(text[i]) )
+            break;
+        ++i;
     }
     cursor1 = i;
     len = cursor1-cursor2;
@@ -1513,8 +1512,7 @@ void CStudio::UpdateDialogAction()
     CWindow*    pw;
     CEdit*      pe;
     CButton*    pb;
-    std::string        name;
-    int         len, i;
+    std::string name;
     bool        bError;
 
     pw = static_cast< CWindow* >(m_interface->SearchControl(EVENT_WINDOW9));
@@ -1525,7 +1523,7 @@ void CStudio::UpdateDialogAction()
     if ( pb == nullptr )  return;
 
     name = pe->GetText(100);
-    len = name.size();
+    std::size_t len = name.size();
     if ( len == 0 )
     {
         bError = true;
@@ -1533,7 +1531,7 @@ void CStudio::UpdateDialogAction()
     else
     {
         bError = false;
-        for ( i=0 ; i<len ; i++ )
+        for (std::size_t i=0 ; i<len ; i++ )
         {
             if ( name[i] == '*'  ||
                  name[i] == '?'  ||
@@ -1638,9 +1636,8 @@ bool CStudio::ReadProgram()
 {
     CWindow*    pw;
     CEdit*      pe;
-    std::string        filename;
-    std::string        dir;
-    size_t p;
+    std::string filename;
+    std::string dir;
 
     pw = static_cast< CWindow* >(m_interface->SearchControl(EVENT_WINDOW9));
     if ( pw == nullptr )  return false;
@@ -1650,7 +1647,7 @@ bool CStudio::ReadProgram()
     filename = pe->GetText(100);
     if ( filename.empty() )  return false;
 
-    p = filename.find(".txt");
+    std::size_t p = filename.find(".txt");
     if ( p == std::string::npos )
     {
         filename += ".txt";
@@ -1676,10 +1673,8 @@ bool CStudio::WriteProgram()
 {
     CWindow*    pw;
     CEdit*      pe;
-    std::string        filename;
-    std::string        dir;
-    size_t p;
-
+    std::string filename;
+    std::string dir;
     pw = static_cast< CWindow* >(m_interface->SearchControl(EVENT_WINDOW9));
     if ( pw == nullptr )  return false;
 
@@ -1688,7 +1683,7 @@ bool CStudio::WriteProgram()
     filename = pe->GetText(100);
     if ( filename.empty() )  return false;
 
-    p = filename.find(".txt");
+    std::size_t p = filename.find(".txt");
     if ( p == std::string::npos )
     {
         filename += ".txt";

--- a/test/cbot/compile_graph.cpp
+++ b/test/cbot/compile_graph.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[])
     if (!program->Compile(code.c_str(), externFunctions, nullptr))
     {
         CBotError error;
-        int cursor1, cursor2;
+        std::size_t cursor1, cursor2;
         program->GetError(error, cursor1, cursor2);
         std::cerr << "COMPILE ERROR: " << error << " @ " << cursor1 << " - " << cursor2 << std::endl;
         return 1;

--- a/test/cbot/console.cpp
+++ b/test/cbot/console.cpp
@@ -76,7 +76,7 @@ int main(int argc, char* argv[])
     if (!program->Compile(code.c_str(), externFunctions, nullptr))
     {
         CBotError error;
-        int cursor1, cursor2;
+        std::size_t cursor1, cursor2;
         program->GetError(error, cursor1, cursor2);
         std::string errorStr;
         GetResource(RES_CBOT, error, errorStr);
@@ -104,7 +104,7 @@ int main(int argc, char* argv[])
         while (!program->Run(nullptr)); // Run the program
 
         CBotError error;
-        int cursor1, cursor2;
+        std::size_t cursor1, cursor2;
         program->GetError(error, cursor1, cursor2);
         if (error != 0)
         {

--- a/test/unit/CBot/CBot_test.cpp
+++ b/test/unit/CBot/CBot_test.cpp
@@ -47,14 +47,15 @@ private:
         {
         }
 
-        CBotTestFail(std::string message, int cursor1, int cursor2) : CBotTestFail(message)
+        CBotTestFail(std::string message, std::size_t cursor1, std::size_t cursor2)
+            : CBotTestFail(message)
         {
             this->cursor1 = cursor1;
             this->cursor2 = cursor2;
         }
 
-        int cursor1 = -1;
-        int cursor2 = -1;
+        std::size_t cursor1 = SIZE_MAX;
+        std::size_t cursor2 = SIZE_MAX;
     };
 
     static CBotTypResult cFail(CBotVar* &var, void* user)
@@ -208,7 +209,7 @@ protected:
         program->Compile(code, tests);
 
         CBotError error;
-        int cursor1, cursor2;
+        std::size_t cursor1 = 0, cursor2 = 0;
         program->GetError(error, cursor1, cursor2);
         if (error != expectedCompileError)
         {


### PR DESCRIPTION
Fix #477 & #1003
Fix caret moves and selections
Fix also huge text limits (uniformation of size_t for size management) (separated commit)

UTF8 can comes from files, keyboard & paste.

The internal UTF8 storage is now fully managed.
Some still "bad displayed characters" let depends now only from the font possibilities :
that can be controlled thanks to web font viewer like : http://mathew-kurian.github.io/CharacterMap/

( cleaned elements from #1116 )