### PR TITLE
Set up GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,93 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: krzysh/colobot-build:latest
+    strategy:
+      matrix:
+        target_os: [windows, linux]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v1
+    - name: Create build directory
+      run: cmake -E make_directory build
+    - name: Run CMake (for Windows using MXE)
+      working-directory: build
+      # FIXME: without -lsetupapi linking sdl2 fails
+      run: /opt/mxe/usr/bin/i686-w64-mingw32.static-cmake -DCMAKE_CXX_STANDARD_LIBRARIES="-lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 -lsetupapi" -DCMAKE_INSTALL_PREFIX=/install -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDEV_BUILD=1 -DPORTABLE=1 -DTOOLS=1 -DTESTS=0 ..
+      if: matrix.target_os == 'windows'
+    - name: Run CMake (for Linux)
+      working-directory: build
+      run: cmake -DCMAKE_INSTALL_PREFIX=/install -DCMAKE_SKIP_INSTALL_RPATH=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDEV_BUILD=1 -DPORTABLE=1 -DTOOLS=1 -DTESTS=1 -DDESKTOP=1 ..
+      if: matrix.target_os == 'linux'
+    - name: Build
+      working-directory: build
+      run: make -j `nproc`
+    - name: Install
+      working-directory: build
+      run: DESTDIR=. make install
+    - name: Patch library path
+      working-directory: build
+      run: patchelf --set-rpath '.' install/colobot
+      if: matrix.target_os == 'linux'
+    - name: Upload build
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{matrix.target_os}}-debug
+        path: build/install
+    - name: Create AppImage
+      working-directory: build
+      run: |
+        # Download app image tool
+        wget -N https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+        chmod +x linuxdeploy-x86_64.AppImage
+        ./linuxdeploy-x86_64.AppImage --appimage-extract
+        
+        # Create AppImage
+        NO_STRIP=1 ./squashfs-root/AppRun -e colobot --output appimage --appdir colobot.AppDir -d desktop/colobot.desktop -i ../desktop/colobot.svg
+        chmod +x Colobot-*-x86_64.AppImage
+        
+        # Prepare folder for zip
+        mkdir -p appimage
+        cp -rp install/data appimage/data
+        cp -rp install/lang appimage/lang
+        cp -p Colobot-*-x86_64.AppImage appimage/colobot
+      if: matrix.target_os == 'linux'
+    - name: Upload AppImage
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{matrix.target_os}}-debug-AppImage
+        path: build/appimage
+      if: matrix.target_os == 'linux'
+    - name: Run tests
+      # TODO: Maybe run Windows tests using wine as well?
+      working-directory: build
+      run: ./colobot_ut --gtest_output=xml:gtestresults.xml
+      if: matrix.target_os == 'linux'
+    - name: Upload test results
+      uses: actions/upload-artifact@v2
+      with:
+        name: Test results
+        path: build/gtestresults.xml
+      if: matrix.target_os == 'linux'
+  doc:
+    runs-on: ubuntu-latest
+    container: krzysh/colobot-build:latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Create build directory
+      run: cmake -E make_directory build
+    - name: Run CMake
+      working-directory: build
+      run: cmake ..
+    - name: Build docs
+      working-directory: build
+      run: make doc
+    - name: Upload docs
+      uses: actions/upload-artifact@v2
+      with:
+        name: doc
+        path: build/doc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,22 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    container: krzysh/colobot-build:latest
+    runs-on: ${{ matrix.host_os }}
+    container: ${{ matrix.container }}
     strategy:
       matrix:
-        target_os: [windows, linux]
+        target_os: [linux]
+        host_os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        container: ['']
+        include:
+          - target_os: windows
+            host_os: ubuntu-latest
+            container: krzysh/colobot-build:latest
       fail-fast: false
     steps:
