### PR TITLE
Fix missing <limits> include

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -27,6 +27,7 @@
 #include "CBot/CBot.h"
 
 #include <memory>
+#include <limits>
 #include <string>
 #include <boost/optional.hpp>
 


### PR DESCRIPTION
Add missing <limits> include for std::numeric_limits.  This fixes
build failure after boost stopped implicitly including it for us.