### PR TITLE
Prevent game crash on bad savegame title

### DIFF
--- a/src/level/player_profile.cpp
+++ b/src/level/player_profile.cpp
@@ -478,13 +478,20 @@ std::vector<SavedScene> CPlayerProfile::GetSavedSceneList()
     for (auto dir : saveDirs)
     {
         std::string savegameFile = GetSaveFile(dir+"/data.sav");
-        if (CResourceManager::Exists(savegameFile))
+        if (CResourceManager::Exists(savegameFile) && CResourceManager::GetFileSize(savegameFile) > 0)
         {
             CLevelParser levelParser(savegameFile);
             levelParser.Load();
             CLevelParserLine* line = levelParser.GetIfDefined("Created");
             int time = line != nullptr ? line->GetParam("date")->AsInt() : 0;
-            sortedSaveDirs[time] = SavedScene(GetSaveFile(dir), levelParser.Get("Title")->GetParam("text")->AsString());
+            try
+            {
+                sortedSaveDirs[time] = SavedScene(GetSaveFile(dir), levelParser.Get("Title")->GetParam("text")->AsString());
+            }
+            catch (CLevelParserException &e)
+            {
+                GetLogger()->Error("Error trying to load savegame title: %s\n", e.what());
+            }
         }
     }
 

--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -4738,7 +4738,7 @@ bool CRobotMain::IOWriteScene(std::string filename, std::string filecbot, std::s
     }
     catch (CLevelParserException& e)
     {
-        GetLogger()->Error("Failed to save level state - %s\n", e.what());
+        GetLogger()->Error("Failed to save level state - %s\n", e.what()); // TODO add visual error to notify user that save failed
         return false;
     }
 


### PR DESCRIPTION
It was noted in issues #1207 and #1232 that game can crash when savegame does not contain title. This might be a problem when saving game fails and user is informed about it only in console. Proper fix should be a visible error message informing that saving failed. This commit filters invalid savegames from load windows and prevents game crash in narrow cases.