+    - name: Install Colobot dependencies
+      run: sudo apt-get install -y --no-install-recommends build-essential cmake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsndfile1-dev libvorbis-dev libogg-dev libpng-dev libglew-dev libopenal-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-regex-dev libphysfs-dev gettext git po4a vorbis-tools librsvg2-bin xmlstarlet
+      if: matrix.container == ''
     - uses: actions/checkout@v1
     - name: Create build directory
       run: cmake -E make_directory build
@@ -38,6 +47,7 @@ jobs:
       with:
         name: ${{matrix.target_os}}-debug
         path: build/install
+      if: matrix.target_os == 'windows' || matrix.host_os == 'ubuntu-18.04'
     - name: Create AppImage
       working-directory: build
       run: |
@@ -61,7 +71,7 @@ jobs:
       with:
         name: ${{matrix.target_os}}-debug-AppImage
         path: build/appimage
-      if: matrix.target_os == 'linux'
+      if: matrix.target_os == 'linux' && matrix.host_os == 'ubuntu-18.04'
     - name: Run tests
       # TODO: Maybe run Windows tests using wine as well?
       working-directory: build
@@ -70,13 +80,14 @@ jobs:
     - name: Upload test results
       uses: actions/upload-artifact@v2
       with:
-        name: Test results
+        name: Test results (${{ matrix.target_os }}, ${{ matrix.host_os }})
         path: build/gtestresults.xml
       if: matrix.target_os == 'linux'
   doc:
     runs-on: ubuntu-latest
-    container: krzysh/colobot-build:latest
     steps:
+    - name: Install Colobot dependencies
+      run: sudo apt-get install -y --no-install-recommends build-essential cmake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsndfile1-dev libvorbis-dev libogg-dev libpng-dev libglew-dev libopenal-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-regex-dev libphysfs-dev gettext git po4a vorbis-tools librsvg2-bin xmlstarlet doxygen graphviz
     - uses: actions/checkout@v1
     - name: Create build directory
       run: cmake -E make_directory build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       CLANG_PREFIX: /usr/lib/llvm-3.6
     steps:
     - name: Download Colobot dependencies
