### PR TITLE
Make the update-pot target run automatically

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -19,7 +19,7 @@ add_custom_command(OUTPUT ${_potFile}
     VERBATIM
 )
 
-add_custom_target(update-pot DEPENDS ${_potFile})
+add_custom_target(update-pot ALL DEPENDS ${_potFile})
 
 # Generate translations
 


### PR DESCRIPTION
Because people forget about running it
despite the comment in `restext.cpp`.

If there's a reason it should not be in the ALL target then discuss below.