### PR TITLE
Fix AppImage builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,7 @@ pipeline {
                                     # Create AppImage
                                     NO_STRIP=1 ./squashfs-root/AppRun -e colobot --output appimage --appdir colobot.AppDir -d desktop/colobot.desktop -i ../../desktop/colobot.svg
                                     #rename AppImage file to avoid "No such file or directory" errors
-                                    find . -maxdepth 1 -type f -name '*AppImage' -name 'Colobot*' -exec sh -c 'x="{}"; mv "$x" "Colobot-x86_64.AppImage"' \;
+                                    find . -maxdepth 1 -type f -name '*AppImage' -name 'Colobot*' -exec sh -c 'x="{}"; mv "$x" "Colobot-x86_64.AppImage"' \\;
                                     chmod +x Colobot-x86_64.AppImage
                                     
                                     # Prepare folder for zip

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,6 +81,8 @@ pipeline {
                                     
                                     # Create AppImage
                                     NO_STRIP=1 ./squashfs-root/AppRun -e colobot --output appimage --appdir colobot.AppDir -d desktop/colobot.desktop -i ../../desktop/colobot.svg
+                                    #rename AppImage file to avoid "No such file or directory" errors
+                                    find . -maxdepth 1 -type f -name '*AppImage' -name 'Colobot*' -exec sh -c 'x="{}"; mv "$x" "Colobot-x86_64.AppImage"' \;
                                     chmod +x Colobot-x86_64.AppImage
                                     
                                     # Prepare folder for zip


### PR DESCRIPTION
AppImage filenames generated by linuxdeploy tool differed from what Jenkins had expected. Because of that whole pipeline reported failure.
Now generated AppImage filename is changed to meet Jenkinsfile expectation, so everything works again.