### PR TITLE
Detect invalid values in StringUtils::Utf8CharSizeAt()

### DIFF
--- a/src/common/stringutils.cpp
+++ b/src/common/stringutils.cpp
@@ -173,14 +173,19 @@ int StrUtils::Utf8CharSizeAt(const std::string &str, unsigned int pos)
     if (pos >= str.size())
         return 0;
 
-    if ((str[pos] & 0x80) == 0)
-        return 1;
-    else if ((str[pos] & 0xC0) == 0xC0)
-        return 2;
-    else
+    const char c = str[pos];
+    if(c >= 0xF0)
+        return 4;
+    if(c >= 0xE0)
         return 3;
+    if(c >= 0xC0)
+        return 2;
 
-    return 0;
+    // Invalid char - unexpected continuation byte
+    if(c >= 0x80)
+        return 0;
+    
+    return 1;
 }
 
 std::size_t StrUtils::Utf8StringLength(const std::string &str)

--- a/src/common/stringutils.cpp
+++ b/src/common/stringutils.cpp
@@ -22,6 +22,7 @@
 
 #include <cstdarg>
 #include <cstdio>
+#include <stdexcept>
 #include <vector>
 
 
@@ -183,7 +184,7 @@ int StrUtils::Utf8CharSizeAt(const std::string &str, unsigned int pos)
 
     // Invalid char - unexpected continuation byte
     if(c >= 0x80)
-        return 0;
+        throw new std::invalid_argument("Unexpected UTF-8 continuation byte");
     
     return 1;
 }


### PR DESCRIPTION
This changeset fixes the `StrUtils::Utf8CharSizeAt()` method not recognizing UTF-8 continuation bytes and erroneously returning `3` for those.

Related to issue #1268.