### PR TITLE
Remove dependency on `sed` for simple substitution in CMake

### DIFF
--- a/cmake/replace_in_file.cmake
+++ b/cmake/replace_in_file.cmake
@@ -1,0 +1,37 @@
+# The script replaces all occurences of REGEX_MATCH with the REPLACE_WITH string.
+# The regex rules are like in CMake except the matches are done line by line.
+# The purpose of the script is to remove the dependency on `sed` for simple substitutions.
+# It's not a function so that it can be used in add_custom_command().
+#
+# Parameters:
+# - REGEX_MATCH
+# - REPLACE_WITH
+# - FILE_PATH
+#
+# Example usage:
+#    $ cmake -DREGEX_MATCH="^(Text).*$" -DREPLACE_WITH="\1\1\n" -DFILE_PATH="test.txt" -P replace_in_file.cmake
+# This will change "Text\n" into "TextText\n" in a file "test.txt".
+
+# ^ and $ work on the whole input
+# so we have to split the file by lines in order to have the ^ and $ working like in `sed`
+file(STRINGS "${FILE_PATH}" LINES ENCODING UTF-8)
+
+# Workaround for: lists in CMAKE are broken by the `[` and `]` characters
+#    Replace them before processing and then place them back
+# Caveat: there should not be any placeholder strings in the original file,
+#    or they will be changed to brackets too
+string(REPLACE "[" "COLOBOT_CMAKE_LEFT_SQUARE_BRACKET" LINES "${LINES}")
+string(REPLACE "]" "COLOBOT_CMAKE_RIGHT_SQUARE_BRACKET" LINES "${LINES}")
+
+# Process the file
+set(FILE_STRING_OUT "")
+foreach(LINE IN LISTS LINES)
+    string(REGEX REPLACE "${REGEX_MATCH}" "${REPLACE_WITH}" LINE_OUT "${LINE}")
+    string(APPEND FILE_STRING_OUT "${LINE_OUT}" "\n")
+endforeach()
+
+# Replace the placeholders with brackets before saving
+string(REPLACE "COLOBOT_CMAKE_LEFT_SQUARE_BRACKET" "[" FILE_STRING_OUT "${FILE_STRING_OUT}")
+string(REPLACE "COLOBOT_CMAKE_RIGHT_SQUARE_BRACKET" "]" FILE_STRING_OUT "${FILE_STRING_OUT}")
+
+file(WRITE "${FILE_PATH}" "${FILE_STRING_OUT}")

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -6,13 +6,19 @@ set(_potFile colobot.pot)
 
 # Extract translations
 
-find_program(XGETTEXT_CMD xgettext)
+find_program(XGETTEXT_CMD xgettext REQUIRED)
+
+# xgettext changes the POT-Creation-Date even when there were no changes,
+# which is annoying for version control,
+# so replace this date with a constant string
+set(POT_CREATION_DATE_REGEX_MATCH "^(\"POT-Creation-Date:).*$")
+set(POT_CREATION_DATE_REGEX_REPLACE "\\1 DATE\\\\n\"")
 
 add_custom_command(OUTPUT ${_potFile}
     COMMAND ${XGETTEXT_CMD} ${colobot_SOURCE_DIR}/src/app/app.cpp --output=${_potFile} --no-wrap
     COMMAND ${XGETTEXT_CMD} ${colobot_SOURCE_DIR}/src/common/restext.cpp --output=${_potFile} --no-wrap --join-existing --no-location --keyword=TR
     COMMAND ${XGETTEXT_CMD} ${colobot_SOURCE_DIR}/src/script/script.cpp --output=${_potFile} --no-wrap --join-existing --no-location
-    COMMAND sed -i -e "s|^\\(\"POT-Creation-Date:\\).*$|\\1 DATE\\\\n\"|" ${_potFile}
+    COMMAND ${CMAKE_COMMAND} -DREGEX_MATCH=${POT_CREATION_DATE_REGEX_MATCH} -DREPLACE_WITH=${POT_CREATION_DATE_REGEX_REPLACE} -DFILE_PATH=${_potFile} -P ${colobot_SOURCE_DIR}/cmake/replace_in_file.cmake
 
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Extract translatable messages to ${_potFile}"

--- a/src/common/restext.cpp
+++ b/src/common/restext.cpp
@@ -48,7 +48,7 @@ const char* stringsCbot[CBot::CBotErrMAX]         = { nullptr };
  */
 #define TR(x) x
 
-/* Please run `make update-pot` after changing this file
+/* Please run `cmake --build . --target update-pot` after changing this file
  * in order to update translation files. Thank you.
  */
 


### PR DESCRIPTION
This is part of issue https://github.com/colobot/colobot/issues/1306

The current implementation didn't work for me due to escaping issues, then I discovered that the `sed` binary itself from GnuWin32 is buggy (option `-i` makes it spawn temporary files and they're not removed automatically).

So, yeah, I've just wasted my time implementing a basic `sed` in CMake. But it works at least in the case of `colobot.pot`.

I also added some comments so nobody in the future has to waste their time like me on figuring out what those parts of the scripts do and why.

Also changed the comment in the `restext.cpp` file so it says to use a multiplatform CMake command instead of the unportable `make update-pot` command.