### PR TITLE
GCC11 diagnostics fix

### DIFF
--- a/src/graphics/engine/camera.cpp
+++ b/src/graphics/engine/camera.cpp
@@ -59,14 +59,14 @@ static void SetTransparency(CObject* obj, float value)
 
     if (obj->Implements(ObjectInterfaceType::Carrier))
     {
-        CObject* cargo = dynamic_cast<CCarrierObject*>(obj)->GetCargo();
+        CObject* cargo = dynamic_cast<CCarrierObject&>(*obj).GetCargo();
         if (cargo != nullptr)
             cargo->SetTransparency(value);
     }
 
     if (obj->Implements(ObjectInterfaceType::Powered))
     {
-        CObject* power = dynamic_cast<CPoweredObject*>(obj)->GetPower();
+        CObject* power = dynamic_cast<CPoweredObject&>(*obj).GetPower();
         if (power != nullptr)
             power->SetTransparency(value);
     }
@@ -1233,7 +1233,7 @@ bool CCamera::EventFrameBack(const Event &event)
 
         bool ground = true;
         if (m_cameraObj->Implements(ObjectInterfaceType::Movable))
-            ground = dynamic_cast<CMovableObject*>(m_cameraObj)->GetPhysics()->GetLand();
+            ground = dynamic_cast<CMovableObject&>(*m_cameraObj).GetPhysics()->GetLand();
         if ( ground )  // ground?
         {
             Math::Vector pos = lookatPt + (lookatPt - m_eyePt);
@@ -1326,7 +1326,7 @@ bool CCamera::EventFrameOnBoard(const Event &event)
     {
         assert(m_cameraObj->Implements(ObjectInterfaceType::Controllable));
         Math::Vector lookatPt, upVec;
-        dynamic_cast<CControllableObject*>(m_cameraObj)->AdjustCamera(m_eyePt, m_directionH, m_directionV, lookatPt, upVec, m_type);
+        dynamic_cast<CControllableObject&>(*m_cameraObj).AdjustCamera(m_eyePt, m_directionH, m_directionV, lookatPt, upVec, m_type);
         Math::Vector eye    = m_effectOffset * 0.3f + m_eyePt;
         Math::Vector lookat = m_effectOffset * 0.3f + lookatPt;
 

--- a/src/object/interface/carrier_object.h
+++ b/src/object/interface/carrier_object.h
@@ -51,5 +51,5 @@ public:
 inline bool IsObjectCarryingCargo(CObject* obj)
 {
     return obj->Implements(ObjectInterfaceType::Carrier) &&
-           dynamic_cast<CCarrierObject*>(obj)->IsCarryingCargo();
+           dynamic_cast<CCarrierObject&>(*obj).IsCarryingCargo();
 }

--- a/src/object/interface/powered_object.h
+++ b/src/object/interface/powered_object.h
@@ -61,10 +61,10 @@ inline float GetObjectEnergy(CObject* object)
 
     if (object->Implements(ObjectInterfaceType::Powered))
     {
-        CObject* power = dynamic_cast<CPoweredObject*>(object)->GetPower();
+        CObject* power = dynamic_cast<CPoweredObject&>(*object).GetPower();
         if (power != nullptr && power->Implements(ObjectInterfaceType::PowerContainer))
         {
-            energy = dynamic_cast<CPowerContainerObject*>(power)->GetEnergy();
+            energy = dynamic_cast<CPowerContainerObject&>(*power).GetEnergy();
         }
     }
 
@@ -77,10 +77,10 @@ inline float GetObjectEnergyLevel(CObject* object)
 
     if (object->Implements(ObjectInterfaceType::Powered))
     {
-        CObject* power = dynamic_cast<CPoweredObject*>(object)->GetPower();
+        CObject* power = dynamic_cast<CPoweredObject&>(*object).GetPower();
         if (power != nullptr && power->Implements(ObjectInterfaceType::PowerContainer))
         {
-            energy = dynamic_cast<CPowerContainerObject*>(power)->GetEnergyLevel();
+            energy = dynamic_cast<CPowerContainerObject&>(*power).GetEnergyLevel();
         }
     }
 
@@ -90,5 +90,5 @@ inline float GetObjectEnergyLevel(CObject* object)
 inline bool ObjectHasPowerCell(CObject* object)
 {
     return object->Implements(ObjectInterfaceType::Powered) &&
-           dynamic_cast<CPoweredObject*>(object)->GetPower() != nullptr;
+           dynamic_cast<CPoweredObject&>(*object).GetPower() != nullptr;
 }

--- a/src/object/interface/transportable_object.h
+++ b/src/object/interface/transportable_object.h
@@ -54,5 +54,5 @@ public:
 inline bool IsObjectBeingTransported(CObject* obj)
 {
     return obj->Implements(ObjectInterfaceType::Transportable) &&
-           dynamic_cast<CTransportableObject*>(obj)->IsBeingTransported();
+           dynamic_cast<CTransportableObject&>(*obj).IsBeingTransported();
 }


### PR DESCRIPTION
This Pull Request aims to upstream a patch added to Colobot in the Fedora Linux distribution: [link](https://src.fedoraproject.org/rpms/colobot/c/1b541e3dd55ef72a70d38af8fb56aab00ecbb46c?branch=master)
> In simplest terms, the patch changes the dyncast ever so slightly to avoid
triggering a "this" might be NULL diagnostic in gcc-11.
>
> It's casting to a reference rather than casting to a pointer.  This has the added
advantage that it makes it clear to anyone reading the code that the cast is
expected to succeed every time (as it should if I read the code correctly).