### PR TITLE
Fix update-pot not working with MSBuild

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -12,7 +12,7 @@ add_custom_command(OUTPUT ${_potFile}
     COMMAND ${XGETTEXT_CMD} ${colobot_SOURCE_DIR}/src/app/app.cpp --output=${_potFile} --no-wrap
     COMMAND ${XGETTEXT_CMD} ${colobot_SOURCE_DIR}/src/common/restext.cpp --output=${_potFile} --no-wrap --join-existing --no-location --keyword=TR
     COMMAND ${XGETTEXT_CMD} ${colobot_SOURCE_DIR}/src/script/script.cpp --output=${_potFile} --no-wrap --join-existing --no-location
-    COMMAND sed -i -e "s|^\\(\"POT-Creation-Date:\\).*$|\\1 DATE\\\\n\"|" ${_potFile}
+    COMMAND sed -bi -e "s/^\\(\"POT-Creation-Date:\\).*$/\\1 DATE\\\\n\"/" ${_potFile}
 
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Extract translatable messages to ${_potFile}"

--- a/src/common/restext.cpp
+++ b/src/common/restext.cpp
@@ -48,8 +48,8 @@ const char* stringsCbot[CBot::CBotErrMAX]         = { nullptr };
  */
 #define TR(x) x
 
-/* Please run `make update-pot` after changing this file
- * in order to update translation files. Thank you.
+/* Please run `cmake --build <path_to_build_folder> --target update-pot`
+ * after changing this file in order to update translation files. Thank you.
  */
 
 void InitializeRestext()


### PR DESCRIPTION
 Fixes the `'\1' is not recognized as an internal or external command` error when trying to run the target `update-pot` with MSBuild.

The `|` characters probably messed with cmd.exe or PowerShell syntax rules so they were replaced with slashes `/`.

Also, at least some implementations of sed for Windows would produce CRLF line endings instead of LF line endings. The issue is fixed by adding the flag `-b`.

Also changed the `make update-pot` comment to a portable cmake command. `make update-pot` only works if a generator producing Makefiles was used with `cmake`. The `cmake` command to build a specific target will work for any generator.

Note: I recommend using the following `sed` implementation: https://github.com/mbuilov/sed-windows instead of the one provided by the GnuWin32 project since the latter doesn't clean up temporary files which are created when the in-place option `-i` is used.