-      run: sudo apt-get install -y --no-install-recommends build-essential cmake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsndfile1-dev libvorbis-dev libogg-dev libpng12-dev libglew-dev libopenal-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-regex-dev libphysfs-dev gettext vorbis-tools
+      run: sudo apt-get install -y --no-install-recommends build-essential cmake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsndfile1-dev libvorbis-dev libogg-dev libpng-dev libglew-dev libopenal-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-regex-dev libphysfs-dev gettext git po4a vorbis-tools librsvg2-bin xmlstarlet
     # TODO: migrate colobot-lint to GitHub Actions
     - name: Download colobot-lint
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,162 @@
+name: Linter
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    # it's easiest if it matches the version that was used to build colobot-lint, newer versions don't have llvm-3.6-dev in repo...
+    runs-on: ubuntu-16.04
+    env:
+      CC: /usr/lib/llvm-3.6/bin/clang
+      CXX: /usr/lib/llvm-3.6/bin/clang++
+      CLANG_PREFIX: /usr/lib/llvm-3.6
+    steps:
+    - name: Download Colobot dependencies
+      run: sudo apt-get install -y --no-install-recommends build-essential cmake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsndfile1-dev libvorbis-dev libogg-dev libpng12-dev libglew-dev libopenal-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-regex-dev libphysfs-dev gettext vorbis-tools
+    # TODO: migrate colobot-lint to GitHub Actions
+    - name: Download colobot-lint
+      run: |
+        sudo apt-get install -y --no-install-recommends clang-3.6 libtinyxml2.6.2v5
+        mkdir -p /tmp/colobot-lint
+        cd /tmp/colobot-lint
+        wget -O colobot-lint.zip "https://compiled.colobot.info/job/colobot/job/colobot-lint/job/dev/lastSuccessfulBuild/artifact/*zip*/archive.zip"
+        unzip colobot-lint.zip
+        chmod +x archive/Tools/count_errors.py  # TODO: ???
+    - uses: actions/checkout@v1
+    - name: Create build directory
+      run: cmake -E make_directory build
+    - name: Run CMake
+      working-directory: build
+      run: cmake -DCOLOBOT_LINT_BUILD=1 -DTESTS=1 -DTOOLS=1 -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ..
+    - name: Run linter
+      shell: bash
+      run: |
+        set -e +x
+        # Run colobot-lint
+        WORKSPACE=$PWD
+        COLOBOT_DIR="$WORKSPACE"
+        COLOBOT_BUILD_DIR="$WORKSPACE/build"
+        COLOBOT_LINT_BUILD_DIR="/tmp/colobot-lint/archive/build"
+        COLOBOT_LINT_REPORT_FILE="$WORKSPACE/build/colobot_lint_report.xml"
+        # CLANG_PREFIX="/usr/lib/llvm-3.6" # Set in top-level environment block
+        cd "$COLOBOT_LINT_BUILD_DIR"
+        chmod +x ./colobot-lint
+        # Workaround for Clang not finding system headers
+        rm -rf bin/
+        mkdir -p bin
+        mv ./colobot-lint ./bin/
+        rm -f ./lib
+        ln -s ${CLANG_PREFIX}/lib ./lib
+        echo "Running colobot-lint"
+        find "$WORKSPACE" \( -wholename "$COLOBOT_DIR/src/*.cpp" \
+                         -or -wholename "$COLOBOT_DIR/test/unit/*.cpp" \
+                         -or -wholename "$COLOBOT_BUILD_DIR/fake_header_sources/src/*.cpp" \
+                         -or -wholename "$COLOBOT_BUILD_DIR/fake_header_sources/test/unit/*.cpp" \) \
+                -exec ./bin/colobot-lint \
+                -verbose \
+                -output-format xml \
+                -output-file "$COLOBOT_LINT_REPORT_FILE" \
+                -p "$COLOBOT_BUILD_DIR" \
+                -project-local-include-path "$COLOBOT_DIR/src" -project-local-include-path "$COLOBOT_BUILD_DIR/src" \
+                -license-template-file "$COLOBOT_DIR/LICENSE-HEADER.txt" \
+                {} +
+    - name: Upload results (XML)
+      uses: actions/upload-artifact@v2
+      with:
+        name: XML results
+        path: build/colobot_lint_report.xml
+    - name: Generate HTML report
+      shell: bash
+      run: |
+        set -e +x
+        # Generate HTML report
+        WORKSPACE=$PWD
+        COLOBOT_LINT_BUILD_DIR="/tmp/colobot-lint/archive/build"
+        COLBOT_LINT_REPORT_FILE="$WORKSPACE/build/colobot_lint_report.xml"
+        HTML_REPORT_DIR="$WORKSPACE/build/html_report"
+        echo "Generating HTML report"
+        cd "$COLOBOT_LINT_BUILD_DIR"
+        rm -rf HtmlReport/
+        tar -zxf html_report.tar.gz
+        HtmlReport/generate.py --xml-report "$COLBOT_LINT_REPORT_FILE" --output-dir "$HTML_REPORT_DIR"
+    - name: Upload results (HTML)
+      uses: actions/upload-artifact@v2
+      with:
+        name: HTML results
+        path: build/html_report
+    - name: Update stable/unstable build status
+      shell: bash
+      run: |
+        set -e +x
+        # Update stable/unstable build status
+        ret=0
+        WORKSPACE=$PWD
+        COLOBOT_LINT_REPORT_FILE="$WORKSPACE/build/colobot_lint_report.xml"
+        COLOBOT_LINT_DIR="/tmp/colobot-lint/archive"
+        OVERALL_STABLE_RULES=(
+            "class naming"
+            "code block placement"
+            "compile error"
+        #    "compile warning"
+        #    "enum naming"
+        #    "function naming"
+            "header file not self-contained"
+        #    "implicit bool cast"
+        #    "include style"
+        #    "inconsistent declaration parameter name"
+            "license header"
+        #    "naked delete"
+        #    "naked new"
+        #    "old style function"
+            "old-style null pointer"
+        #    "possible forward declaration"
+            "undefined function"
+        #    "uninitialized field"
+        #    "uninitialized local variable"
+        #    "unused forward declaration"
+        #    "variable naming"
+            "whitespace"
+        )
+        echo "Checking rule stability (overall)"
+        for ((i = 0; i < ${#OVERALL_STABLE_RULES[@]}; i++)); do
+            rule="${OVERALL_STABLE_RULES[$i]}"
+            count="$("$COLOBOT_LINT_DIR/Tools/count_errors.py" --rule-filter="$rule" --xml-report-file "$COLOBOT_LINT_REPORT_FILE")"
+            if [ "$count" != "0" ]; then
+               echo "UNSTABLE RULE: $rule ($count occurences)"
+               ret=1
+            fi
+        done
+        STABLE_RULES_WITHOUT_CBOT=(
+            "class naming"
+            "code block placement"
+            "compile error"
+            "compile warning"
+        #    "enum naming"
+        #    "function naming"
+            "header file not self-contained"
+        #    "implicit bool cast"
+            "include style"
+            "inconsistent declaration parameter name"
+            "license header"
+            "naked delete"
+            "naked new"
+        #    "old style function"
+            "old-style null pointer"
+        #    "possible forward declaration"
+            "undefined function"
+            "uninitialized field"
+        #    "uninitialized local variable"
+            "unused forward declaration"
+        #    "variable naming"
+            "whitespace"
+        )
+        echo "Checking rule stability (without CBOT)"
+        for ((i = 0; i < ${#STABLE_RULES_WITHOUT_CBOT[@]}; i++)); do
+            rule="${STABLE_RULES_WITHOUT_CBOT[$i]}"
+            count="$("$COLOBOT_LINT_DIR/Tools/count_errors.py" --rule-filter="$rule" --file-filter="-.*CBot.*" --xml-report-file "$COLOBOT_LINT_REPORT_FILE")"
+            if [ "$count" != "0" ]; then
+               echo "UNSTABLE RULE: $rule (without CBOT, $count occurences)"
+               ret=1
+            fi
+        done
+        exit $ret

--- a/.github/workflows/verify-pr-target.yml
+++ b/.github/workflows/verify-pr-target.yml
@@ -1,0 +1,11 @@
+name: Verify pull request target
+
+on: [pull_request]
+
+jobs:
+  wrong_pr_target:
+    runs-on: ubuntu-latest
+    if: github.base_ref == 'master'
+    steps:
+    - name: Wrong pull request target
+      run: echo "This pull request targets the master branch. Please edit the pull request to target dev." && exit 1

--- a/.github/workflows/verify-pr-target.yml
+++ b/.github/workflows/verify-pr-target.yml
@@ -3,9 +3,12 @@ name: Verify pull request target
 on: [pull_request]
 
 jobs:
-  wrong_pr_target:
+  check_pr_target:
     runs-on: ubuntu-latest
-    if: github.base_ref == 'master'
     steps:
     - name: Wrong pull request target
       run: echo "This pull request targets the master branch. Please edit the pull request to target dev." && exit 1
+      if: github.base_ref == 'master'
+    - name: Correct pull request target
+      run: echo "This pull request targets the correct branch." && exit 0
+      if: github.base_ref != 'master'


### PR DESCRIPTION
Our Jenkins server is slooow, and GitHub actions are free and give us more flexibility (building on Windows and MacOS). This is pretty much a straight port of our Jenkinsfile.

Note that I left the Jenkinsfile for now - we'll be using both systems until we are sure that the GitHub Actions are stable.

Future plans:
* modernize some parts of the build process (use `cmake --build`, remove unused flags)
* add builds on Windows and MacOS to the build matrix (and consider dropping MXE in favor of native builds?)
* send results from the linter using [annotations](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks#checks) (there seems to be no action available to use the cppcheck XML, so we would need something to convert it first into e.g. [this format](https://github.com/marketplace/actions/annotations-action))
* see if there is any option to display unit test results in the UI, but so far I haven't found any

The data files part of this PR will follow soon.