### PR TITLE
Save audio settings when option changes

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -72,7 +72,6 @@ void CSettings::SaveSettings()
     CRobotMain* main = CRobotMain::GetInstancePointer();
     Gfx::CEngine* engine = Gfx::CEngine::GetInstancePointer();
     Gfx::CCamera* camera = main->GetCamera();
-    CSoundInterface* sound = app->GetSound();
 
     GetConfigFile().SetBoolProperty("Setup", "Tooltips", m_tooltips);
     GetConfigFile().SetBoolProperty("Setup", "InterfaceGlint", m_interfaceGlint);
@@ -80,7 +79,6 @@ void CSettings::SaveSettings()
     GetConfigFile().SetBoolProperty("Setup", "Soluce4", m_soluce4);
     GetConfigFile().SetBoolProperty("Setup", "Movies", m_movies);
     GetConfigFile().SetBoolProperty("Setup", "FocusLostPause", m_focusLostPause);
-    GetConfigFile().SetBoolProperty("Setup", "FocusLostMute", m_focusLostMute);
     GetConfigFile().SetBoolProperty("Setup", "OldCameraScroll", camera->GetOldCameraScroll());
     GetConfigFile().SetBoolProperty("Setup", "CameraInvertX", camera->GetCameraInvertX());
     GetConfigFile().SetBoolProperty("Setup", "CameraInvertY", camera->GetCameraInvertY());
@@ -95,8 +93,6 @@ void CSettings::SaveSettings()
     GetConfigFile().SetIntProperty("Setup", "JoystickIndex", app->GetJoystickEnabled() ? app->GetJoystick().index : -1);
     GetConfigFile().SetFloatProperty("Setup", "ParticleDensity", engine->GetParticleDensity());
     GetConfigFile().SetFloatProperty("Setup", "ClippingDistance", engine->GetClippingDistance());
-    GetConfigFile().SetIntProperty("Setup", "AudioVolume", sound->GetAudioVolume());
-    GetConfigFile().SetIntProperty("Setup", "MusicVolume", sound->GetMusicVolume());
     GetConfigFile().SetBoolProperty("Setup", "EditIndentMode", engine->GetEditIndentMode());
     GetConfigFile().SetIntProperty("Setup", "EditIndentValue", engine->GetEditIndentValue());
     GetConfigFile().SetBoolProperty("Setup", "PauseBlur", engine->GetPauseBlurEnabled());
@@ -111,6 +107,9 @@ void CSettings::SaveSettings()
     GetConfigFile().SetBoolProperty("Setup", "ShadowMappingQuality", engine->GetShadowMappingQuality());
     GetConfigFile().SetIntProperty("Setup", "ShadowMappingResolution",
         engine->GetShadowMappingOffscreen() ? engine->GetShadowMappingOffscreenResolution() : 0);
+
+    // Save Audio settings
+    SaveAudioSettings();
 
     // Experimental settings
     GetConfigFile().SetBoolProperty("Experimental", "TerrainShadows", engine->GetTerrainShadows());
@@ -138,6 +137,16 @@ void CSettings::SaveSettings()
     GetConfigFile().SetStringProperty("Language", "Lang", lang);
 
     GetConfigFile().Save();
+}
+
+void CSettings::SaveAudioSettings()
+{
+    CApplication* app = CApplication::GetInstancePointer();
+    CSoundInterface* sound = app->GetSound();
+
+    GetConfigFile().SetIntProperty("Setup", "AudioVolume", sound->GetAudioVolume());
+    GetConfigFile().SetIntProperty("Setup", "MusicVolume", sound->GetMusicVolume());
+    GetConfigFile().SetBoolProperty("Setup", "FocusLostMute", m_focusLostMute);
 }
 
 void CSettings::LoadSettings()

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -37,6 +37,7 @@ public:
     void SaveSettings();
     void LoadSettings();
 
+    void SaveAudioSettings();
 
     void SetTooltips(bool tooltips);
     bool GetTooltips();

--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -742,7 +742,7 @@ bool CRobotMain::ProcessEvent(Event &event)
             }
             else
             {
-                m_sound->SetMusicVolume(100);
+                m_sound->SetMusicVolume(MAXVOLUME*3/4);
             }
             // Set audio volume
             if (GetConfigFile().GetIntProperty("Setup", "AudioVolume", volume))
@@ -751,7 +751,7 @@ bool CRobotMain::ProcessEvent(Event &event)
             }
             else
             {
-                m_sound->SetAudioVolume(100);
+                m_sound->SetAudioVolume(MAXVOLUME);
             }
         }
 

--- a/src/ui/screen/screen_setup_sound.cpp
+++ b/src/ui/screen/screen_setup_sound.cpp
@@ -173,6 +173,8 @@ void CScreenSetupSound::UpdateSetupButtons()
     {
         pc->SetState(STATE_CHECK, m_settings->GetFocusLostMute());
     }
+
+    m_settings->SaveAudioSettings();
 }
 
 // Updates the engine function of the buttons after the setup phase.
@@ -199,6 +201,8 @@ void CScreenSetupSound::ChangeSetupButtons()
         value = ps->GetVisibleValue();
         m_sound->SetMusicVolume(static_cast<int>(value));
     }
+
+    m_settings->SaveAudioSettings();
 }
 
 } // namespace Ui


### PR DESCRIPTION
Mute/unmute option when game window is in background relies on settings
being updates. This happens when users leaves Options screen. This
commit adds saving audio settings on each change.

This is a fix for #1315