### PR TITLE
Add cell capacity parameters (#1242)

### DIFF
--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -3150,8 +3150,7 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
 
                 m_missionType = line->GetParam("type")->AsMissionType(MISSION_NORMAL);
                 m_globalMagnifyDamage = line->GetParam("magnifyDamage")->AsFloat(1.0f);
-                m_globalCapacity = line->GetParam("capacity")->AsFloat(1.0f);
-                m_globalNuclearCapacity = line->GetParam("nuclearCapacity")->AsFloat(1.0f);
+                m_globalNuclearCapacity = line->GetParam("nuclearCapacity")->AsFloat(10.0f);
                 m_globalCellCapacity = line->GetParam("cellCapacity")->AsFloat(1.0f);
 
                 continue;
@@ -5979,11 +5978,6 @@ void CRobotMain::RemoveFromSelectionHistory(CObject* object)
 float CRobotMain::GetGlobalMagnifyDamage()
 {
     return m_globalMagnifyDamage;
-}
-
-float CRobotMain::GetGlobalCapacity()
-{
-    return m_globalCapacity;
 }
 
 float CRobotMain::GetGlobalNuclearCapacity()

--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -3150,6 +3150,7 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
 
                 m_missionType = line->GetParam("type")->AsMissionType(MISSION_NORMAL);
                 m_globalMagnifyDamage = line->GetParam("magnifyDamage")->AsFloat(1.0f);
+                m_globalCapacity = line->GetParam("capacity")->AsFloat(1.0f);
 
                 continue;
             }
@@ -5976,6 +5977,11 @@ void CRobotMain::RemoveFromSelectionHistory(CObject* object)
 float CRobotMain::GetGlobalMagnifyDamage()
 {
     return m_globalMagnifyDamage;
+}
+
+float CRobotMain::GetGlobalCapacity()
+{
+    return m_globalCapacity;
 }
 
 // Beginning of the effect when the instruction "detect" is used.

--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -3151,6 +3151,8 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
                 m_missionType = line->GetParam("type")->AsMissionType(MISSION_NORMAL);
                 m_globalMagnifyDamage = line->GetParam("magnifyDamage")->AsFloat(1.0f);
                 m_globalCapacity = line->GetParam("capacity")->AsFloat(1.0f);
+                m_globalNuclearCapacity = line->GetParam("nuclearCapacity")->AsFloat(1.0f);
+                m_globalCellCapacity = line->GetParam("cellCapacity")->AsFloat(1.0f);
 
                 continue;
             }
@@ -5982,6 +5984,16 @@ float CRobotMain::GetGlobalMagnifyDamage()
 float CRobotMain::GetGlobalCapacity()
 {
     return m_globalCapacity;
+}
+
+float CRobotMain::GetGlobalNuclearCapacity()
+{
+    return m_globalNuclearCapacity;
+}
+
+float CRobotMain::GetGlobalCellCapacity()
+{
+    return m_globalCellCapacity;
 }
 
 // Beginning of the effect when the instruction "detect" is used.

--- a/src/level/robotmain.h
+++ b/src/level/robotmain.h
@@ -468,8 +468,6 @@ public:
     //! Returns global magnifyDamage setting
     float       GetGlobalMagnifyDamage();
 
-    //! Returns global capacity setting
-    float       GetGlobalCapacity();
     //! Returns global NuclearCell capacity Setting
     float       GetGlobalNuclearCapacity();
     //! Returns global PowerCell capacity setting
@@ -657,8 +655,7 @@ protected:
 
     float           m_globalMagnifyDamage = 0.0f;
 
-    float           m_globalCapacity = 1.0f;
-    float           m_globalNuclearCapacity = 1.0f;
+    float           m_globalNuclearCapacity = 10.0f;
     float           m_globalCellCapacity = 1.0f;
 
     bool            m_exitAfterMission = false;

--- a/src/level/robotmain.h
+++ b/src/level/robotmain.h
@@ -468,6 +468,9 @@ public:
     //! Returns global magnifyDamage setting
     float       GetGlobalMagnifyDamage();
 
+    //! Returns global capacity setting
+    float       GetGlobalCapacity();
+
     void        StartDetectEffect(COldObject* object, CObject* target);
 
     //! Enable crash sphere debug rendering
@@ -649,6 +652,8 @@ protected:
     bool            m_winTerminate = false;
 
     float           m_globalMagnifyDamage = 0.0f;
+
+    float           m_globalCapacity = 1.0f;
 
     bool            m_exitAfterMission = false;
 

--- a/src/level/robotmain.h
+++ b/src/level/robotmain.h
@@ -470,6 +470,10 @@ public:
 
     //! Returns global capacity setting
     float       GetGlobalCapacity();
+    //! Returns global NuclearCell capacity Setting
+    float       GetGlobalNuclearCapacity();
+    //! Returns global PowerCell capacity setting
+    float       GetGlobalCellCapacity();
 
     void        StartDetectEffect(COldObject* object, CObject* target);
 
@@ -654,6 +658,8 @@ protected:
     float           m_globalMagnifyDamage = 0.0f;
 
     float           m_globalCapacity = 1.0f;
+    float           m_globalNuclearCapacity = 1.0f;
+    float           m_globalCellCapacity = 1.0f;
 
     bool            m_exitAfterMission = false;
 

--- a/src/object/old_object.cpp
+++ b/src/object/old_object.cpp
@@ -2500,7 +2500,7 @@ float COldObject::GetAbsTime()
 
 float COldObject::GetCapacity()
 {
-    return (m_type == OBJECT_ATOMIC ? 10.0f : 1.0f) * m_main->GetGlobalCapacity();
+    return (m_type == OBJECT_ATOMIC ? 10.0f * m_main->GetGlobalNuclearCapacity() : 1.0f * m_main->GetGlobalCellCapacity() ) * m_main->GetGlobalCapacity();
 }
 
 bool COldObject::IsRechargeable()

--- a/src/object/old_object.cpp
+++ b/src/object/old_object.cpp
@@ -2500,7 +2500,7 @@ float COldObject::GetAbsTime()
 
 float COldObject::GetCapacity()
 {
-    return m_type == OBJECT_ATOMIC ? 10.0f : 1.0f;
+    return (m_type == OBJECT_ATOMIC ? 10.0f : 1.0f) * m_main->GetGlobalCapacity();
 }
 
 bool COldObject::IsRechargeable()

--- a/src/object/old_object.cpp
+++ b/src/object/old_object.cpp
@@ -2500,7 +2500,7 @@ float COldObject::GetAbsTime()
 
 float COldObject::GetCapacity()
 {
-    return (m_type == OBJECT_ATOMIC ? 10.0f * m_main->GetGlobalNuclearCapacity() : 1.0f * m_main->GetGlobalCellCapacity() ) * m_main->GetGlobalCapacity();
+    return m_type == OBJECT_ATOMIC ? m_main->GetGlobalNuclearCapacity() : m_main->GetGlobalCellCapacity() ;
 }
 
 bool COldObject::IsRechargeable()


### PR DESCRIPTION
Usage: add `Level capacity=X` line in scene file, where X is battery capacity multiplier. It's floating point type, so you can make your batteries 33% bigger with `Level capacity=1.33`.