### PR TITLE
Fix OpenGL specular lighting

### DIFF
--- a/src/graphics/opengl/gl21device.cpp
+++ b/src/graphics/opengl/gl21device.cpp
@@ -388,6 +388,7 @@ bool CGL21Device::Create()
         uni.modelMatrix = glGetUniformLocation(m_normalProgram, "uni_ModelMatrix");
         uni.normalMatrix = glGetUniformLocation(m_normalProgram, "uni_NormalMatrix");
         uni.shadowMatrix = glGetUniformLocation(m_normalProgram, "uni_ShadowMatrix");
+        uni.cameraPosition = glGetUniformLocation(m_normalProgram, "uni_CameraPosition");
 
         uni.primaryTexture = glGetUniformLocation(m_normalProgram, "uni_PrimaryTexture");
         uni.secondaryTexture = glGetUniformLocation(m_normalProgram, "uni_SecondaryTexture");
@@ -441,6 +442,7 @@ bool CGL21Device::Create()
         glUniformMatrix4fv(uni.modelMatrix, 1, GL_FALSE, matrix.Array());
         glUniformMatrix4fv(uni.normalMatrix, 1, GL_FALSE, matrix.Array());
         glUniformMatrix4fv(uni.shadowMatrix, 1, GL_FALSE, matrix.Array());
+        glUniform3f(uni.cameraPosition, 0.0f, 0.0f, 0.0f);
 
         glUniform1i(uni.primaryTexture, 0);
         glUniform1i(uni.secondaryTexture, 1);
