### PR TITLE
Fix CBOT script hanging at delete()

### DIFF
--- a/src/script/scriptfunc.cpp
+++ b/src/script/scriptfunc.cpp
@@ -734,6 +734,9 @@ bool CScriptFunctions::rDelete(CBotVar* var, CBotVar* result, int& exception, vo
     }
     else
     {
+        CScript* script = static_cast<CScript*>(user);
+        bool deleteSelf = (obj == script->m_object);
+
         if ( exploType != DestructionType::NoEffect && obj->Implements(ObjectInterfaceType::Destroyable) )
         {
             dynamic_cast<CDestroyableObject*>(obj)->DestroyObject(static_cast<DestructionType>(exploType));
@@ -752,12 +755,13 @@ bool CScriptFunctions::rDelete(CBotVar* var, CBotVar* result, int& exception, vo
             }
             CObjectManager::GetInstancePointer()->DeleteObject(obj);
         }
+        // Returning "false" here makes sure the program doesn't try to keep executing
+        // if the robot just destroyed itself using delete(this.id)
+        // See issue #925
+        return !deleteSelf;
     }
 
-    // Returning "false" here makes sure the program doesn't try to keep executing if the robot just destroyed itself
-    // using delete(this.id)
-    // See issue #925
-    return false;
+    return true;
 }
 
 static CBotTypResult compileSearch(CBotVar* &var, void* user, CBotTypResult returnValue)


### PR DESCRIPTION
Related issues #925 and #1067.

This fixes ```CScriptFunctions::rDelete()``` being called more than once
for each delete() call from a CBOT script.

After a95f736 and before 319d8e6, the following program called rDelete() over 300 times!!
Even after 319d8e6, rDelete() is still called at least two times.
```c++
extern void object::New()
{
	int mineID = radar(Mine).id;
	delete(mineID);     // delete a single mine
	message("done");
}
```
Except for the special case where a bot deletes itself, runtime CScriptFunctions should only return 'false'
when also returning an error, or for long running tasks that have not completed.