### PR TITLE
Load dialog improvements

### DIFF
--- a/src/ui/screen/screen_io.cpp
+++ b/src/ui/screen/screen_io.cpp
@@ -157,7 +157,10 @@ void CScreenIO::IOUpdateList(bool isWrite)
     }
 
     if (m_saveList.size() <= static_cast<unsigned int>(sel))
+    {
+        pi->SetFilenameImage(""); // clear screenshot, nothing selected or New save selected
         return;
+    }
 
     std::string filename = m_saveList.at(sel) + "/screen.png";
     if ( isWrite )
@@ -165,10 +168,6 @@ void CScreenIO::IOUpdateList(bool isWrite)
         if ( sel < max-1 )
         {
             pi->SetFilenameImage(filename.c_str());
-        }
-        else
-        {
-            pi->SetFilenameImage("");
         }
     }
     else

--- a/src/ui/screen/screen_io.cpp
+++ b/src/ui/screen/screen_io.cpp
@@ -244,22 +244,24 @@ void CScreenIO::IOWriteScene()
 
 // Reads the scene.
 
-void CScreenIO::IOReadScene()
+bool CScreenIO::IOReadScene()
 {
     CWindow*    pw;
     CList*      pl;
 
     pw = static_cast<CWindow*>(m_interface->SearchControl(EVENT_WINDOW5));
-    if ( pw == nullptr )  return;
+    if ( pw == nullptr )  return false;
     pl = static_cast<CList*>(pw->SearchControl(EVENT_INTERFACE_IOLIST));
-    if ( pl == nullptr )  return;
+    if ( pl == nullptr )  return false;
 
     int sel = pl->GetSelect();
-    if (sel < 0 || sel >= static_cast<int>(m_saveList.size())) return;
+    if (sel < 0 || sel >= static_cast<int>(m_saveList.size())) return false;
 
     m_main->GetPlayerProfile()->LoadScene(m_saveList.at(sel));
 
     m_screenLevelList->SetSelection(m_main->GetLevelCategory(), m_main->GetLevelChap()-1, m_main->GetLevelRank()-1);
+
+    return true;
 }
 
 } // namespace Ui

--- a/src/ui/screen/screen_io.cpp
+++ b/src/ui/screen/screen_io.cpp
@@ -143,6 +143,19 @@ void CScreenIO::IOUpdateList(bool isWrite)
     sel = pl->GetSelect();
     max = pl->GetTotal();
 
+    // enable/disable buttons if we have selected a game
+    pb = static_cast<CButton*>(pw->SearchControl(EVENT_INTERFACE_IODELETE));
+    if ( pb != nullptr )
+    {
+        pb->SetState(STATE_ENABLE, (!isWrite && sel < max) || (isWrite && sel < max - 1));
+    }
+
+    pb = static_cast<CButton*>(pw->SearchControl(EVENT_INTERFACE_IOREAD));
+    if ( pb != nullptr )
+    {
+        pb->SetState(STATE_ENABLE, sel < max);
+    }
+
     if (m_saveList.size() <= static_cast<unsigned int>(sel))
         return;
 
@@ -156,12 +169,6 @@ void CScreenIO::IOUpdateList(bool isWrite)
         else
         {
             pi->SetFilenameImage("");
-        }
-
-        pb = static_cast<CButton*>(pw->SearchControl(EVENT_INTERFACE_IODELETE));
-        if ( pb != nullptr )
-        {
-            pb->SetState(STATE_ENABLE, sel < max-1);
         }
     }
     else

--- a/src/ui/screen/screen_io.h
+++ b/src/ui/screen/screen_io.h
@@ -39,7 +39,7 @@ protected:
     void IOUpdateList(bool isWrite);
     void IODeleteScene();
     void IOWriteScene();
-    void IOReadScene();
+    bool IOReadScene();
 
 protected:
     CScreenLevelList* m_screenLevelList;

--- a/src/ui/screen/screen_io_read.cpp
+++ b/src/ui/screen/screen_io_read.cpp
@@ -168,8 +168,7 @@ bool CScreenIORead::EventProcess(const Event &event)
 
     if ( event.type == EVENT_INTERFACE_IOREAD )
     {
-        IOReadScene();
-        if(m_inSimulation)
+        if(IOReadScene() && m_inSimulation)
         {
             m_main->StopSuspend();
             m_main->ChangePhase(PHASE_SIMUL);


### PR DESCRIPTION
This PR fixes a bug when user presses Load when no savegame is selected. It also disables Load and Delete buttons if no savegame is selected.