@@ -653,6 +655,7 @@ void CGL21Device::SetTransform(TransformType type, const Math::Matrix &matrix)
     else if (type == TRANSFORM_VIEW)
     {
         Math::Matrix scale;
+        Math::Vector cameraPosition;
         scale.Set(3, 3, -1.0f);
         m_viewMat = Math::MultiplyMatrices(scale, matrix);
 
@@ -660,6 +663,12 @@ void CGL21Device::SetTransform(TransformType type, const Math::Matrix &matrix)
         m_combinedMatrix = Math::MultiplyMatrices(m_projectionMat, m_modelviewMat);
 
         glUniformMatrix4fv(m_uniforms[m_mode].viewMatrix, 1, GL_FALSE, m_viewMat.Array());
+
+        if (m_uniforms[m_mode].cameraPosition >= 0) {
+            cameraPosition.LoadZero();
+            cameraPosition = MatrixVectorMultiply(m_viewMat.Inverse(), cameraPosition);
+            glUniform3fv(m_uniforms[m_mode].cameraPosition, 1, cameraPosition.Array());
+        }
     }
     else if (type == TRANSFORM_PROJECTION)
     {

--- a/src/graphics/opengl/gl33device.cpp
+++ b/src/graphics/opengl/gl33device.cpp
@@ -363,6 +363,7 @@ bool CGL33Device::Create()
         uni.modelMatrix = glGetUniformLocation(m_normalProgram, "uni_ModelMatrix");
         uni.normalMatrix = glGetUniformLocation(m_normalProgram, "uni_NormalMatrix");
         uni.shadowMatrix = glGetUniformLocation(m_normalProgram, "uni_ShadowMatrix");
+        uni.cameraPosition = glGetUniformLocation(m_normalProgram, "uni_CameraPosition");
 
         uni.primaryTexture = glGetUniformLocation(m_normalProgram, "uni_PrimaryTexture");
         uni.secondaryTexture = glGetUniformLocation(m_normalProgram, "uni_SecondaryTexture");
@@ -420,6 +421,7 @@ bool CGL33Device::Create()
         glUniformMatrix4fv(uni.modelMatrix, 1, GL_FALSE, matrix.Array());
         glUniformMatrix4fv(uni.normalMatrix, 1, GL_FALSE, matrix.Array());
         glUniformMatrix4fv(uni.shadowMatrix, 1, GL_FALSE, matrix.Array());
+        glUniform3f(uni.cameraPosition, 0.0f, 0.0f, 0.0f);
 
         glUniform1i(uni.primaryTexture, 0);
         glUniform1i(uni.secondaryTexture, 1);
@@ -660,6 +662,7 @@ void CGL33Device::SetTransform(TransformType type, const Math::Matrix &matrix)
     else if (type == TRANSFORM_VIEW)
     {
         Math::Matrix scale;
+        Math::Vector cameraPosition;
         scale.Set(3, 3, -1.0f);
         m_viewMat = Math::MultiplyMatrices(scale, matrix);
 
@@ -667,6 +670,12 @@ void CGL33Device::SetTransform(TransformType type, const Math::Matrix &matrix)
         m_combinedMatrixOutdated = true;
 
         glUniformMatrix4fv(m_uni->viewMatrix, 1, GL_FALSE, m_viewMat.Array());
+
+        if (m_uni->cameraPosition >= 0) {
+            cameraPosition.LoadZero();
+            cameraPosition = MatrixVectorMultiply(m_viewMat.Inverse(), cameraPosition);
+            glUniform3fv(m_uni->cameraPosition, 1, cameraPosition.Array());
+        }
     }
     else if (type == TRANSFORM_PROJECTION)
     {

--- a/src/graphics/opengl/glutil.h
+++ b/src/graphics/opengl/glutil.h
@@ -167,6 +167,8 @@ struct UniformLocations
     GLint shadowMatrix = -1;
     //! Normal matrix
     GLint normalMatrix = -1;
+    //! Camera position
+    GLint cameraPosition = -1;
 
     //! Primary texture sampler
     GLint primaryTexture = -1;

--- a/src/graphics/opengl/shaders/gl21/fs_normal.glsl
+++ b/src/graphics/opengl/shaders/gl21/fs_normal.glsl
@@ -56,6 +56,7 @@ uniform Material uni_Material;
 uniform int uni_LightCount;
 uniform LightParams uni_Light[4];
 
+varying vec3 pass_CameraDirection;
 varying float pass_Distance;
 varying vec4 pass_Color;
 varying vec3 pass_Normal;
@@ -76,16 +77,17 @@ void main()
         vec4 specular = vec4(0.0f);
 
         vec3 normal = normalize(pass_Normal);
+        vec3 camera = normalize(pass_CameraDirection);
 
         for (int i = 0; i < uni_LightCount; i++)
         {
             LightParams light = uni_Light[i];
 
-            vec3 lightDirection = light.Position.xyz;
-            vec3 reflectDirection = -reflect(lightDirection, normal);
+            vec3 lightDirection = normalize(light.Position.xyz);
+            vec3 reflectAxis = normalize(lightDirection + camera);
 
             float diffuseComponent = clamp(dot(normal, lightDirection), 0.0f, 1.0f);
-            float specularComponent = clamp(pow(dot(normal, lightDirection + reflectDirection), 10.0f), 0.0f, 1.0f);
+            float specularComponent = pow(clamp(dot(normal, reflectAxis), 0.0f, 1.0f), 10.0f);
 
             ambient += light.Ambient;
             diffuse += diffuseComponent * light.Diffuse;

--- a/src/graphics/opengl/shaders/gl21/vs_normal.glsl
+++ b/src/graphics/opengl/shaders/gl21/vs_normal.glsl
@@ -24,7 +24,9 @@ uniform mat4 uni_ViewMatrix;
 uniform mat4 uni_ModelMatrix;
 uniform mat4 uni_ShadowMatrix;
 uniform mat4 uni_NormalMatrix;
+uniform vec3 uni_CameraPosition;
 
+varying vec3 pass_CameraDirection;
 varying float pass_Distance;
 varying vec4 pass_Color;
 varying vec3 pass_Normal;
@@ -40,6 +42,7 @@ void main()
 
     gl_Position = uni_ProjectionMatrix * eyeSpace;
 
+    pass_CameraDirection = uni_CameraPosition - position.xyz;
     pass_Color = gl_Color;
     pass_Normal = normalize((uni_NormalMatrix * vec4(gl_Normal, 0.0f)).xyz);
     pass_Distance = abs(eyeSpace.z / eyeSpace.w);

--- a/src/graphics/opengl/shaders/gl33/fs_normal.glsl
+++ b/src/graphics/opengl/shaders/gl33/fs_normal.glsl
@@ -63,6 +63,7 @@ in VertexData
     vec4 ShadowCoord;
     vec4 LightColor;
     float Distance;
+    vec3 CameraDirection;
 } data;
 
 out vec4 out_FragColor;
@@ -78,17 +79,17 @@ void main()
         vec4 specular = vec4(0.0f);
 
         vec3 normal = normalize(data.Normal);
+        vec3 camera = normalize(data.CameraDirection);
 
         for (int i = 0; i < uni_LightCount; i++)
         {
-            vec3 lightDirection = uni_Light[i].Position.xyz;
-
-            vec3 reflectDirection = -reflect(lightDirection, normal);
+            vec3 lightDirection = normalize(uni_Light[i].Position.xyz);
+            vec3 reflectAxis = normalize(lightDirection + camera);
 
             ambient += uni_Light[i].Ambient;
             diffuse += clamp(dot(normal, lightDirection), 0.0f, 1.0f)
                     * uni_Light[i].Diffuse;
-            specular += clamp(pow(dot(normal, lightDirection + reflectDirection), 10.0f), 0.0f, 1.0f)
+            specular += pow(clamp(dot(normal, reflectAxis), 0.0f, 1.0f), 10.0f)
                     * uni_Light[i].Specular;
         }
 

--- a/src/graphics/opengl/shaders/gl33/vs_normal.glsl
+++ b/src/graphics/opengl/shaders/gl33/vs_normal.glsl
@@ -25,6 +25,7 @@ uniform mat4 uni_ViewMatrix;
 uniform mat4 uni_ModelMatrix;
 uniform mat4 uni_ShadowMatrix;
 uniform mat4 uni_NormalMatrix;
+uniform vec3 uni_CameraPosition;
 
 layout(location = 0) in vec4 in_VertexCoord;
 layout(location = 1) in vec3 in_Normal;
@@ -41,6 +42,7 @@ out VertexData
     vec4 ShadowCoord;
     vec4 LightColor;
     float Distance;
+    vec3 CameraDirection;
 } data;
 
 void main()
@@ -56,4 +58,5 @@ void main()
     data.Normal = normalize((uni_NormalMatrix * vec4(in_Normal, 0.0f)).xyz);
     data.ShadowCoord = vec4(shadowCoord.xyz / shadowCoord.w, 1.0f);
     data.Distance = abs(eyeSpace.z);
+    data.CameraDirection = uni_CameraPosition - position.xyz;
 }


