### PR TITLE
Fix build on ARM and PPC

### DIFF
--- a/src/object/task/taskgoto.h
+++ b/src/object/task/taskgoto.h
@@ -147,7 +147,7 @@ protected:
     int             m_bmTotal = 0;      // number of points in m_bmPoints
     int             m_bmIndex = 0;      // index in m_bmPoints
     Math::Vector        m_bmPoints[MAXPOINTS+2];
-    char            m_bmIter[MAXPOINTS+2] = {};
+    signed char     m_bmIter[MAXPOINTS+2] = {};
     int             m_bmIterCounter = 0;
     CObject*        m_bmCargoObject = nullptr;
     float           m_bmFinalMove = 0.0f;  // final advance distance


### PR DESCRIPTION
ARM and PPC use unsigned char by default.
Otherwise I get this error:
```
/tmp/usr/ports/games/colobot/work/colobot-colobot-gold-0.1.12-alpha/src/object/task/taskgoto.cpp:1720:22: error: result of comparison of constant -1 with expression of type 'char' is always false [-Werror,-Wtautological-constant-out-of-range-compare]
    if ( m_bmIter[i] == -1 )
         ~~~~~~~~~~~ ^  ~~
1 error generated.
ninja: build stopped: subcommand failed.
```
