### PR TITLE
Remove unnecessary warning if there is no fonts.ini file

### DIFF
--- a/src/graphics/engine/text.cpp
+++ b/src/graphics/engine/text.cpp
@@ -194,7 +194,7 @@ bool CText::Create()
     CFontLoader fontLoader;
     if (!fontLoader.Init())
     {
-        GetLogger()->Warn("Error on parsing fonts config file: failed to open file\n");
+        GetLogger()->Debug("Error on parsing fonts config file: failed to open file\n");
     }
     if (TTF_Init() != 0)
     {


### PR DESCRIPTION
Not sure why I decided to make it a warning back then, I think Debug should be fine.