### PR TITLE
Add missing includes in CBotExprLitString.cpp

### DIFF
--- a/src/CBot/CBotInstr/CBotExprLitString.cpp
+++ b/src/CBot/CBotInstr/CBotExprLitString.cpp
@@ -24,6 +24,8 @@
 
 #include "CBot/CBotVar/CBotVar.h"
 
+#include <stdexcept>
+
 namespace CBot
 {
 


### PR DESCRIPTION
Without this `#include`, GCC 10.0.1 used in Fedora 32 (unreleased yet) complains loudly.

Fixes issue #1289.