### PR DESCRIPTION
I've taken a look at GL shaders in Colobot recently and I've noticed that the specular lighting calculation is completely broken. Every single fragment gets specular light component equal to 1 regardless of light direction and camera position. Fortunately, the problem is hidden for now because every single material in the game has specular reflection of (0; 0; 0).

This pull request fixes specular lighting calculation in OpenGL 2.1 renderer. The same fix needs to be applied to OpenGL 3.3 renderer but unfortunately it's not a trivial copy-paste and my Intel GPU only supports OpenGL 3.0 so I wouldn't even be able to compile the shaders to check for syntax errors.

You can force enable specular lighting for testing by editing `src/graphics/opengl/shaders/gl21/fs_normal.glsl` and temporarily deleting the multiplication by `uni_Material.specular` on line 118. There are some outstanding issues with light sources in game data which sometimes have vertical direction of 0 (so they're effectively in the horizontal plane relative to camera position). This produces visual artifacts like below:

![colobot-specular](https://user-images.githubusercontent.com/1794396/60540601-d7141a80-9d0f-11e9-84c4-d6ab9e44ff70.png)

While this would be a perfectly valid specular effect for a light source close above horizon (like a sunrise or sunset), the problem is that the light source here is actually below horizon and it's shining through the terrain. The light source is located infinitely far away at the tip of the 2D "light cone". Changing the vertical direction of the light source in level definition file fixes these artifacts.