### PR TITLE
Bump CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Contains global options and definitions
 ##
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.17)
 
 project(colobot C CXX)
 

--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.17)
 
 set(COLOBOT_ICON_FILE ${CMAKE_CURRENT_SOURCE_DIR}/colobot.svg)
 

--- a/lib/gtest/CMakeLists.txt
+++ b/lib/gtest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.17)
 
 include_directories(. include)
 

--- a/lib/localename/CMakeLists.txt
+++ b/lib/localename/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.17)
 
 add_library(localename STATIC localename.c)

--- a/lib/wingetopt/CMakeLists.txt
+++ b/lib/wingetopt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.17)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 add_library(wingetopt STATIC src/getopt.c src/getopt.h)

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.17)
 
 find_package(Gettext REQUIRED)
 


### PR DESCRIPTION
The version bump is to version 3.17. It is available from the Kitware repository (https://apt.kitware.com/) on the Ubuntu 16.04, the oldest still supported LTS, so I think it's fine. I don't think there'll be a need to bump it down later.

I rebuild the Docker image with MXE used by our CI in https://github.com/colobot/colobot-misc/commit/b518dfa59790778366268f1bf93d8419e677e9d0  The changes still have to propagate to the Docker Hub.

It took me almost 1 day and a half to make this change! Most of this time was spent waiting for the MXE libraries to be build, which could take hours, as it failed randomly from network or memory issues and required frequent restarts. And then there was some error anyway requiring making a fix in the Dockerfile which meant building everything from scratch again.

I don't think we should care about MXE anymore, at least on the `dev-modern` branch. It's vastly counterproductive to keep it working. It just wasted 2 days of my time I could use for actually making some improvements in the building system. I hope we can drop the MXE madness and make good MSVC support instead. It somehow works now, but I still wasn't able to compile the tests and make linter work with it, so one of the main goals is to make them work.

Related PR in data: https://github.com/colobot/colobot/pull/1323