### PR TITLE
GCC11 diagnostics fix (round 2)

### DIFF
--- a/src/graphics/engine/lightning.cpp
+++ b/src/graphics/engine/lightning.cpp
@@ -323,7 +323,7 @@ CObject* CLightning::SearchObject(Math::Vector pos)
 
         if (!obj->Implements(ObjectInterfaceType::Destroyable)) continue;
 
-        float detect = m_magnetic * dynamic_cast<CDestroyableObject*>(obj)->GetLightningHitProbability();
+        float detect = m_magnetic * dynamic_cast<CDestroyableObject&>(*obj).GetLightningHitProbability();
         if (detect == 0.0f) continue;
 
         Math::Vector oPos = obj->GetPosition();

--- a/src/graphics/engine/particle.cpp
+++ b/src/graphics/engine/particle.cpp
@@ -953,7 +953,7 @@ void CParticle::FrameParticle(float rTime)
             m_particle[i].goal = m_particle[i].pos;
             if (object != nullptr && object->Implements(ObjectInterfaceType::Damageable))
             {
-                dynamic_cast<CDamageableObject*>(object)->DamageObject(DamageType::Phazer, 0.002f, m_particle[i].objFather);
+                dynamic_cast<CDamageableObject&>(*object).DamageObject(DamageType::Phazer, 0.002f, m_particle[i].objFather);
             }
 
             m_particle[i].zoom = 1.0f-(m_particle[i].time-m_particle[i].duration);
@@ -1156,7 +1156,7 @@ void CParticle::FrameParticle(float rTime)
                 {
                     if (object->Implements(ObjectInterfaceType::Damageable))
                     {
-                        dynamic_cast<CDamageableObject*>(object)->DamageObject(DamageType::Fire, 0.001f, m_particle[i].objFather);
+                        dynamic_cast<CDamageableObject&>(*object).DamageObject(DamageType::Fire, 0.001f, m_particle[i].objFather);
                     }
 
                     m_exploGunCounter++;
@@ -1222,7 +1222,7 @@ void CParticle::FrameParticle(float rTime)
                 m_particle[i].goal = m_particle[i].pos;
                 if (object != nullptr)
                 {
-                    if (object->GetType() == OBJECT_MOBILErs && dynamic_cast<CShielder*>(object)->GetActiveShieldRadius() > 0.0f)  // protected by shield?
+                    if (object->GetType() == OBJECT_MOBILErs && dynamic_cast<CShielder&>(*object).GetActiveShieldRadius() > 0.0f)  // protected by shield?
                     {
                         CreateParticle(m_particle[i].pos, Math::Vector(0.0f, 0.0f, 0.0f), Math::Point(6.0f, 6.0f), PARTIGUNDEL, 2.0f);
                         if (m_lastTimeGunDel > 0.2f)
@@ -1240,7 +1240,7 @@ void CParticle::FrameParticle(float rTime)
 
                         if (object->Implements(ObjectInterfaceType::Damageable))
                         {
-                            dynamic_cast<CDamageableObject*>(object)->DamageObject(DamageType::Organic, 0.1f, m_particle[i].objFather);  // starts explosion
+                            dynamic_cast<CDamageableObject&>(*object).DamageObject(DamageType::Organic, 0.1f, m_particle[i].objFather);  // starts explosion
                         }
                     }
                 }
@@ -1270,7 +1270,7 @@ void CParticle::FrameParticle(float rTime)
                 m_particle[i].goal = m_particle[i].pos;
                 if (object != nullptr)
                 {
-                    if (object->GetType() == OBJECT_MOBILErs && dynamic_cast<CShielder*>(object)->GetActiveShieldRadius() > 0.0f)
+                    if (object->GetType() == OBJECT_MOBILErs && dynamic_cast<CShielder&>(*object).GetActiveShieldRadius() > 0.0f)
                     {
                         CreateParticle(m_particle[i].pos, Math::Vector(0.0f, 0.0f, 0.0f), Math::Point(6.0f, 6.0f), PARTIGUNDEL, 2.0f);
                         if (m_lastTimeGunDel > 0.2f)
@@ -1285,7 +1285,7 @@ void CParticle::FrameParticle(float rTime)
                     {
                         if (object->Implements(ObjectInterfaceType::Damageable))
                         {
-                            dynamic_cast<CDamageableObject*>(object)->DamageObject(DamageType::Fire, std::numeric_limits<float>::infinity(), m_particle[i].objFather);  // starts explosion
+                            dynamic_cast<CDamageableObject&>(*object).DamageObject(DamageType::Fire, std::numeric_limits<float>::infinity(), m_particle[i].objFather);  // starts explosion
                         }
                     }
                 }
@@ -1344,7 +1344,7 @@ void CParticle::FrameParticle(float rTime)
                 {
                     if (object->Implements(ObjectInterfaceType::Damageable))
                     {
-                        dynamic_cast<CDamageableObject*>(object)->DamageObject(DamageType::Organic, 0.001f, m_particle[i].objFather);
+                        dynamic_cast<CDamageableObject&>(*object).DamageObject(DamageType::Organic, 0.001f, m_particle[i].objFather);
                     }
 
                     m_exploGunCounter ++;
@@ -2422,7 +2422,7 @@ void CParticle::FrameParticle(float rTime)
                 if (object != nullptr)
                 {
                     assert(object->Implements(ObjectInterfaceType::Damageable));
-                    dynamic_cast<CDamageableObject*>(object)->DamageObject(DamageType::Tower, std::numeric_limits<float>::infinity(), m_particle[i].objFather);
+                    dynamic_cast<CDamageableObject&>(*object).DamageObject(DamageType::Tower, std::numeric_limits<float>::infinity(), m_particle[i].objFather);
                 }
             }
 

--- a/src/graphics/engine/pyro.cpp
+++ b/src/graphics/engine/pyro.cpp
@@ -129,7 +129,7 @@ bool CPyro::Create(PyroType type, CObject* obj, float force)
 
     CObject* power = nullptr;
     if (obj->Implements(ObjectInterfaceType::Powered))
-        power = dynamic_cast<CPoweredObject*>(obj)->GetPower();
+        power = dynamic_cast<CPoweredObject&>(*obj).GetPower();
 
     if (power == nullptr)
     {
@@ -260,7 +260,7 @@ bool CPyro::Create(PyroType type, CObject* obj, float force)
             m_sound->Play(SOUND_DEADw, m_pos);
         }
         assert(m_object->Implements(ObjectInterfaceType::Controllable));
-        if ( type == PT_SHOTH && dynamic_cast<CControllableObject*>(m_object)->GetSelect() )
+        if ( type == PT_SHOTH && dynamic_cast<CControllableObject&>(*m_object).GetSelect() )
         {
             m_sound->Play(SOUND_AIE, m_pos);
             m_sound->Play(SOUND_AIE, m_engine->GetEyePt());
@@ -278,10 +278,10 @@ bool CPyro::Create(PyroType type, CObject* obj, float force)
     if ( m_type == PT_DEADG )
     {
         assert(m_object->Implements(ObjectInterfaceType::Destroyable));
-        dynamic_cast<CDestroyableObject*>(m_object)->SetDying(DeathType::Dead);
+        dynamic_cast<CDestroyableObject&>(*m_object).SetDying(DeathType::Dead);
 
         assert(obj->Implements(ObjectInterfaceType::Movable));
-        dynamic_cast<CMovableObject*>(obj)->GetMotion()->SetAction(MHS_DEADg, 1.0f);
+        dynamic_cast<CMovableObject&>(*obj).GetMotion()->SetAction(MHS_DEADg, 1.0f);
 
         m_camera->StartCentering(m_object, Math::PI*0.5f, 99.9f, 0.0f, 1.5f);
         m_camera->StartOver(CAM_OVER_EFFECT_FADEOUT_WHITE, m_pos, 1.0f);
@@ -291,10 +291,10 @@ bool CPyro::Create(PyroType type, CObject* obj, float force)
     if ( m_type == PT_DEADW )
     {
         assert(m_object->Implements(ObjectInterfaceType::Destroyable));
-        dynamic_cast<CDestroyableObject*>(m_object)->SetDying(DeathType::Dead);
+        dynamic_cast<CDestroyableObject&>(*m_object).SetDying(DeathType::Dead);
 
         assert(obj->Implements(ObjectInterfaceType::Movable));
-        dynamic_cast<CMovableObject*>(obj)->GetMotion()->SetAction(MHS_DEADw, 1.0f);
+        dynamic_cast<CMovableObject&>(*obj).GetMotion()->SetAction(MHS_DEADw, 1.0f);
 
         m_camera->StartCentering(m_object, Math::PI*0.5f, 99.9f, 0.0f, 3.0f);
         m_camera->StartOver(CAM_OVER_EFFECT_FADEOUT_BLACK, m_pos, 1.0f);
@@ -312,7 +312,7 @@ bool CPyro::Create(PyroType type, CObject* obj, float force)
     if ( m_type == PT_SHOTH )
     {
         assert(m_object->Implements(ObjectInterfaceType::Controllable));
-        if ( m_camera->GetBlood() && dynamic_cast<CControllableObject*>(m_object)->GetSelect() )
+        if ( m_camera->GetBlood() && dynamic_cast<CControllableObject&>(*m_object).GetSelect() )
         {
             m_camera->StartOver(CAM_OVER_EFFECT_BLOOD, m_pos, force);
         }
@@ -1413,7 +1413,7 @@ void CPyro::DeleteObject(bool primary, bool secondary)
         if (m_object->Implements(ObjectInterfaceType::Transportable))
         {
             // TODO: this should be handled in the object's destructor
-            CObject* transporter = dynamic_cast<CTransportableObject*>(m_object)->GetTransporter();
+            CObject* transporter = dynamic_cast<CTransportableObject&>(*m_object).GetTransporter();
             if (transporter != nullptr)
             {
                 if (transporter->Implements(ObjectInterfaceType::Powered))
@@ -1582,12 +1582,12 @@ void CPyro::ExploStart()
     m_object->Simplify();
     m_object->SetLock(true);  // ruin not usable yet
     assert(m_object->Implements(ObjectInterfaceType::Destroyable));
-    dynamic_cast<CDestroyableObject*>(m_object)->SetDying(DeathType::Exploding);  // being destroyed
+    dynamic_cast<CDestroyableObject&>(*m_object).SetDying(DeathType::Exploding);  // being destroyed
     m_object->FlatParent();
 
-    if ( m_object->Implements(ObjectInterfaceType::Controllable) && dynamic_cast<CControllableObject*>(m_object)->GetSelect() )
+    if ( m_object->Implements(ObjectInterfaceType::Controllable) && dynamic_cast<CControllableObject&>(*m_object).GetSelect() )
     {
-        dynamic_cast<CControllableObject*>(m_object)->SetSelect(false);  // deselects the object
+        dynamic_cast<CControllableObject&>(*m_object).SetSelect(false);  // deselects the object
         m_camera->SetType(CAM_TYPE_EXPLO);
         m_main->DeselectAll();
     }
@@ -1611,7 +1611,7 @@ void CPyro::ExploStart()
 
         // TODO: temporary hack (hopefully)
         assert(m_object->Implements(ObjectInterfaceType::Old));
-        Math::Vector pos = dynamic_cast<COldObject*>(m_object)->GetPartPosition(i);
+        Math::Vector pos = dynamic_cast<COldObject&>(*m_object).GetPartPosition(i);
 
         Math::Vector speed;
         float weight;
@@ -1658,9 +1658,9 @@ void CPyro::BurnStart()
     m_object->Simplify();
     m_object->SetLock(true);  // ruin not usable yet
 
-    if ( m_object->Implements(ObjectInterfaceType::Controllable) && dynamic_cast<CControllableObject*>(m_object)->GetSelect() )
+    if ( m_object->Implements(ObjectInterfaceType::Controllable) && dynamic_cast<CControllableObject&>(*m_object).GetSelect() )
     {
-        dynamic_cast<CControllableObject*>(m_object)->SetSelect(false);  // deselects the object
+        dynamic_cast<CControllableObject&>(*m_object).SetSelect(false);  // deselects the object
         m_camera->SetType(CAM_TYPE_EXPLO);
         m_main->DeselectAll();
     }
@@ -2198,7 +2198,7 @@ void CPyro::BurnProgress()
 
     if (m_object->Implements(ObjectInterfaceType::Powered))
     {
-        CObject* sub = dynamic_cast<CPoweredObject*>(m_object)->GetPower();
+        CObject* sub = dynamic_cast<CPoweredObject&>(*m_object).GetPower();
         if (sub != nullptr)  // is there a battery?
             sub->SetScaleY(1.0f - m_progress);  // complete flattening
     }
@@ -2292,7 +2292,7 @@ CObject* CPyro::FallSearchBeeExplo()
 
         if (obj->GetType() == OBJECT_MOBILErs)
         {
-            float shieldRadius = dynamic_cast<CShielder*>(obj)->GetActiveShieldRadius();
+            float shieldRadius = dynamic_cast<CShielder&>(*obj).GetActiveShieldRadius();
             if ( shieldRadius > 0.0f )
             {
                 float distance = Math::Distance(oPos, bulletCrashSphere.sphere.pos);
@@ -2360,12 +2360,12 @@ void CPyro::FallProgress(float rTime)
                 {
                     assert(m_object->Implements(ObjectInterfaceType::Destroyable));
                     // TODO: implement "killer"?
-                    dynamic_cast<CDestroyableObject*>(m_object)->DestroyObject(DestructionType::Explosion);
+                    dynamic_cast<CDestroyableObject&>(*m_object).DestroyObject(DestructionType::Explosion);
                 }
             }
             else
             {
-                if (obj->GetType() == OBJECT_MOBILErs && dynamic_cast<CShielder*>(obj)->GetActiveShieldRadius() > 0.0f)  // protected by shield?
+                if (obj->GetType() == OBJECT_MOBILErs && dynamic_cast<CShielder&>(*obj).GetActiveShieldRadius() > 0.0f)  // protected by shield?
                 {
                     m_particle->CreateParticle(pos, Math::Vector(0.0f, 0.0f, 0.0f),
                                                 Math::Point(6.0f, 6.0f), PARTIGUNDEL, 2.0f, 0.0f, 0.0f);
@@ -2376,7 +2376,7 @@ void CPyro::FallProgress(float rTime)
                 else
                 {
                     assert(obj->Implements(ObjectInterfaceType::Damageable));
-                    if (dynamic_cast<CDamageableObject*>(obj)->DamageObject(DamageType::FallingObject))
+                    if (dynamic_cast<CDamageableObject&>(*obj).DamageObject(DamageType::FallingObject))
                     {
                         DeleteObject(true, true);  // removes the ball
                     }
@@ -2384,7 +2384,7 @@ void CPyro::FallProgress(float rTime)
                     {
                         assert(m_object->Implements(ObjectInterfaceType::Destroyable));
                         // TODO: implement "killer"?
-                        dynamic_cast<CDestroyableObject*>(m_object)->DestroyObject(DestructionType::Explosion);
+                        dynamic_cast<CDestroyableObject&>(*m_object).DestroyObject(DestructionType::Explosion);
                     }
                 }
             }

--- a/src/level/mainmovie.cpp
+++ b/src/level/mainmovie.cpp
@@ -90,7 +90,7 @@ bool CMainMovie::Start(MainMovieType type, float time)
         }
 
         assert(pObj->Implements(ObjectInterfaceType::Movable));
-        dynamic_cast<CMovableObject*>(pObj)->GetMotion()->SetAction(MHS_SATCOM, 0.5f);  // reads the SatCom
+        dynamic_cast<CMovableObject&>(*pObj).GetMotion()->SetAction(MHS_SATCOM, 0.5f);  // reads the SatCom
 
         m_camera->GetCamera(m_initialEye, m_initialLookat);
         m_camera->SetType(Gfx::CAM_TYPE_SCRIPT);
@@ -110,7 +110,7 @@ bool CMainMovie::Start(MainMovieType type, float time)
         if ( pObj != nullptr )
         {
             assert(pObj->Implements(ObjectInterfaceType::Movable));
-            dynamic_cast<CMovableObject*>(pObj)->GetMotion()->SetAction(-1);  // finishes reading SatCom
+            dynamic_cast<CMovableObject&>(*pObj).GetMotion()->SetAction(-1);  // finishes reading SatCom
         }
 
         m_camera->SetType(Gfx::CAM_TYPE_BACK);
@@ -132,7 +132,7 @@ bool CMainMovie::Stop()
         if ( pObj != nullptr )
         {
             assert(pObj->Implements(ObjectInterfaceType::Movable));
-            dynamic_cast<CMovableObject*>(pObj)->GetMotion()->SetAction(-1);  // finishes reading SatCom
+            dynamic_cast<CMovableObject&>(*pObj).GetMotion()->SetAction(-1);  // finishes reading SatCom
         }
     }
 

--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -1361,7 +1361,7 @@ void CRobotMain::ExecuteCmd(const std::string& cmd)
         {
             CObject* object = GetSelect();
             if (object != nullptr && object->Implements(ObjectInterfaceType::Shielded))
-                dynamic_cast<CShieldedObject*>(object)->SetMagnifyDamage(dynamic_cast<CShieldedObject*>(object)->GetMagnifyDamage()*0.1f);
+                dynamic_cast<CShieldedObject&>(*object).SetMagnifyDamage(dynamic_cast<CShieldedObject&>(*object).GetMagnifyDamage()*0.1f);
             return;
         }
 
@@ -1369,7 +1369,7 @@ void CRobotMain::ExecuteCmd(const std::string& cmd)
         {
             CObject* object = GetSelect();
             if (object != nullptr && object->Implements(ObjectInterfaceType::JetFlying))
-                dynamic_cast<CJetFlyingObject*>(object)->SetRange(dynamic_cast<CJetFlyingObject*>(object)->GetRange()*10.0f);
+                dynamic_cast<CJetFlyingObject&>(*object).SetRange(dynamic_cast<CJetFlyingObject&>(*object).GetRange()*10.0f);
             return;
         }
 
@@ -1394,16 +1394,16 @@ void CRobotMain::ExecuteCmd(const std::string& cmd)
             {
                 if (object->Implements(ObjectInterfaceType::Powered))
                 {
-                    CObject* power = dynamic_cast<CPoweredObject*>(object)->GetPower();
+                    CObject* power = dynamic_cast<CPoweredObject&>(*object).GetPower();
                     if (power != nullptr && power->Implements(ObjectInterfaceType::PowerContainer))
-                        dynamic_cast<CPowerContainerObject*>(power)->SetEnergyLevel(1.0f);
+                        dynamic_cast<CPowerContainerObject&>(*power).SetEnergyLevel(1.0f);
                 }
 
                 if (object->Implements(ObjectInterfaceType::Shielded))
-                    dynamic_cast<CShieldedObject*>(object)->SetShield(1.0f);
+                    dynamic_cast<CShieldedObject&>(*object).SetShield(1.0f);
 
                 if (object->Implements(ObjectInterfaceType::JetFlying))
-                    dynamic_cast<CJetFlyingObject*>(object)->SetReactorRange(1.0f);
+                    dynamic_cast<CJetFlyingObject&>(*object).SetReactorRange(1.0f);
             }
             return;
         }
@@ -1416,9 +1416,9 @@ void CRobotMain::ExecuteCmd(const std::string& cmd)
             {
                 if (object->Implements(ObjectInterfaceType::Powered))
                 {
-                    CObject* power = dynamic_cast<CPoweredObject*>(object)->GetPower();
+                    CObject* power = dynamic_cast<CPoweredObject&>(*object).GetPower();
                     if (power != nullptr && power->Implements(ObjectInterfaceType::PowerContainer))
-                        dynamic_cast<CPowerContainerObject*>(power)->SetEnergyLevel(1.0f);
+                        dynamic_cast<CPowerContainerObject&>(*power).SetEnergyLevel(1.0f);
                 }
             }
             return;
@@ -1428,7 +1428,7 @@ void CRobotMain::ExecuteCmd(const std::string& cmd)
         {
             CObject* object = GetSelect();
             if (object != nullptr && object->Implements(ObjectInterfaceType::Shielded))
-                dynamic_cast<CShieldedObject*>(object)->SetShield(1.0f);
+                dynamic_cast<CShieldedObject&>(*object).SetShield(1.0f);
             return;
         }
 
@@ -1438,7 +1438,7 @@ void CRobotMain::ExecuteCmd(const std::string& cmd)
             if (object != nullptr)
             {
                 if (object->Implements(ObjectInterfaceType::JetFlying))
-                    dynamic_cast<CJetFlyingObject*>(object)->SetReactorRange(1.0f);
+                    dynamic_cast<CJetFlyingObject&>(*object).SetReactorRange(1.0f);
             }
             return;
         }
@@ -1538,7 +1538,7 @@ void CRobotMain::StartDisplayInfo(int index, bool movie)
     if (!m_editLock && movie && !m_movie->IsExist() && human)
     {
         assert(obj->Implements(ObjectInterfaceType::Movable));
-        if (dynamic_cast<CMovableObject*>(obj)->GetMotion()->GetAction() == -1)
+        if (dynamic_cast<CMovableObject&>(*obj).GetMotion()->GetAction() == -1)
         {
             m_movieInfoIndex = index;
             m_movie->Start(MM_SATCOMopen, 2.5f);
@@ -1852,7 +1852,7 @@ CObject* CRobotMain::DeselectAll()
 void CRobotMain::SelectOneObject(CObject* obj, bool displayError)
 {
     assert(obj->Implements(ObjectInterfaceType::Controllable));
-    dynamic_cast<CControllableObject*>(obj)->SetSelect(true, displayError);
+    dynamic_cast<CControllableObject&>(*obj).SetSelect(true, displayError);
     m_camera->SetControllingObject(obj);
 
     ObjectType type = obj->GetType();
@@ -1891,7 +1891,7 @@ void CRobotMain::SelectOneObject(CObject* obj, bool displayError)
          type == OBJECT_MOBILEdr ||
          type == OBJECT_APOLLO2  )
     {
-        m_camera->SetType(dynamic_cast<CControllableObject*>(obj)->GetCameraType());
+        m_camera->SetType(dynamic_cast<CControllableObject&>(*obj).GetCameraType());
     }
     else
     {
@@ -1907,7 +1907,7 @@ bool CRobotMain::SelectObject(CObject* obj, bool displayError)
     if (m_movieLock || m_editLock) return false;
     if (m_movie->IsExist()) return false;
     if (obj != nullptr &&
-        (!obj->Implements(ObjectInterfaceType::Controllable) || !(dynamic_cast<CControllableObject*>(obj)->GetSelectable() || m_cheatSelectInsect))) return false;
+        (!obj->Implements(ObjectInterfaceType::Controllable) || !(dynamic_cast<CControllableObject&>(*obj).GetSelectable() || m_cheatSelectInsect))) return false;
 
     if (m_missionType == MISSION_CODE_BATTLE && m_codeBattleStarted && m_codeBattleSpectator)
     {
@@ -1983,7 +1983,7 @@ CObject* CRobotMain::GetSelect()
     for (CObject* obj : m_objMan->GetAllObjects())
     {
         if (!obj->Implements(ObjectInterfaceType::Controllable)) continue;
-        if (dynamic_cast<CControllableObject*>(obj)->GetSelect())
+        if (dynamic_cast<CControllableObject&>(*obj).GetSelect())
             return obj;
     }
     return nullptr;
@@ -2001,7 +2001,7 @@ CObject* CRobotMain::DetectObject(Math::Point pos)
 
         CObject* transporter = nullptr;
         if (obj->Implements(ObjectInterfaceType::Transportable))
-            transporter = dynamic_cast<CTransportableObject*>(obj)->GetTransporter();
+            transporter = dynamic_cast<CTransportableObject&>(*obj).GetTransporter();
 
         if (transporter != nullptr && !transporter->GetDetectable()) continue;
         if (obj->GetProxyActivate()) continue;
@@ -2009,14 +2009,14 @@ CObject* CRobotMain::DetectObject(Math::Point pos)
         CObject* target = obj;
         if (obj->Implements(ObjectInterfaceType::PowerContainer) && obj->Implements(ObjectInterfaceType::Transportable))
         {
-            target = dynamic_cast<CTransportableObject*>(obj)->GetTransporter();  // battery connected
+            target = dynamic_cast<CTransportableObject&>(*obj).GetTransporter();  // battery connected
             if (target == nullptr)
             {
                 target = obj; // standalone battery
             }
             else
             {
-                if (!target->Implements(ObjectInterfaceType::Powered) || dynamic_cast<CPoweredObject*>(target)->GetPower() != obj)
+                if (!target->Implements(ObjectInterfaceType::Powered) || dynamic_cast<CPoweredObject&>(*target).GetPower() != obj)
                 {
                     // transported, but not in the power slot
                     target = obj;
@@ -2046,7 +2046,7 @@ bool CRobotMain::DestroySelectedObject()
 
     m_engine->GetPyroManager()->Create(Gfx::PT_FRAGT, obj);
 
-    dynamic_cast<CControllableObject*>(obj)->SetSelect(false);  // deselects the object
+    dynamic_cast<CControllableObject&>(*obj).SetSelect(false);  // deselects the object
     m_camera->SetType(Gfx::CAM_TYPE_EXPLO);
     DeselectAll();
     RemoveFromSelectionHistory(obj);
@@ -2069,7 +2069,7 @@ void CRobotMain::HiliteClear()
     for (CObject* obj : m_objMan->GetAllObjects())
     {
         if (!obj->Implements(ObjectInterfaceType::Controllable)) continue;
-        dynamic_cast<CControllableObject*>(obj)->SetHighlight(false);
+        dynamic_cast<CControllableObject&>(*obj).SetHighlight(false);
     }
     m_map->SetHighlight(nullptr);
     m_short->SetHighlight(nullptr);
@@ -2129,12 +2129,12 @@ void CRobotMain::HiliteObject(Math::Point pos)
             }
         }
 
-        if (obj->Implements(ObjectInterfaceType::Controllable) && (dynamic_cast<CControllableObject*>(obj)->GetSelectable() || m_cheatSelectInsect))
+        if (obj->Implements(ObjectInterfaceType::Controllable) && (dynamic_cast<CControllableObject&>(*obj).GetSelectable() || m_cheatSelectInsect))
         {
-            if (dynamic_cast<CControllableObject*>(obj)->GetSelectable())
+            if (dynamic_cast<CControllableObject&>(*obj).GetSelectable())
             {
                 // Don't highlight objects that would not be selectable without selectinsect
-                dynamic_cast<CControllableObject*>(obj)->SetHighlight(true);
+                dynamic_cast<CControllableObject&>(*obj).SetHighlight(true);
             }
             m_map->SetHighlight(obj);
             m_short->SetHighlight(obj);
@@ -2391,7 +2391,7 @@ bool CRobotMain::EventFrame(const Event &event)
             if (obj->GetType() == OBJECT_TOTO)
                 toto = obj;
             else if (obj->Implements(ObjectInterfaceType::Interactive))
-                dynamic_cast<CInteractiveObject*>(obj)->EventProcess(event);
+                dynamic_cast<CInteractiveObject&>(*obj).EventProcess(event);
 
             if ( obj->GetProxyActivate() )  // active if it is near?
             {
@@ -2414,7 +2414,7 @@ bool CRobotMain::EventFrame(const Event &event)
                 continue;
 
             if (obj->Implements(ObjectInterfaceType::Interactive))
-                dynamic_cast<CInteractiveObject*>(obj)->EventProcess(event);
+                dynamic_cast<CInteractiveObject&>(*obj).EventProcess(event);
         }
 
         m_engine->GetPyroManager()->EventProcess(event);
@@ -2438,7 +2438,7 @@ bool CRobotMain::EventFrame(const Event &event)
 
     // Advances toto following the camera, because its position depends on the camera.
     if (toto != nullptr)
-        dynamic_cast<CInteractiveObject*>(toto)->EventProcess(event);
+        dynamic_cast<CInteractiveObject&>(*toto).EventProcess(event);
 
     // NOTE: m_movieLock is set only after the first update of CAutoBase finishes
 
@@ -2671,7 +2671,7 @@ bool CRobotMain::EventObject(const Event &event)
     {
         if (obj->Implements(ObjectInterfaceType::Interactive))
         {
-            dynamic_cast<CInteractiveObject*>(obj)->EventProcess(event);
+            dynamic_cast<CInteractiveObject&>(*obj).EventProcess(event);
         }
     }
 
@@ -2712,7 +2712,7 @@ void CRobotMain::ScenePerso()
         obj->SetDrawFront(true);  // draws the interface
 
         assert(obj->Implements(ObjectInterfaceType::Movable));
-        CMotionHuman* mh = static_cast<CMotionHuman*>(dynamic_cast<CMovableObject*>(obj)->GetMotion());
+        CMotionHuman* mh = static_cast<CMotionHuman*>(dynamic_cast<CMovableObject&>(*obj).GetMotion());
         mh->StartDisplayPerso();
     }
 }
@@ -3382,7 +3382,7 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
                 assert(m_controller->Implements(ObjectInterfaceType::ProgramStorage));
 
                 assert(m_controller->Implements(ObjectInterfaceType::Old));
-                dynamic_cast<COldObject*>(m_controller)->SetCheckToken(false);
+                dynamic_cast<COldObject&>(*m_controller).SetCheckToken(false);
 
                 if (line->GetParam("script")->IsDefined())
                 {
@@ -3390,7 +3390,7 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
                     Program* program = programStorage->AddProgram();
                     programStorage->ReadProgram(program, line->GetParam("script")->AsPath("ai"));
                     program->readOnly = true;
-                    dynamic_cast<CProgrammableObject*>(m_controller)->RunProgram(program);
+                    dynamic_cast<CProgrammableObject&>(*m_controller).RunProgram(program);
                 }
                 continue;
             }
@@ -3415,7 +3415,7 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
                     if (m_fixScene && obj->GetType() == OBJECT_HUMAN)
                     {
                         assert(obj->Implements(ObjectInterfaceType::Movable));
-                        CMotion* motion = dynamic_cast<CMovableObject*>(obj)->GetMotion();
+                        CMotion* motion = dynamic_cast<CMovableObject&>(*obj).GetMotion();
                         if (m_phase == PHASE_WIN ) motion->SetAction(MHS_WIN,  0.4f);
                         if (m_phase == PHASE_LOST) motion->SetAction(MHS_LOST, 0.5f);
                     }
@@ -3430,7 +3430,7 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
                     {
                         CProgramStorageObject* programStorage = dynamic_cast<CProgramStorageObject*>(obj);
 
-                        if (obj->Implements(ObjectInterfaceType::Controllable) && dynamic_cast<CControllableObject*>(obj)->GetSelectable() && obj->GetType() != OBJECT_HUMAN)
+                        if (obj->Implements(ObjectInterfaceType::Controllable) && dynamic_cast<CControllableObject&>(*obj).GetSelectable() && obj->GetType() != OBJECT_HUMAN)
                         {
                             programStorage->SetProgramStorageIndex(rankObj);
                         }
@@ -3813,7 +3813,7 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
                 assert(obj->Implements(ObjectInterfaceType::Controllable));
                 SelectObject(obj);
                 m_camera->SetControllingObject(obj);
-                m_camera->SetType(dynamic_cast<CControllableObject*>(obj)->GetCameraType());
+                m_camera->SetType(dynamic_cast<CControllableObject&>(*obj).GetCameraType());
             }
         }
 
@@ -4410,7 +4410,7 @@ void CRobotMain::StartShowLimit()
     CObject* obj = GetSelect();
     if (obj == nullptr) return;
     if (!obj->Implements(ObjectInterfaceType::Ranged)) return;
-    float range = dynamic_cast<CRangedObject*>(obj)->GetShowLimitRadius();
+    float range = dynamic_cast<CRangedObject&>(*obj).GetShowLimitRadius();
     if (range == 0.0f) return;
     SetShowLimit(0, Gfx::PARTILIMIT1, obj, obj->GetPosition(), range);
 }
@@ -4580,8 +4580,8 @@ bool CRobotMain::IOIsBusy()
     {
         if (! obj->Implements(ObjectInterfaceType::TaskExecutor)) continue;
 
-        if (obj->Implements(ObjectInterfaceType::Programmable) && dynamic_cast<CProgrammableObject*>(obj)->IsProgram()) continue; // TODO: I'm not sure if this is correct but this is how it worked earlier
-        if (dynamic_cast<CTaskExecutorObject*>(obj)->IsForegroundTask()) return true;
+        if (obj->Implements(ObjectInterfaceType::Programmable) && dynamic_cast<CProgrammableObject&>(*obj).IsProgram()) continue; // TODO: I'm not sure if this is correct but this is how it worked earlier
+        if (dynamic_cast<CTaskExecutorObject&>(*obj).IsForegroundTask()) return true;
     }
     return false;
 }
@@ -4632,7 +4632,7 @@ void CRobotMain::IOWriteObject(CLevelParserLine* line, CObject* obj, const std::
 
         if (obj->Implements(ObjectInterfaceType::Programmable))
         {
-            int run = dynamic_cast<CProgramStorageObject*>(obj)->GetProgramIndex(dynamic_cast<CProgrammableObject*>(obj)->GetCurrentProgram());
+            int run = dynamic_cast<CProgramStorageObject&>(*obj).GetProgramIndex(dynamic_cast<CProgrammableObject&>(*obj).GetCurrentProgram());
             if (run != -1)
             {
                 line->AddParam("run", MakeUnique<CLevelParserParam>(run+1));
@@ -4707,11 +4707,11 @@ bool CRobotMain::IOWriteScene(std::string filename, std::string filecbot, std::s
     {
         if (obj->GetType() == OBJECT_TOTO) continue;
         if (IsObjectBeingTransported(obj)) continue;
-        if (obj->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject*>(obj)->IsDying()) continue;
+        if (obj->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject&>(*obj).IsDying()) continue;
 
         if (obj->Implements(ObjectInterfaceType::Carrier))
         {
-            CObject* cargo = dynamic_cast<CCarrierObject*>(obj)->GetCargo();
+            CObject* cargo = dynamic_cast<CCarrierObject&>(*obj).GetCargo();
             if (cargo != nullptr)  // object transported?
             {
                 line = MakeUnique<CLevelParserLine>("CreateFret");
@@ -4722,7 +4722,7 @@ bool CRobotMain::IOWriteScene(std::string filename, std::string filecbot, std::s
 
         if (obj->Implements(ObjectInterfaceType::Powered))
         {
-            CObject* power = dynamic_cast<CPoweredObject*>(obj)->GetPower();
+            CObject* power = dynamic_cast<CPoweredObject&>(*obj).GetPower();
             if (power != nullptr) // battery transported?
             {
                 line = MakeUnique<CLevelParserLine>("CreatePower");
@@ -4761,7 +4761,7 @@ bool CRobotMain::IOWriteScene(std::string filename, std::string filecbot, std::s
     {
         if (obj->GetType() == OBJECT_TOTO) continue;
         if (IsObjectBeingTransported(obj)) continue;
-        if (obj->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject*>(obj)->IsDying()) continue;
+        if (obj->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject&>(*obj).IsDying()) continue;
 
         if (!SaveFileStack(obj, ostr))
         {
@@ -4912,7 +4912,7 @@ CObject* CRobotMain::IOReadScene(std::string filename, std::string filecbot)
             {
                 assert(obj->Implements(ObjectInterfaceType::Carrier)); // TODO: exception?
                 assert(obj->Implements(ObjectInterfaceType::Old));
-                dynamic_cast<CCarrierObject*>(obj)->SetCargo(cargo);
+                dynamic_cast<CCarrierObject&>(*obj).SetCargo(cargo);
                 auto task = MakeUnique<CTaskManip>(dynamic_cast<COldObject*>(obj));
                 task->Start(TMO_AUTO, TMA_GRAB);  // holds the object!
             }
@@ -4920,9 +4920,9 @@ CObject* CRobotMain::IOReadScene(std::string filename, std::string filecbot)
             if (power != nullptr)
             {
                 assert(obj->Implements(ObjectInterfaceType::Powered));
-                dynamic_cast<CPoweredObject*>(obj)->SetPower(power);
+                dynamic_cast<CPoweredObject&>(*obj).SetPower(power);
                 assert(power->Implements(ObjectInterfaceType::Transportable));
-                dynamic_cast<CTransportableObject*>(power)->SetTransporter(obj);
+                dynamic_cast<CTransportableObject&>(*power).SetTransporter(obj);
             }
             cargo = nullptr;
             power = nullptr;
@@ -4954,7 +4954,7 @@ CObject* CRobotMain::IOReadScene(std::string filename, std::string filecbot)
                 {
                     if (obj->GetType() == OBJECT_TOTO) continue;
                     if (IsObjectBeingTransported(obj)) continue;
-                    if (obj->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject*>(obj)->IsDying()) continue;
+                    if (obj->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject&>(*obj).IsDying()) continue;
 
                     if (!ReadFileStack(obj, istr))
                     {
@@ -5311,7 +5311,7 @@ Error CRobotMain::CheckEndMission(bool frame)
             if (m_base != nullptr && !m_endTakeImmediat)
             {
                 assert(m_base->Implements(ObjectInterfaceType::Controllable));
-                if(dynamic_cast<CControllableObject*>(m_base)->GetSelectable())
+                if(dynamic_cast<CControllableObject&>(*m_base).GetSelectable())
                     return ERR_MISSION_NOTERM;
             }
         }

--- a/src/level/scene_conditions.cpp
+++ b/src/level/scene_conditions.cpp
@@ -82,7 +82,7 @@ bool CObjectCondition::CheckForObject(CObject* obj)
     }
     else if (obj->Implements(ObjectInterfaceType::Powered))
     {
-        CObject* powerObj = dynamic_cast<CPoweredObject*>(obj)->GetPower();
+        CObject* powerObj = dynamic_cast<CPoweredObject&>(*obj).GetPower();
         if(powerObj != nullptr && powerObj->Implements(ObjectInterfaceType::PowerContainer))
         {
             power = dynamic_cast<CPowerContainerObject*>(powerObj);
@@ -98,7 +98,7 @@ bool CObjectCondition::CheckForObject(CObject* obj)
 
     Math::Vector oPos;
     if (IsObjectBeingTransported(obj))
-        oPos = dynamic_cast<CTransportableObject*>(obj)->GetTransporter()->GetPosition();
+        oPos = dynamic_cast<CTransportableObject&>(*obj).GetTransporter()->GetPosition();
     else
         oPos = obj->GetPosition();
     oPos.y = 0.0f;

--- a/src/object/auto/autobase.cpp
+++ b/src/object/auto/autobase.cpp
@@ -169,7 +169,7 @@ begin:
             else
             {
                 assert(pObj->Implements(ObjectInterfaceType::Controllable));
-                m_camera->SetType(dynamic_cast<CControllableObject*>(pObj)->GetCameraType());
+                m_camera->SetType(dynamic_cast<CControllableObject&>(*pObj).GetCameraType());
             }
 
             m_main->StartMusic();
@@ -594,7 +594,7 @@ begin:
                 else
                 {
                     assert(pObj->Implements(ObjectInterfaceType::Controllable));
-                    m_camera->SetType(dynamic_cast<CControllableObject*>(pObj)->GetCameraType());
+                    m_camera->SetType(dynamic_cast<CControllableObject&>(*pObj).GetCameraType());
                 }
                 m_sound->Play(SOUND_BOUM, m_object->GetPosition());
                 m_soundChannel = -1;
@@ -1124,7 +1124,7 @@ bool CAutoBase::Abort()
             else
             {
                 assert(pObj->Implements(ObjectInterfaceType::Controllable));
-                m_camera->SetType(dynamic_cast<CControllableObject*>(pObj)->GetCameraType());
+                m_camera->SetType(dynamic_cast<CControllableObject&>(*pObj).GetCameraType());
             }
 
             m_engine->SetFogStart(m_fogStart);
@@ -1248,7 +1248,7 @@ void CAutoBase::FreezeCargo(bool freeze)
             m_cargoObjects.insert(obj);
             if ( obj->Implements(ObjectInterfaceType::Movable) )
             {
-                CPhysics* physics = dynamic_cast<CMovableObject*>(obj)->GetPhysics();
+                CPhysics* physics = dynamic_cast<CMovableObject&>(*obj).GetPhysics();
                 physics->SetFreeze(freeze);
             }
         }

--- a/src/object/auto/autodestroyer.cpp
+++ b/src/object/auto/autodestroyer.cpp
@@ -176,7 +176,7 @@ bool CAutoDestroyer::EventProcess(const Event &event)
             if ( scrap != nullptr )
             {
                 assert(scrap->Implements(ObjectInterfaceType::Destroyable));
-                dynamic_cast<CDestroyableObject*>(scrap)->DestroyObject(DestructionType::Explosion);
+                dynamic_cast<CDestroyableObject&>(*scrap).DestroyObject(DestructionType::Explosion);
             }
             m_bExplo = true;
         }

--- a/src/object/auto/autoegg.cpp
+++ b/src/object/auto/autoegg.cpp
@@ -74,7 +74,7 @@ void CAutoEgg::DeleteObject(bool all)
                 alien->SetLock(false);
                 if (alien->Implements(ObjectInterfaceType::Programmable))
                 {
-                    dynamic_cast<CProgrammableObject*>(alien)->SetActivity(true);  // the insect is active
+                    dynamic_cast<CProgrammableObject&>(*alien).SetActivity(true);  // the insect is active
                 }
             }
             else
@@ -123,7 +123,7 @@ void CAutoEgg::Init()
 
     if (alien->Implements(ObjectInterfaceType::Programmable))
     {
-        dynamic_cast<CProgrammableObject*>(alien)->SetActivity(false);
+        dynamic_cast<CProgrammableObject&>(*alien).SetActivity(false);
     }
 }
 
@@ -204,7 +204,7 @@ bool CAutoEgg::EventProcess(const Event &event)
     if ( alien == nullptr )  return true;
     if (alien->Implements(ObjectInterfaceType::Programmable))
     {
-        dynamic_cast<CProgrammableObject*>(alien)->SetActivity(false);
+        dynamic_cast<CProgrammableObject&>(*alien).SetActivity(false);
     }
 
     m_progress += event.rTime*m_speed;
@@ -265,7 +265,7 @@ Error CAutoEgg::IsEnded()
         alien->SetLock(false);
         if(alien->Implements(ObjectInterfaceType::Programmable))
         {
-            dynamic_cast<CProgrammableObject*>(alien)->SetActivity(true);  // the insect is active
+            dynamic_cast<CProgrammableObject&>(*alien).SetActivity(true);  // the insect is active
         }
     }
 

--- a/src/object/auto/autofactory.cpp
+++ b/src/object/auto/autofactory.cpp
@@ -397,7 +397,7 @@ bool CAutoFactory::EventProcess(const Event &event)
             if ( vehicle != nullptr )
             {
                 assert(vehicle->Implements(ObjectInterfaceType::Movable));
-                physics = dynamic_cast<CMovableObject*>(vehicle)->GetPhysics();
+                physics = dynamic_cast<CMovableObject&>(*vehicle).GetPhysics();
                 physics->SetFreeze(false);  // can move
 
                 vehicle->SetLock(false);  // vehicle useable
@@ -408,7 +408,7 @@ bool CAutoFactory::EventProcess(const Event &event)
                 {
                     if (vehicle->Implements(ObjectInterfaceType::Programmable) && vehicle->Implements(ObjectInterfaceType::ProgramStorage))
                     {
-                        Program* program = dynamic_cast<CProgramStorageObject*>(vehicle)->AddProgram();
+                        Program* program = dynamic_cast<CProgramStorageObject&>(*vehicle).AddProgram();
 
                         if (boost::regex_match(m_program, boost::regex("[A-Za-z0-9_]+"))) // Public function name?
                         {
@@ -424,7 +424,7 @@ bool CAutoFactory::EventProcess(const Event &event)
                             program->script->SendScript(m_program.c_str());
                         }
 
-                        dynamic_cast<CProgrammableObject*>(vehicle)->RunProgram(program);
+                        dynamic_cast<CProgrammableObject&>(*vehicle).RunProgram(program);
                     }
                 }
             }
@@ -670,7 +670,7 @@ bool CAutoFactory::CreateVehicle()
     vehicle->SetLock(true);  // not usable
 
     assert(vehicle->Implements(ObjectInterfaceType::Movable));
-    CPhysics* physics = dynamic_cast<CMovableObject*>(vehicle)->GetPhysics();
+    CPhysics* physics = dynamic_cast<CMovableObject&>(*vehicle).GetPhysics();
     physics->SetFreeze(true);  // it doesn't move
 
     if (vehicle->Implements(ObjectInterfaceType::ProgramStorage))

--- a/src/object/auto/autonuclearplant.cpp
+++ b/src/object/auto/autonuclearplant.cpp
@@ -400,7 +400,7 @@ void CAutoNuclearPlant::CreatePower()
     float powerLevel = 1.0f;
     CObject* power = CObjectManager::GetInstancePointer()->CreateObject(pos, angle, OBJECT_ATOMIC, powerLevel);
 
-    dynamic_cast<CTransportableObject*>(power)->SetTransporter(m_object);
+    dynamic_cast<CTransportableObject&>(*power).SetTransporter(m_object);
     power->SetPosition(Math::Vector(22.0f, 3.0f, 0.0f));
     m_object->SetPower(power);
 }

--- a/src/object/auto/autopowercaptor.cpp
+++ b/src/object/auto/autopowercaptor.cpp
@@ -269,7 +269,7 @@ void CAutoPowerCaptor::ChargeObject(float rTime)
 
         if (obj->Implements(ObjectInterfaceType::Powered))
         {
-            CObject* power = dynamic_cast<CPoweredObject*>(obj)->GetPower();
+            CObject* power = dynamic_cast<CPoweredObject&>(*obj).GetPower();
             if ( power != nullptr && power->Implements(ObjectInterfaceType::PowerContainer) )
             {
                 CPowerContainerObject* powerContainer = dynamic_cast<CPowerContainerObject*>(power);
@@ -285,7 +285,7 @@ void CAutoPowerCaptor::ChargeObject(float rTime)
 
         if (obj->Implements(ObjectInterfaceType::Carrier))
         {
-            CObject* power = dynamic_cast<CCarrierObject*>(obj)->GetCargo();
+            CObject* power = dynamic_cast<CCarrierObject&>(*obj).GetCargo();
             if ( power != nullptr && power->Implements(ObjectInterfaceType::PowerContainer) )
             {
                 CPowerContainerObject* powerContainer = dynamic_cast<CPowerContainerObject*>(power);

--- a/src/object/auto/autopowerplant.cpp
+++ b/src/object/auto/autopowerplant.cpp
@@ -331,7 +331,7 @@ bool CAutoPowerPlant::EventProcess(const Event &event)
 
                 cargo->SetScale(1.0f);
                 cargo->SetLock(false);  // usable battery
-                dynamic_cast<CTransportableObject*>(cargo)->SetTransporter(m_object);
+                dynamic_cast<CTransportableObject&>(*cargo).SetTransporter(m_object);
                 cargo->SetPosition(Math::Vector(0.0f, 3.0f, 0.0f));
                 m_object->SetPower(cargo);
 

--- a/src/object/auto/autopowerstation.cpp
+++ b/src/object/auto/autopowerstation.cpp
@@ -138,7 +138,7 @@ bool CAutoPowerStation::EventProcess(const Event &event)
         {
             if (vehicle->Implements(ObjectInterfaceType::Powered))
             {
-                CObject* power = dynamic_cast<CPoweredObject*>(vehicle)->GetPower();
+                CObject* power = dynamic_cast<CPoweredObject&>(*vehicle).GetPower();
                 if ( power != nullptr && power->Implements(ObjectInterfaceType::PowerContainer) )
                 {
                     CPowerContainerObject* powerContainer = dynamic_cast<CPowerContainerObject*>(power);
@@ -158,7 +158,7 @@ bool CAutoPowerStation::EventProcess(const Event &event)
 
             if (vehicle->Implements(ObjectInterfaceType::Carrier))
             {
-                CObject* power = dynamic_cast<CCarrierObject*>(vehicle)->GetCargo();
+                CObject* power = dynamic_cast<CCarrierObject&>(*vehicle).GetCargo();
                 if ( power != nullptr && power->Implements(ObjectInterfaceType::PowerContainer) )
                 {
                     CPowerContainerObject* powerContainer = dynamic_cast<CPowerContainerObject*>(power);

--- a/src/object/auto/autorepair.cpp
+++ b/src/object/auto/autorepair.cpp
@@ -148,7 +148,7 @@ bool CAutoRepair::EventProcess(const Event &event)
             assert(vehicle->Implements(ObjectInterfaceType::Shielded));
 
         if ( m_progress < 1.0f ||
-             (vehicle != nullptr && dynamic_cast<CShieldedObject*>(vehicle)->GetShield() < 1.0f) )
+             (vehicle != nullptr && dynamic_cast<CShieldedObject&>(*vehicle).GetShield() < 1.0f) )
         {
             if ( vehicle != nullptr )
             {
@@ -243,9 +243,9 @@ CObject* CAutoRepair::SearchVehicle()
     {
         if (obj == m_object) continue;
         if ( !obj->Implements(ObjectInterfaceType::Shielded) ) continue;
-        if ( !dynamic_cast<CShieldedObject*>(obj)->IsRepairable() )  continue;
+        if ( !dynamic_cast<CShieldedObject&>(*obj).IsRepairable() )  continue;
 
-        if ( obj->Implements(ObjectInterfaceType::Movable) && !dynamic_cast<CMovableObject*>(obj)->GetPhysics()->GetLand() )  continue;  // in flight?
+        if ( obj->Implements(ObjectInterfaceType::Movable) && !dynamic_cast<CMovableObject&>(*obj).GetPhysics()->GetLand() )  continue;  // in flight?
 
         Math::Vector oPos = obj->GetPosition();
         float dist = Math::Distance(oPos, sPos);

--- a/src/object/auto/autotower.cpp
+++ b/src/object/auto/autotower.cpp
@@ -289,7 +289,7 @@ CObject* CAutoTower::SearchTarget(Math::Vector &impact)
         {
             if ( obj->Implements(ObjectInterfaceType::Movable) )
             {
-                CPhysics* physics = dynamic_cast<CMovableObject*>(obj)->GetPhysics();
+                CPhysics* physics = dynamic_cast<CMovableObject&>(*obj).GetPhysics();
                 float speed = fabs(physics->GetLinMotionX(MO_REASPEED));
                 if ( speed > 20.0f )  continue;  // moving too fast?
             }
@@ -302,8 +302,7 @@ CObject* CAutoTower::SearchTarget(Math::Vector &impact)
         if ( distance > TOWER_SCOPE )  continue;  // too far
         if ( distance < min )
         {
-            min = distance;
-            best = obj;
+            min = distance; best = obj;
         }
     }
     if ( best == nullptr )  return nullptr;
@@ -327,7 +326,7 @@ Error CAutoTower::GetError()
         return ERR_TOWER_POWER;  // no battery
     }
 
-    if ( dynamic_cast<CPowerContainerObject*>(m_object->GetPower())->GetEnergy() < ENERGY_FIRE )
+    if ( dynamic_cast<CPowerContainerObject&>(*m_object->GetPower()).GetEnergy() < ENERGY_FIRE )
     {
         return ERR_TOWER_ENERGY;  // not enough energy
     }

--- a/src/object/implementation/program_storage_impl.cpp
+++ b/src/object/implementation/program_storage_impl.cpp
@@ -270,7 +270,7 @@ void CProgramStorageObjectImpl::LoadAllProgramsForLevel(CLevelParserLine* levelS
 
             if (m_object->Implements(ObjectInterfaceType::Programmable) && i == run)
             {
-                dynamic_cast<CProgrammableObject*>(m_object)->RunProgram(program);
+                dynamic_cast<CProgrammableObject&>(*m_object).RunProgram(program);
             }
         }
         else
@@ -327,7 +327,7 @@ void CProgramStorageObjectImpl::SaveAllProgramsForSavedScene(CLevelParserLine* l
     }
 
     if (m_programStorageIndex < 0) return;
-    if (!m_object->Implements(ObjectInterfaceType::Controllable) || !dynamic_cast<CControllableObject*>(m_object)->GetSelectable() || m_object->GetType() == OBJECT_HUMAN) return;
+    if (!m_object->Implements(ObjectInterfaceType::Controllable) || !dynamic_cast<CControllableObject&>(*m_object).GetSelectable() || m_object->GetType() == OBJECT_HUMAN) return;
 
     GetLogger()->Debug("Saving saved scene programs to '%s/prog%.3d___.txt'\n", levelSource.c_str(), m_programStorageIndex);
     for (unsigned int i = 0; i < m_program.size(); i++)
@@ -379,7 +379,7 @@ void CProgramStorageObjectImpl::LoadAllProgramsForSavedScene(CLevelParserLine* l
 
             if (m_object->Implements(ObjectInterfaceType::Programmable) && i == run)
             {
-                dynamic_cast<CProgrammableObject*>(m_object)->RunProgram(program);
+                dynamic_cast<CProgrammableObject&>(*m_object).RunProgram(program);
             }
         }
     }
@@ -403,7 +403,7 @@ void CProgramStorageObjectImpl::LoadAllProgramsForSavedScene(CLevelParserLine* l
 
             if (m_object->Implements(ObjectInterfaceType::Programmable) && i == run)
             {
-                dynamic_cast<CProgrammableObject*>(m_object)->RunProgram(program);
+                dynamic_cast<CProgrammableObject&>(*m_object).RunProgram(program);
             }
         }
     }

--- a/src/object/implementation/programmable_impl.cpp
+++ b/src/object/implementation/programmable_impl.cpp
@@ -68,7 +68,7 @@ bool CProgrammableObjectImpl::EventProcess(const Event &event)
 {
     if (event.type == EVENT_FRAME)
     {
-        if ( m_object->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject*>(m_object)->IsDying() && IsProgram() )
+        if ( m_object->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject&>(*m_object).IsDying() && IsProgram() )
         {
             StopProgram();
         }
@@ -113,7 +113,7 @@ void CProgrammableObjectImpl::RunProgram(Program* program)
     {
         m_currentProgram = program;  // start new program
         m_object->UpdateInterface();
-        if (m_object->Implements(ObjectInterfaceType::Controllable) && dynamic_cast<CControllableObject*>(m_object)->GetTrainer())
+        if (m_object->Implements(ObjectInterfaceType::Controllable) && dynamic_cast<CControllableObject&>(*m_object).GetTrainer())
             CRobotMain::GetInstancePointer()->StartMissionTimer();
     }
 }
@@ -155,7 +155,7 @@ bool CProgrammableObjectImpl::ReadStack(std::istream &istr)
         {
             if (m_object->Implements(ObjectInterfaceType::ProgramStorage))
             {
-                int count = static_cast<int>(dynamic_cast<CProgramStorageObject*>(m_object)->GetProgramCount());
+                int count = static_cast<int>(dynamic_cast<CProgramStorageObject&>(*m_object).GetProgramCount());
                 if (!(op < count))
                 {
                     GetLogger()->Info("Object program count: %i\n", count);
@@ -163,7 +163,7 @@ bool CProgrammableObjectImpl::ReadStack(std::istream &istr)
                     return false;
                 }
 
-                m_currentProgram = dynamic_cast<CProgramStorageObject*>(m_object)->GetProgram(op);
+                m_currentProgram = dynamic_cast<CProgramStorageObject&>(*m_object).GetProgram(op);
                 if (!m_currentProgram->script->ReadStack(istr))
                 {
                     GetLogger()->Error("Restore state failed at program index: %i\n", op);
@@ -203,7 +203,7 @@ bool CProgrammableObjectImpl::WriteStack(std::ostream &ostr)
         op = -1;
         if (m_object->Implements(ObjectInterfaceType::ProgramStorage))
         {
-            op = dynamic_cast<CProgramStorageObject*>(m_object)->GetProgramIndex(m_currentProgram);
+            op = dynamic_cast<CProgramStorageObject&>(*m_object).GetProgramIndex(m_currentProgram);
         }
         if (!CBot::WriteShort(ostr, op)) return false;
 
@@ -266,7 +266,7 @@ void CProgrammableObjectImpl::TraceRecordFrame()
     assert(m_object->Implements(ObjectInterfaceType::TraceDrawing));
     CTraceDrawingObject* traceDrawing = dynamic_cast<CTraceDrawingObject*>(m_object);
 
-    CPhysics* physics = dynamic_cast<CMovableObject*>(m_object)->GetPhysics();
+    CPhysics* physics = dynamic_cast<CMovableObject&>(*m_object).GetPhysics();
 
     speed = physics->GetLinMotionX(MO_REASPEED);
     if ( speed > 0.0f )  oper = TO_ADVANCE;
@@ -353,7 +353,7 @@ void CProgrammableObjectImpl::TraceRecordStop()
     buffer << "}\n";
 
     assert(m_object->Implements(ObjectInterfaceType::ProgramStorage));
-    Program* prog = dynamic_cast<CProgramStorageObject*>(m_object)->AddProgram();
+    Program* prog = dynamic_cast<CProgramStorageObject&>(*m_object).AddProgram();
     prog->script->SendScript(buffer.str().c_str());
 }
 

--- a/src/object/motion/motionant.cpp
+++ b/src/object/motion/motionant.cpp
@@ -429,7 +429,7 @@ bool CMotionAnt::EventFrame(const Event &event)
     assert(m_object->Implements(ObjectInterfaceType::Destroyable));
     if ( dynamic_cast<CDestroyableObject*>(m_object)->GetDying() == DeathType::Burning )  // burning?
     {
-        if ( dynamic_cast<CBaseAlien*>(m_object)->GetFixed() )
+        if ( dynamic_cast<CBaseAlien&>(*m_object).GetFixed() )
         {
             m_actionType = MAS_BURN;
         }
@@ -724,7 +724,7 @@ bool CMotionAnt::EventFrame(const Event &event)
         if ( m_progress >= 1.0f )
         {
             SetAction(-1);
-            dynamic_cast<CBaseAlien*>(m_object)->SetFixed(false);  // moving again
+            dynamic_cast<CBaseAlien&>(*m_object).SetFixed(false);  // moving again
         }
     }
     else

--- a/src/object/motion/motionspider.cpp
+++ b/src/object/motion/motionspider.cpp
@@ -364,7 +364,7 @@ bool CMotionSpider::EventFrame(const Event &event)
     assert(m_object->Implements(ObjectInterfaceType::Destroyable));
     if (dynamic_cast<CDestroyableObject*>(m_object)->GetDying() == DeathType::Burning )  // burning?
     {
-        if ( dynamic_cast<CBaseAlien*>(m_object)->GetFixed() )
+        if ( dynamic_cast<CBaseAlien&>(*m_object).GetFixed() )
         {
             m_actionType = MSS_BURN;
         }
@@ -648,7 +648,7 @@ bool CMotionSpider::EventFrame(const Event &event)
         if ( m_progress >= 1.0f )
         {
             SetAction(-1);
-            dynamic_cast<CBaseAlien*>(m_object)->SetFixed(false);  // moving again
+            dynamic_cast<CBaseAlien&>(*m_object).SetFixed(false);  // moving again
         }
     }
     else

--- a/src/object/motion/motionvehicle.cpp
+++ b/src/object/motion/motionvehicle.cpp
@@ -1075,7 +1075,7 @@ void CMotionVehicle::Create(Math::Vector pos, float angle, ObjectType type,
 
         powerCell->SetPosition(powerCellPos);
         powerCell->SetRotation(Math::Vector(0.0f, powerCellAngle, 0.0f));
-        dynamic_cast<CTransportableObject*>(powerCell)->SetTransporter(m_object);
+        dynamic_cast<CTransportableObject&>(*powerCell).SetTransporter(m_object);
         assert(m_object->Implements(ObjectInterfaceType::Powered));
         m_object->SetPower(powerCell);
     }

--- a/src/object/object_manager.cpp
+++ b/src/object/object_manager.cpp
@@ -217,7 +217,7 @@ void CObjectManager::DestroyTeam(int team, DestructionType destructionType)
         {
             if (object->Implements(ObjectInterfaceType::Destroyable))
             {
-                dynamic_cast<CDestroyableObject*>(object)->DestroyObject(destructionType);
+                dynamic_cast<CDestroyableObject&>(*object).DestroyObject(destructionType);
             }
             else
             {
@@ -336,7 +336,7 @@ std::vector<CObject*> CObjectManager::RadarAll(CObject* pThis, Math::Vector this
         {
             if ( pObj->Implements(ObjectInterfaceType::Movable) )
             {
-                CPhysics* physics = dynamic_cast<CMovableObject*>(pObj)->GetPhysics();
+                CPhysics* physics = dynamic_cast<CMovableObject&>(*pObj).GetPhysics();
                 if ( physics != nullptr )
                 {
                     if ( !physics->GetLand() )  continue;
@@ -346,7 +346,7 @@ std::vector<CObject*> CObjectManager::RadarAll(CObject* pThis, Math::Vector this
         if ( filter_flying == FILTER_ONLYFLYING )
         {
             if ( !pObj->Implements(ObjectInterfaceType::Movable) ) continue;
-            CPhysics* physics = dynamic_cast<CMovableObject*>(pObj)->GetPhysics();
+            CPhysics* physics = dynamic_cast<CMovableObject&>(*pObj).GetPhysics();
             if ( physics == nullptr ) continue;
             if ( physics->GetLand() ) continue;
         }

--- a/src/object/old_object.cpp
+++ b/src/object/old_object.cpp
@@ -285,8 +285,8 @@ void COldObject::DeleteObject(bool bAll)
         {
             if (m_power->Implements(ObjectInterfaceType::Old))
             {
-                dynamic_cast<COldObject*>(m_power)->SetTransporter(nullptr);
-                dynamic_cast<COldObject*>(m_power)->DeleteObject(bAll);
+                dynamic_cast<COldObject&>(*m_power).SetTransporter(nullptr);
+                dynamic_cast<COldObject&>(*m_power).DeleteObject(bAll);
             }
             m_power = nullptr;
         }
@@ -294,8 +294,8 @@ void COldObject::DeleteObject(bool bAll)
         {
             if (m_cargo->Implements(ObjectInterfaceType::Old))
             {
-                dynamic_cast<COldObject*>(m_cargo)->SetTransporter(nullptr);
-                dynamic_cast<COldObject*>(m_cargo)->DeleteObject(bAll);
+                dynamic_cast<COldObject&>(*m_cargo).SetTransporter(nullptr);
+                dynamic_cast<COldObject&>(*m_cargo).DeleteObject(bAll);
             }
             m_cargo = nullptr;
         }

--- a/src/object/task/taskfire.cpp
+++ b/src/object/task/taskfire.cpp
@@ -317,7 +317,7 @@ Error CTaskFire::Start(float delay)
     CObject* power = dynamic_cast<CPoweredObject*>(m_object)->GetPower();
     if (power == nullptr || !power->Implements(ObjectInterfaceType::PowerContainer))  return ERR_FIRE_ENERGY;
 
-    energy = dynamic_cast<CPowerContainerObject*>(power)->GetEnergy();
+    energy = dynamic_cast<CPowerContainerObject&>(*power).GetEnergy();
          if ( m_bOrganic )  fire = m_delay*ENERGY_FIREi;
     else if ( m_bRay     )  fire = m_delay*ENERGY_FIREr;
     else                    fire = m_delay*ENERGY_FIRE;

--- a/src/object/task/taskfireant.cpp
+++ b/src/object/task/taskfireant.cpp
@@ -60,7 +60,7 @@ bool CTaskFireAnt::EventProcess(const Event &event)
     if ( event.type != EVENT_FRAME )  return true;
     if ( m_bError )  return false;
 
-    if ( dynamic_cast<CBaseAlien*>(m_object)->GetFixed() )  // insect on its back?
+    if ( dynamic_cast<CBaseAlien&>(*m_object).GetFixed() )  // insect on its back?
     {
         m_bError = true;
         return false;
@@ -100,7 +100,7 @@ Error CTaskFireAnt::Start(Math::Vector impact)
     if ( type != OBJECT_ANT )  return ERR_WRONG_BOT;
 
     // Insect on its back?
-    if ( dynamic_cast<CBaseAlien*>(m_object)->GetFixed() )  return ERR_WRONG_BOT;
+    if ( dynamic_cast<CBaseAlien&>(*m_object).GetFixed() )  return ERR_WRONG_BOT;
 
     m_physics->SetMotorSpeed(Math::Vector(0.0f, 0.0f, 0.0f));
 
@@ -130,7 +130,7 @@ Error CTaskFireAnt::IsEnded()
 
     if ( m_engine->GetPause() )  return ERR_CONTINUE;
     if ( m_bError )  return ERR_STOP;
-    if ( dynamic_cast<CBaseAlien*>(m_object)->GetFixed() )  return ERR_STOP;  // insect on its back?
+    if ( dynamic_cast<CBaseAlien&>(*m_object).GetFixed() )  return ERR_STOP;  // insect on its back?
 
     if ( m_phase == TFA_TURN )  // rotation ?
     {

--- a/src/object/task/taskgoto.cpp
+++ b/src/object/task/taskgoto.cpp
@@ -1202,7 +1202,7 @@ bool CTaskGoto::AdjustTarget(CObject* pObj, Math::Vector &pos, float &distance)
          type == OBJECT_MOBILEdr )
     {
         assert(pObj->Implements(ObjectInterfaceType::Powered));
-        pos = dynamic_cast<CPoweredObject*>(pObj)->GetPowerPosition();
+        pos = dynamic_cast<CPoweredObject&>(*pObj).GetPowerPosition();
         pos.x -= TAKE_DIST+TAKE_DIST_OTHER+distance;
         mat = pObj->GetWorldMatrix(0);
         pos = Transform(*mat, pos);

--- a/src/object/task/taskmanip.cpp
+++ b/src/object/task/taskmanip.cpp
@@ -304,8 +304,8 @@ Error CTaskManip::Start(TaskManipOrder order, TaskManipArm arm)
             assert(other->Implements(ObjectInterfaceType::Transportable));
 
             m_object->SetCargo(other);  // takes the ball
-            dynamic_cast<CTransportableObject*>(other)->SetTransporter(m_object);
-            dynamic_cast<CTransportableObject*>(other)->SetTransporterPart(0);  // taken with the base
+            dynamic_cast<CTransportableObject&>(*other).SetTransporter(m_object);
+            dynamic_cast<CTransportableObject&>(*other).SetTransporterPart(0);  // taken with the base
             other->SetPosition(Math::Vector(0.0f, -3.0f, 0.0f));
         }
         else
@@ -314,7 +314,7 @@ Error CTaskManip::Start(TaskManipOrder order, TaskManipArm arm)
             assert(other->Implements(ObjectInterfaceType::Transportable));
 
             m_object->SetCargo(nullptr);  // lick the ball
-            dynamic_cast<CTransportableObject*>(other)->SetTransporter(nullptr);
+            dynamic_cast<CTransportableObject&>(*other).SetTransporter(nullptr);
             pos = m_object->GetPosition();
             pos.y -= 3.0f;
             other->SetPosition(pos);
@@ -903,7 +903,7 @@ CObject* CTaskManip::SearchOtherObject(bool bAdvance, Math::Vector &pos,
         ObjectType type = pObj->GetType();
         if ( !pObj->Implements(ObjectInterfaceType::Powered) )  continue;
 
-        CObject* power = dynamic_cast<CPoweredObject*>(pObj)->GetPower();
+        CObject* power = dynamic_cast<CPoweredObject&>(*pObj).GetPower();
         if (power != nullptr)
         {
             if (power->GetLock())  continue;
@@ -911,7 +911,7 @@ CObject* CTaskManip::SearchOtherObject(bool bAdvance, Math::Vector &pos,
         }
 
         mat = pObj->GetWorldMatrix(0);
-        Math::Vector oPos = Transform(*mat, dynamic_cast<CPoweredObject*>(pObj)->GetPowerPosition());
+        Math::Vector oPos = Transform(*mat, dynamic_cast<CPoweredObject&>(*pObj).GetPowerPosition());
 
         oAngle = pObj->GetRotationY();
         if ( type == OBJECT_TOWER    ||
@@ -946,7 +946,7 @@ CObject* CTaskManip::SearchOtherObject(bool bAdvance, Math::Vector &pos,
             angle = Math::RotateAngle(oPos.x-iPos.x, iPos.z-oPos.z);  // CW !
             if ( Math::TestAngle(angle, iAngle-aLimit, iAngle+aLimit) )
             {
-                Math::Vector powerPos = dynamic_cast<CPoweredObject*>(pObj)->GetPowerPosition();
+                Math::Vector powerPos = dynamic_cast<CPoweredObject&>(*pObj).GetPowerPosition();
                 height = powerPos.y;
                 pos = oPos;
                 return pObj;
@@ -974,8 +974,8 @@ bool CTaskManip::TransporterTakeObject()
         if ( m_object->GetType() == OBJECT_HUMAN ||
              m_object->GetType() == OBJECT_TECH  )
         {
-            dynamic_cast<CTransportableObject*>(cargo)->SetTransporter(m_object);
-            dynamic_cast<CTransportableObject*>(cargo)->SetTransporterPart(4);  // takes with the hand
+            dynamic_cast<CTransportableObject&>(*cargo).SetTransporter(m_object);
+            dynamic_cast<CTransportableObject&>(*cargo).SetTransporterPart(4);  // takes with the hand
 
             cargo->SetPosition(Math::Vector(1.7f, -0.5f, 1.1f));
             cargo->SetRotationY(0.1f);
@@ -984,8 +984,8 @@ bool CTaskManip::TransporterTakeObject()
         }
         else if ( m_bSubm )
         {
-            dynamic_cast<CTransportableObject*>(cargo)->SetTransporter(m_object);
-            dynamic_cast<CTransportableObject*>(cargo)->SetTransporterPart(2);  // takes with the right claw
+            dynamic_cast<CTransportableObject&>(*cargo).SetTransporter(m_object);
+            dynamic_cast<CTransportableObject&>(*cargo).SetTransporterPart(2);  // takes with the right claw
 
             Math::Vector pos = Math::Vector(1.1f, -1.0f, 1.0f);  // relative
             cargo->SetPosition(pos);
@@ -995,8 +995,8 @@ bool CTaskManip::TransporterTakeObject()
         }
         else
         {
-            dynamic_cast<CTransportableObject*>(cargo)->SetTransporter(m_object);
-            dynamic_cast<CTransportableObject*>(cargo)->SetTransporterPart(3);  // takes with the hand
+            dynamic_cast<CTransportableObject&>(*cargo).SetTransporter(m_object);
+            dynamic_cast<CTransportableObject&>(*cargo).SetTransporterPart(3);  // takes with the hand
 
             Math::Vector pos = Math::Vector(4.7f, 0.0f, 0.0f);  // relative to the hand (lem4)
             cargo->SetPosition(pos);
@@ -1020,8 +1020,8 @@ bool CTaskManip::TransporterTakeObject()
 
         if ( m_bSubm )
         {
-            dynamic_cast<CTransportableObject*>(cargo)->SetTransporter(m_object);
-            dynamic_cast<CTransportableObject*>(cargo)->SetTransporterPart(2);  // takes with the right claw
+            dynamic_cast<CTransportableObject&>(*cargo).SetTransporter(m_object);
+            dynamic_cast<CTransportableObject&>(*cargo).SetTransporterPart(2);  // takes with the right claw
 
             pos = Math::Vector(1.1f, -1.0f, 1.0f);  // relative
             cargo->SetPosition(pos);
@@ -1031,8 +1031,8 @@ bool CTaskManip::TransporterTakeObject()
         }
         else
         {
-            dynamic_cast<CTransportableObject*>(cargo)->SetTransporter(m_object);
-            dynamic_cast<CTransportableObject*>(cargo)->SetTransporterPart(3);  // takes with the hand
+            dynamic_cast<CTransportableObject&>(*cargo).SetTransporter(m_object);
+            dynamic_cast<CTransportableObject&>(*cargo).SetTransporterPart(3);  // takes with the hand
 
             pos = Math::Vector(4.7f, 0.0f, 0.0f);  // relative to the hand (lem4)
             cargo->SetPosition(pos);
@@ -1054,8 +1054,8 @@ bool CTaskManip::TransporterTakeObject()
 
         m_cargoType = cargo->GetType();
 
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporter(m_object);
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporterPart(3);  // takes with the hand
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporter(m_object);
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporterPart(3);  // takes with the hand
 
         pos = Math::Vector(4.7f, 0.0f, 0.0f);  // relative to the hand (lem4)
         cargo->SetPosition(pos);
@@ -1080,7 +1080,7 @@ bool CTaskManip::TransporterTakeObject()
         cargo->SetRotationX(0.0f);
         cargo->SetRotationZ(Math::PI/2.0f);
         cargo->SetRotationY(0.0f);
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporterPart(3);  // takes with the hand
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporterPart(3);  // takes with the hand
 
         m_object->SetPower(nullptr);
         m_object->SetCargo(cargo);  // takes
@@ -1094,15 +1094,15 @@ bool CTaskManip::TransporterTakeObject()
         if (other == nullptr)  return false;
         assert(other->Implements(ObjectInterfaceType::Powered));
 
-        CObject* cargo = dynamic_cast<CPoweredObject*>(other)->GetPower();
+        CObject* cargo = dynamic_cast<CPoweredObject&>(*other).GetPower();
         if (cargo == nullptr)  return false;  // the other does not have a battery?
         assert(cargo->Implements(ObjectInterfaceType::Transportable));
 
         m_cargoType = cargo->GetType();
 
-        dynamic_cast<CPoweredObject*>(other)->SetPower(nullptr);
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporter(m_object);
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporterPart(3);  // takes with the hand
+        dynamic_cast<CPoweredObject&>(*other).SetPower(nullptr);
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporter(m_object);
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporterPart(3);  // takes with the hand
 
         pos = Math::Vector(4.7f, 0.0f, 0.0f);  // relative to the hand (lem4)
         cargo->SetPosition(pos);
@@ -1137,7 +1137,7 @@ bool CTaskManip::TransporterDeposeObject()
         cargo->SetRotationZ(0.0f);
         cargo->FloorAdjust();  // plate well on the ground
 
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporter(nullptr);
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporter(nullptr);
         m_object->SetCargo(nullptr);  // deposit
     }
 
@@ -1157,7 +1157,7 @@ bool CTaskManip::TransporterDeposeObject()
         cargo->SetRotationX(0.0f);
         cargo->SetRotationZ(0.0f);
 
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporter(nullptr);
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporter(nullptr);
         m_object->SetCargo(nullptr);  // deposit
     }
 
@@ -1172,8 +1172,8 @@ bool CTaskManip::TransporterDeposeObject()
 
         if (m_object->GetPower() != nullptr)  return false;
 
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporter(m_object);
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporterPart(0);  // carried by the base
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporter(m_object);
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporterPart(0);  // carried by the base
 
         cargo->SetPosition(m_object->GetPowerPosition());
         cargo->SetRotationY(0.0f);
@@ -1193,7 +1193,7 @@ bool CTaskManip::TransporterDeposeObject()
         if (other == nullptr)  return false;
         assert(other->Implements(ObjectInterfaceType::Powered));
 
-        CObject* cargo = dynamic_cast<CPoweredObject*>(other)->GetPower();
+        CObject* cargo = dynamic_cast<CPoweredObject&>(*other).GetPower();
         if (cargo != nullptr)  return false;  // the other already has a battery?
 
         cargo = m_object->GetCargo();
@@ -1202,14 +1202,14 @@ bool CTaskManip::TransporterDeposeObject()
 
         m_cargoType = cargo->GetType();
 
-        dynamic_cast<CPoweredObject*>(other)->SetPower(cargo);
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporter(other);
+        dynamic_cast<CPoweredObject&>(*other).SetPower(cargo);
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporter(other);
 
-        cargo->SetPosition(dynamic_cast<CPoweredObject*>(other)->GetPowerPosition());
+        cargo->SetPosition(dynamic_cast<CPoweredObject&>(*other).GetPowerPosition());
         cargo->SetRotationY(0.0f);
         cargo->SetRotationX(0.0f);
         cargo->SetRotationZ(0.0f);
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporterPart(0);  // carried by the base
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporterPart(0);  // carried by the base
 
         m_object->SetCargo(nullptr);  // deposit
     }

--- a/src/object/task/taskrecover.cpp
+++ b/src/object/task/taskrecover.cpp
@@ -194,7 +194,7 @@ Error CTaskRecover::Start()
     CObject* power = dynamic_cast<CPoweredObject*>(m_object)->GetPower();
     if (power == nullptr || !power->Implements(ObjectInterfaceType::PowerContainer))  return ERR_RECOVER_ENERGY;
 
-    float energy = dynamic_cast<CPowerContainerObject*>(power)->GetEnergy();
+    float energy = dynamic_cast<CPowerContainerObject&>(*power).GetEnergy();
     if ( energy < ENERGY_RECOVER+0.05f )  return ERR_RECOVER_ENERGY;
 
     Math::Matrix* mat = m_object->GetWorldMatrix(0);

--- a/src/object/task/taskshield.cpp
+++ b/src/object/task/taskshield.cpp
@@ -309,7 +309,7 @@ Error CTaskShield::Start(TaskShieldMode mode, float delay)
 
     CObject* power = m_object->GetPower();
     if (power == nullptr || !power->Implements(ObjectInterfaceType::PowerContainer))  return ERR_SHIELD_ENERGY;
-    float energy = dynamic_cast<CPowerContainerObject*>(power)->GetEnergy();
+    float energy = dynamic_cast<CPowerContainerObject&>(*power).GetEnergy();
     if ( energy == 0.0f )  return ERR_SHIELD_ENERGY;
 
     Math::Matrix* mat = m_object->GetWorldMatrix(0);

--- a/src/object/task/taskspiderexplo.cpp
+++ b/src/object/task/taskspiderexplo.cpp
@@ -57,7 +57,7 @@ bool CTaskSpiderExplo::EventProcess(const Event &event)
     if ( event.type != EVENT_FRAME )  return true;
 
     // Momentarily stationary object (ant on the back)?
-    if ( dynamic_cast<CBaseAlien*>(m_object)->GetFixed() )
+    if ( dynamic_cast<CBaseAlien&>(*m_object).GetFixed() )
     {
         m_bError = true;
         return true;

--- a/src/object/task/tasktake.cpp
+++ b/src/object/task/tasktake.cpp
@@ -131,9 +131,9 @@ Error CTaskTake::Start()
         CObject* other = SearchFriendObject(oAngle, 1.5f, Math::PI*0.50f);
         if (other != nullptr) assert(other->Implements(ObjectInterfaceType::Powered));
 
-        if (other != nullptr && dynamic_cast<CPoweredObject*>(other)->GetPower() != nullptr)
+        if (other != nullptr && dynamic_cast<CPoweredObject&>(*other).GetPower() != nullptr)
         {
-            CObject* power = dynamic_cast<CPoweredObject*>(other)->GetPower();
+            CObject* power = dynamic_cast<CPoweredObject&>(*other).GetPower();
             type = power->GetType();
             if ( type == OBJECT_URANIUM )  return ERR_MANIP_RADIO;
             assert(power->Implements(ObjectInterfaceType::Transportable));
@@ -161,7 +161,7 @@ Error CTaskTake::Start()
         CObject* other = SearchFriendObject(oAngle, 1.5f, Math::PI*0.50f);
         if (other != nullptr) assert(other->Implements(ObjectInterfaceType::Powered));
 
-        if (other != nullptr && dynamic_cast<CPoweredObject*>(other)->GetPower() == nullptr )
+        if (other != nullptr && dynamic_cast<CPoweredObject&>(*other).GetPower() == nullptr )
         {
 //?         m_camera->StartCentering(m_object, Math::PI*0.3f, -Math::PI*0.1f, 0.0f, 0.8f);
             m_arm = TTA_FRIEND;
@@ -390,7 +390,7 @@ CObject* CTaskTake::SearchFriendObject(float &angle,
 
         assert(pObj->Implements(ObjectInterfaceType::Powered));
 
-        CObject* power = dynamic_cast<CPoweredObject*>(pObj)->GetPower();
+        CObject* power = dynamic_cast<CPoweredObject&>(*pObj).GetPower();
         if (power != nullptr)
         {
             if ( power->GetLock() )  continue;
@@ -398,7 +398,7 @@ CObject* CTaskTake::SearchFriendObject(float &angle,
         }
 
         Math::Matrix* mat = pObj->GetWorldMatrix(0);
-        Math::Vector oPos = Math::Transform(*mat, dynamic_cast<CPoweredObject*>(pObj)->GetPowerPosition());
+        Math::Vector oPos = Math::Transform(*mat, dynamic_cast<CPoweredObject&>(*pObj).GetPowerPosition());
 
         float distance = fabs(Math::Distance(oPos, iPos) - (iRad+1.0f));
         if ( distance <= dLimit )
@@ -406,7 +406,7 @@ CObject* CTaskTake::SearchFriendObject(float &angle,
             angle = Math::RotateAngle(oPos.x-iPos.x, iPos.z-oPos.z);  // CW !
             if ( Math::TestAngle(angle, iAngle-aLimit, iAngle+aLimit) )
             {
-                Math::Vector powerPos = dynamic_cast<CPoweredObject*>(pObj)->GetPowerPosition();
+                Math::Vector powerPos = dynamic_cast<CPoweredObject&>(*pObj).GetPowerPosition();
                 m_height = powerPos.y;
                 return pObj;
             }
@@ -430,8 +430,8 @@ bool CTaskTake::TransporterTakeObject()
 
         m_cargoType = cargo->GetType();
 
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporter(m_object);
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporterPart(4);  // takes with the hand
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporter(m_object);
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporterPart(4);  // takes with the hand
 
 //?     cargo->SetPosition(Math::Vector(2.2f, -1.0f, 1.1f));
         cargo->SetPosition(Math::Vector(1.7f, -0.5f, 1.1f));
@@ -449,15 +449,15 @@ bool CTaskTake::TransporterTakeObject()
         if (other == nullptr)  return false;
         assert(other->Implements(ObjectInterfaceType::Powered));
 
-        CObject* cargo = dynamic_cast<CPoweredObject*>(other)->GetPower();
+        CObject* cargo = dynamic_cast<CPoweredObject&>(*other).GetPower();
         if (cargo == nullptr)  return false;  // the other does not have a battery?
         assert(cargo->Implements(ObjectInterfaceType::Transportable));
 
         m_cargoType = cargo->GetType();
 
-        dynamic_cast<CPoweredObject*>(other)->SetPower(nullptr);
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporter(m_object);
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporterPart(4);  // takes with the hand
+        dynamic_cast<CPoweredObject&>(*other).SetPower(nullptr);
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporter(m_object);
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporterPart(4);  // takes with the hand
 
 //?     cargo->SetPosition(Math::Vector(2.2f, -1.0f, 1.1f));
         cargo->SetPosition(Math::Vector(1.7f, -0.5f, 1.1f));
@@ -492,7 +492,7 @@ bool CTaskTake::TransporterDeposeObject()
         cargo->SetRotationZ(0.0f);
         cargo->FloorAdjust();  // plate well on the ground
 
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporter(nullptr);
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporter(nullptr);
         m_object->SetCargo(nullptr);  // deposit
     }
 
@@ -503,7 +503,7 @@ bool CTaskTake::TransporterDeposeObject()
         if (other == nullptr)  return false;
         assert(other->Implements(ObjectInterfaceType::Powered));
 
-        CObject* cargo = dynamic_cast<CPoweredObject*>(other)->GetPower();
+        CObject* cargo = dynamic_cast<CPoweredObject&>(*other).GetPower();
         if (cargo != nullptr)  return false;  // the other already has a battery?
 
         cargo = m_object->GetCargo();
@@ -511,14 +511,14 @@ bool CTaskTake::TransporterDeposeObject()
         assert(cargo->Implements(ObjectInterfaceType::Transportable));
         m_cargoType = cargo->GetType();
 
-        dynamic_cast<CPoweredObject*>(other)->SetPower(cargo);
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporter(other);
+        dynamic_cast<CPoweredObject&>(*other).SetPower(cargo);
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporter(other);
 
-        cargo->SetPosition(dynamic_cast<CPoweredObject*>(other)->GetPowerPosition());
+        cargo->SetPosition(dynamic_cast<CPoweredObject&>(*other).GetPowerPosition());
         cargo->SetRotationY(0.0f);
         cargo->SetRotationX(0.0f);
         cargo->SetRotationZ(0.0f);
-        dynamic_cast<CTransportableObject*>(cargo)->SetTransporterPart(0);  // carried by the base
+        dynamic_cast<CTransportableObject&>(*cargo).SetTransporterPart(0);  // carried by the base
 
         m_object->SetCargo(nullptr);  // deposit
     }

--- a/src/object/task/taskterraform.cpp
+++ b/src/object/task/taskterraform.cpp
@@ -215,7 +215,7 @@ Error CTaskTerraform::Start()
 
     power = m_object->GetPower();
     if ( power == nullptr || !power->Implements(ObjectInterfaceType::PowerContainer) )  return ERR_TERRA_ENERGY;
-    energy = dynamic_cast<CPowerContainerObject*>(power)->GetEnergy();
+    energy = dynamic_cast<CPowerContainerObject&>(*power).GetEnergy();
     if ( energy < ENERGY_TERRA+0.05f )  return ERR_TERRA_ENERGY;
 
     speed = m_physics->GetMotorSpeed();
@@ -426,7 +426,7 @@ bool CTaskTerraform::Terraform()
             {
                 if ( dist > 5.0f )  continue;
                 m_engine->GetPyroManager()->Create(Gfx::PT_EXPLOT, pObj);
-                dynamic_cast<CDamageableObject*>(m_object)->DamageObject(DamageType::Explosive, 0.9f);
+                dynamic_cast<CDamageableObject&>(*m_object).DamageObject(DamageType::Explosive, 0.9f);
             }
             else if ( type == OBJECT_PLANT0    ||
                       type == OBJECT_PLANT1    ||
@@ -444,6 +444,7 @@ bool CTaskTerraform::Terraform()
             {
                 if ( dist > 7.5f )  continue;
                 m_engine->GetPyroManager()->Create(Gfx::PT_FRAGV, pObj);
+
             }
             else // Other?
             {
@@ -454,7 +455,7 @@ bool CTaskTerraform::Terraform()
         else
         {
             if ( !pObj->Implements(ObjectInterfaceType::Movable) )  continue;
-            motion = dynamic_cast<CMovableObject*>(pObj)->GetMotion();
+            motion = dynamic_cast<CMovableObject&>(*pObj).GetMotion();
 
             dist = Math::Distance(m_terraPos, pObj->GetPosition());
             if ( dist > ACTION_RADIUS )  continue;
@@ -462,13 +463,13 @@ bool CTaskTerraform::Terraform()
             if ( type == OBJECT_ANT || type == OBJECT_SPIDER )
             {
                 assert(pObj->Implements(ObjectInterfaceType::TaskExecutor));
-                dynamic_cast<CTaskExecutorObject*>(pObj)->StopForegroundTask();
+                dynamic_cast<CTaskExecutorObject&>(*pObj).StopForegroundTask();
 
                 int actionType = -1;
                 if (type == OBJECT_ANT)    actionType = MAS_BACK1;
                 if (type == OBJECT_SPIDER) actionType = MSS_BACK1;
                 motion->SetAction(actionType, 0.8f+Math::Rand()*0.3f);
-                dynamic_cast<CBaseAlien*>(pObj)->SetFixed(true);  // not moving
+                dynamic_cast<CBaseAlien&>(*pObj).SetFixed(true);  // not moving
 
                 if ( dist > 5.0f ) continue;
                 m_engine->GetPyroManager()->Create(Gfx::PT_EXPLOO, pObj);

--- a/src/physics/physics.cpp
+++ b/src/physics/physics.cpp
@@ -804,7 +804,7 @@ void CPhysics::MotorUpdate(float aTime, float rTime)
 
     if (m_object->Implements(ObjectInterfaceType::Powered))
     {
-        power = dynamic_cast<CPowerContainerObject*>(dynamic_cast<CPoweredObject*>(m_object)->GetPower());  // searches for the object battery uses
+        power = dynamic_cast<CPowerContainerObject*>(dynamic_cast<CPoweredObject&>(*m_object).GetPower());  // searches for the object battery uses
         if ( GetObjectEnergy(m_object) == 0.0f )  // no battery or flat?
         {
             motorSpeed.x =  0.0f;
@@ -822,7 +822,7 @@ void CPhysics::MotorUpdate(float aTime, float rTime)
         }
     }
 
-    if ( m_object->GetType() == OBJECT_HUMAN && dynamic_cast<CDestroyableObject*>(m_object)->GetDying() == DeathType::Dead )  // dead man?
+    if ( m_object->GetType() == OBJECT_HUMAN && dynamic_cast<CDestroyableObject&>(*m_object).GetDying() == DeathType::Dead )  // dead man?
     {
         motorSpeed.x = 0.0f;
         motorSpeed.z = 0.0f;
@@ -852,7 +852,7 @@ void CPhysics::MotorUpdate(float aTime, float rTime)
     }
 
     if ( m_object->Implements(ObjectInterfaceType::JetFlying) &&
-         dynamic_cast<CJetFlyingObject*>(m_object)->GetRange() > 0.0f )  // limited flight range?
+         dynamic_cast<CJetFlyingObject&>(*m_object).GetRange() > 0.0f )  // limited flight range?
     {
         CJetFlyingObject* jetFlying = dynamic_cast<CJetFlyingObject*>(m_object);
         if ( m_bLand || m_bSwim || m_bObstacle )  // on the ground or in the water?
@@ -960,7 +960,7 @@ void CPhysics::MotorUpdate(float aTime, float rTime)
         bool reactorCool = true;
         if ( m_object->Implements(ObjectInterfaceType::JetFlying) )
         {
-            reactorCool = dynamic_cast<CJetFlyingObject*>(m_object)->GetReactorRange() > 0.1f;
+            reactorCool = dynamic_cast<CJetFlyingObject&>(*m_object).GetReactorRange() > 0.1f;
         }
         if ( motorSpeed.y > 0.0f && reactorCool && pos.y < h )
         {
@@ -1463,7 +1463,7 @@ bool CPhysics::EventFrame(const Event &event)
     iAngle = angle = m_object->GetRotation();
 
     // Accelerate is the descent, brake is the ascent.
-    if ( m_bFreeze || (m_object->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject*>(m_object)->IsDying()) )
+    if ( m_bFreeze || (m_object->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject&>(*m_object).IsDying()) )
     {
         m_linMotion.terrainSpeed.x = 0.0f;
         m_linMotion.terrainSpeed.z = 0.0f;
@@ -1618,8 +1618,8 @@ void CPhysics::SoundMotor(float rTime)
     else if ( type == OBJECT_ANT )
     {
         assert(m_object->Implements(ObjectInterfaceType::Destroyable));
-        if ( dynamic_cast<CDestroyableObject*>(m_object)->GetDying() == DeathType::Burning ||
-             dynamic_cast<CBaseAlien*>(m_object)->GetFixed() )
+        if ( dynamic_cast<CDestroyableObject&>(*m_object).GetDying() == DeathType::Burning ||
+             dynamic_cast<CBaseAlien&>(*m_object).GetFixed() )
         {
             if ( m_lastSoundInsect <= 0.0f )
             {
@@ -1649,7 +1649,7 @@ void CPhysics::SoundMotor(float rTime)
                 else             m_lastSoundInsect = 1.5f+Math::Rand()*4.0f;
             }
         }
-        else if ( dynamic_cast<CDestroyableObject*>(m_object)->GetDying() == DeathType::Burning )
+        else if ( dynamic_cast<CDestroyableObject&>(*m_object).GetDying() == DeathType::Burning )
         {
             if ( m_lastSoundInsect <= 0.0f )
             {
@@ -1670,7 +1670,7 @@ void CPhysics::SoundMotor(float rTime)
                 else             m_lastSoundInsect = 1.5f+Math::Rand()*4.0f;
             }
         }
-        else if ( dynamic_cast<CDestroyableObject*>(m_object)->GetDying() == DeathType::Burning )
+        else if ( dynamic_cast<CDestroyableObject&>(*m_object).GetDying() == DeathType::Burning )
         {
             if ( m_lastSoundInsect <= 0.0f )
             {
@@ -1682,8 +1682,8 @@ void CPhysics::SoundMotor(float rTime)
     else if ( type == OBJECT_SPIDER )
     {
         assert(m_object->Implements(ObjectInterfaceType::Destroyable));
-        if ( dynamic_cast<CDestroyableObject*>(m_object)->GetDying() == DeathType::Burning ||
-             dynamic_cast<CBaseAlien*>(m_object)->GetFixed() )
+        if ( dynamic_cast<CDestroyableObject&>(*m_object).GetDying() == DeathType::Burning ||
+             dynamic_cast<CBaseAlien&>(*m_object).GetFixed() )
         {
             if ( m_lastSoundInsect <= 0.0f )
             {
@@ -2506,7 +2506,7 @@ int CPhysics::ObjectAdapt(const Math::Vector &pos, const Math::Vector &angle)
     int             colType;
     ObjectType      iType, oType;
 
-    if ( m_object->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject*>(m_object)->IsDying() )  return 0;  // is burning or exploding?
+    if ( m_object->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject&>(*m_object).IsDying() )  return 0;  // is burning or exploding?
     if ( !m_object->GetCollisions() )  return 0;
 
     // iiPos = sphere center is the old position.
@@ -2525,7 +2525,7 @@ int CPhysics::ObjectAdapt(const Math::Vector &pos, const Math::Vector &angle)
     {
         if ( pObj == m_object )  continue;  // yourself?
         if (IsObjectBeingTransported(pObj))  continue;
-        if ( pObj->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject*>(pObj)->GetDying() == DeathType::Exploding )  continue;  // is exploding?
+        if ( pObj->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject&>(*pObj).GetDying() == DeathType::Exploding )  continue;  // is exploding?
 
         oType = pObj->GetType();
         if ( oType == OBJECT_TOTO            )  continue;
@@ -2627,7 +2627,7 @@ int CPhysics::ObjectAdapt(const Math::Vector &pos, const Math::Vector &angle)
 
                     CPhysics* ph = nullptr;
                     if (pObj->Implements(ObjectInterfaceType::Movable))
-                        ph = dynamic_cast<CMovableObject*>(pObj)->GetPhysics();
+                        ph = dynamic_cast<CMovableObject&>(*pObj).GetPhysics();
                     if ( ph != nullptr )
                     {
                         oAngle = pObj->GetRotation();
@@ -2727,7 +2727,7 @@ bool CPhysics::ExploOther(ObjectType iType,
         if ( force > destructionForce && destructionForce >= 0.0f )
         {
             // TODO: implement "killer"?
-            dynamic_cast<CDamageableObject*>(pObj)->DamageObject(damageType);
+            dynamic_cast<CDamageableObject&>(*pObj).DamageObject(damageType);
         }
     }
 
@@ -2753,7 +2753,7 @@ bool CPhysics::ExploOther(ObjectType iType,
         {
             assert(pObj->Implements(ObjectInterfaceType::Damageable));
             // TODO: implement "killer"?
-            dynamic_cast<CDamageableObject*>(pObj)->DamageObject(DamageType::Collision, force/400.0f);
+            dynamic_cast<CDamageableObject&>(*pObj).DamageObject(DamageType::Collision, force/400.0f);
         }
 
         if (oType == OBJECT_MOBILEwa ||
@@ -2790,7 +2790,7 @@ bool CPhysics::ExploOther(ObjectType iType,
         {
             assert(pObj->Implements(ObjectInterfaceType::Damageable));
             // TODO: implement "killer"?
-            dynamic_cast<CDamageableObject*>(pObj)->DamageObject(DamageType::Collision, force/200.0f);
+            dynamic_cast<CDamageableObject&>(*pObj).DamageObject(DamageType::Collision, force/200.0f);
         }
     }
 
@@ -2830,7 +2830,7 @@ int CPhysics::ExploHimself(ObjectType iType, ObjectType oType, float force)
     if ( force > destructionForce && destructionForce >= 0.0f )
     {
         // TODO: implement "killer"?
-        dynamic_cast<CDamageableObject*>(m_object)->DamageObject(DamageType::Explosive);
+        dynamic_cast<CDamageableObject&>(*m_object).DamageObject(DamageType::Explosive);
         return 2;
     }
 
@@ -2917,7 +2917,7 @@ int CPhysics::ExploHimself(ObjectType iType, ObjectType oType, float force)
             }
 
             // TODO: implement "killer"?
-            if ( dynamic_cast<CDamageableObject*>(m_object)->DamageObject(DamageType::Collision, force) )  return 2;
+            if ( dynamic_cast<CDamageableObject&>(*m_object).DamageObject(DamageType::Collision, force) )  return 2;
         }
     }
 
@@ -2969,9 +2969,9 @@ void CPhysics::PowerParticle(float factor, bool bBreak)
     bCarryPower = false;
     if (m_object->Implements(ObjectInterfaceType::Carrier))
     {
-        CObject* cargo = dynamic_cast<CCarrierObject*>(m_object)->GetCargo();
+        CObject* cargo = dynamic_cast<CCarrierObject&>(*m_object).GetCargo();
         if ( cargo != nullptr && cargo->Implements(ObjectInterfaceType::PowerContainer) &&
-            dynamic_cast<CPowerContainerObject*>(cargo)->IsRechargeable() &&
+            dynamic_cast<CPowerContainerObject&>(*cargo).IsRechargeable() &&
             m_object->GetPartRotationZ(1) == ARM_STOCK_ANGLE1 )
         {
             bCarryPower = true;  // carries a battery
@@ -3264,7 +3264,7 @@ void CPhysics::MotorParticle(float aTime, float rTime)
         }
         else    // in flight?
         {
-            if ( !m_bMotor || (m_object->Implements(ObjectInterfaceType::JetFlying) && dynamic_cast<CJetFlyingObject*>(m_object)->GetReactorRange() == 0.0f) )  return;
+            if ( !m_bMotor || (m_object->Implements(ObjectInterfaceType::JetFlying) && dynamic_cast<CJetFlyingObject&>(*m_object).GetReactorRange() == 0.0f) )  return;
 
             if ( m_reactorTemperature < 1.0f )  // not too hot?
             {
@@ -3394,7 +3394,7 @@ void CPhysics::MotorParticle(float aTime, float rTime)
         }
         else    // in flight?
         {
-            if ( !m_bMotor || (m_object->Implements(ObjectInterfaceType::JetFlying) && dynamic_cast<CJetFlyingObject*>(m_object)->GetReactorRange() == 0.0f) )  return;
+            if ( !m_bMotor || (m_object->Implements(ObjectInterfaceType::JetFlying) && dynamic_cast<CJetFlyingObject&>(*m_object).GetReactorRange() == 0.0f) )  return;
 
             if ( aTime-m_lastMotorParticle < m_engine->ParticleAdapt(0.02f) )  return;
             m_lastMotorParticle = aTime;
@@ -3455,7 +3455,7 @@ void CPhysics::MotorParticle(float aTime, float rTime)
 
     if ( (type == OBJECT_HUMAN || type == OBJECT_TECH) && m_bSwim )
     {
-        if ( !m_object->Implements(ObjectInterfaceType::Destroyable) || dynamic_cast<CDestroyableObject*>(m_object)->GetDying() != DeathType::Dead )
+        if ( !m_object->Implements(ObjectInterfaceType::Destroyable) || dynamic_cast<CDestroyableObject&>(*m_object).GetDying() != DeathType::Dead )
         {
             h = Math::Mod(aTime, 5.0f);
             if ( h < 3.5f && ( h < 1.5f || h > 1.6f ) )  return;
@@ -3778,7 +3778,7 @@ Error CPhysics::GetError()
 
     if (m_object->Implements(ObjectInterfaceType::ProgramStorage))
     {
-        if ( dynamic_cast<CProgramStorageObject*>(m_object)->GetActiveVirus() )
+        if ( dynamic_cast<CProgramStorageObject&>(*m_object).GetActiveVirus() )
         {
             return ERR_VEH_VIRUS;
         }
@@ -3786,14 +3786,14 @@ Error CPhysics::GetError()
 
     if (m_object->Implements(ObjectInterfaceType::Powered))
     {
-        CObject* power = dynamic_cast<CPoweredObject*>(m_object)->GetPower();  // searches for the object battery used
+        CObject* power = dynamic_cast<CPoweredObject&>(*m_object).GetPower();  // searches for the object battery used
         if (power == nullptr || !power->Implements(ObjectInterfaceType::PowerContainer))
         {
             return ERR_VEH_POWER;
         }
         else
         {
-            if ( dynamic_cast<CPowerContainerObject*>(power)->GetEnergy() == 0.0f )  return ERR_VEH_ENERGY;
+            if ( dynamic_cast<CPowerContainerObject&>(*power).GetEnergy() == 0.0f )  return ERR_VEH_ENERGY;
         }
     }
 

--- a/src/script/scriptfunc.cpp
+++ b/src/script/scriptfunc.cpp
@@ -728,7 +728,7 @@ bool CScriptFunctions::rDelete(CBotVar* var, CBotVar* result, int& exception, vo
     }
 
     CObject* obj = CObjectManager::GetInstancePointer()->GetObjectById(rank);
-    if ( obj == nullptr || (obj->Implements(ObjectInterfaceType::Old) && dynamic_cast<COldObject*>(obj)->IsDying()) )
+    if ( obj == nullptr || (obj->Implements(ObjectInterfaceType::Old) && dynamic_cast<COldObject&>(*obj).IsDying()) )
     {
         return true;
     }
@@ -739,7 +739,7 @@ bool CScriptFunctions::rDelete(CBotVar* var, CBotVar* result, int& exception, vo
 
         if ( exploType != DestructionType::NoEffect && obj->Implements(ObjectInterfaceType::Destroyable) )
         {
-            dynamic_cast<CDestroyableObject*>(obj)->DestroyObject(static_cast<DestructionType>(exploType));
+            dynamic_cast<CDestroyableObject&>(*obj).DestroyObject(static_cast<DestructionType>(exploType));
         }
         else
         {
@@ -1560,7 +1560,7 @@ bool CScriptFunctions::rProduce(CBotVar* var, CBotVar* result, int& exception, v
         CObjectManager::GetInstancePointer()->CreateObject(pos, angle, OBJECT_EGG);
         if (object->Implements(ObjectInterfaceType::Programmable))
         {
-            dynamic_cast<CProgrammableObject*>(object)->SetActivity(false);
+            dynamic_cast<CProgrammableObject&>(*object).SetActivity(false);
         }
     }
     else
@@ -1582,7 +1582,7 @@ bool CScriptFunctions::rProduce(CBotVar* var, CBotVar* result, int& exception, v
         if (type == OBJECT_MOBILEdr)
         {
             assert(object->Implements(ObjectInterfaceType::Old)); // TODO: temporary hack
-            dynamic_cast<COldObject*>(object)->SetManual(true);
+            dynamic_cast<COldObject&>(*object).SetManual(true);
         }
         script->m_main->CreateShortcuts();
     }
@@ -1597,7 +1597,7 @@ bool CScriptFunctions::rProduce(CBotVar* var, CBotVar* result, int& exception, v
             programStorage->ReadProgram(program, name2.c_str());
             program->readOnly = true;
             program->filename = name;
-            dynamic_cast<CProgrammableObject*>(object)->RunProgram(program);
+            dynamic_cast<CProgrammableObject&>(*object).RunProgram(program);
         }
     }
 
@@ -2203,7 +2203,7 @@ bool CScriptFunctions::rReceive(CBotVar* var, CBotVar* result, int& exception, v
             return true;
         }
 
-        CExchangePost* exchangePost = dynamic_cast<CTaskInfo*>(script->m_taskExecutor->GetForegroundTask())->FindExchangePost(power);
+        CExchangePost* exchangePost = dynamic_cast<CTaskInfo&>(*script->m_taskExecutor->GetForegroundTask()).FindExchangePost(power);
         script->m_returnValue = exchangePost->GetInfoValue(p);
     }
     if ( !WaitForForegroundTask(script, result, exception) )  return false;  // not finished
@@ -2488,7 +2488,7 @@ bool CScriptFunctions::rShield(CBotVar* var, CBotVar* result, int& exception, vo
         }
         else    // up ?
         {
-            dynamic_cast<CShielder*>(pThis)->SetShieldRadius(radius);
+            dynamic_cast<CShielder&>(*pThis).SetShieldRadius(radius);
             err = script->m_taskExecutor->StartTaskShield(TSM_UP, 1000.0f);
             if ( err != ERR_OK )
             {
@@ -2506,7 +2506,7 @@ bool CScriptFunctions::rShield(CBotVar* var, CBotVar* result, int& exception, vo
         else    // up?
         {
             //?         result->SetValInt(1);  // shows the error
-            dynamic_cast<CShielder*>(pThis)->SetShieldRadius(radius);
+            dynamic_cast<CShielder&>(*pThis).SetShieldRadius(radius);
             script->m_taskExecutor->StartTaskShield(TSM_UPDATE, 0.0f);
         }
     }
@@ -2680,7 +2680,7 @@ bool CScriptFunctions::rMotor(CBotVar* var, CBotVar* result, int& exception, voi
     if ( turn < -1.0f )  turn = -1.0f;
     if ( turn >  1.0f )  turn =  1.0f;
 
-    if ( dynamic_cast<CBaseAlien*>(pThis) != nullptr && dynamic_cast<CBaseAlien*>(pThis)->GetFixed() )  // ant on the back?
+    if ( dynamic_cast<CBaseAlien*>(pThis) != nullptr && dynamic_cast<CBaseAlien&>(*pThis).GetFixed() )  // ant on the back?
     {
         speed = 0.0f;
         turn  = 0.0f;
@@ -2789,7 +2789,7 @@ bool CScriptFunctions::rCmdline(CBotVar* var, CBotVar* result, int& exception, v
     assert(pThis->Implements(ObjectInterfaceType::Programmable));
 
     rank = var->GetValInt();
-    value = dynamic_cast<CProgrammableObject*>(pThis)->GetCmdLine(rank);
+    value = dynamic_cast<CProgrammableObject&>(*pThis).GetCmdLine(rank);
     result->SetValFloat(value);
 
     return true;

--- a/src/ui/controls/map.cpp
+++ b/src/ui/controls/map.cpp
@@ -1197,7 +1197,7 @@ void CMap::UpdateObject(CObject* pObj)
          type != OBJECT_WORM     &&
          type != OBJECT_MOBILEtg )
     {
-        if (pObj->Implements(ObjectInterfaceType::Controllable) && !dynamic_cast<CControllableObject*>(pObj)->GetSelectable()) return;
+        if (pObj->Implements(ObjectInterfaceType::Controllable) && !dynamic_cast<CControllableObject&>(*pObj).GetSelectable()) return;
     }
     if ( pObj->GetProxyActivate() )  return;
     if (IsObjectBeingTransported(pObj))  return;
@@ -1330,7 +1330,7 @@ void CMap::UpdateObject(CObject* pObj)
              color != MAPCOLOR_MOVE )  return;
     }*/
 
-    if ( pObj->Implements(ObjectInterfaceType::Controllable) && dynamic_cast<CControllableObject*>(pObj)->GetSelect() )
+    if ( pObj->Implements(ObjectInterfaceType::Controllable) && dynamic_cast<CControllableObject&>(*pObj).GetSelect() )
     {
         m_map[MAPMAXOBJECT-1].type   = type;
         m_map[MAPMAXOBJECT-1].object = pObj;

--- a/src/ui/controls/target.cpp
+++ b/src/ui/controls/target.cpp
@@ -143,13 +143,13 @@ CObject* CTarget::DetectFriendObject(Math::Point pos)
         CObject* target = obj;
         if ( obj->Implements(ObjectInterfaceType::PowerContainer) && IsObjectBeingTransported(obj) )
         {
-            target = dynamic_cast<CTransportableObject*>(obj)->GetTransporter();
+            target = dynamic_cast<CTransportableObject&>(*obj).GetTransporter();
         }
 
         if ( !target->GetDetectable() )  continue;
         if ( target->GetProxyActivate() )  continue;
-        if ( target->Implements(ObjectInterfaceType::Controllable) && dynamic_cast<CControllableObject*>(target)->GetSelect() )  continue;
-        if ( !target->Implements(ObjectInterfaceType::Controllable) || !dynamic_cast<CControllableObject*>(target)->GetSelectable() )  continue;
+        if ( target->Implements(ObjectInterfaceType::Controllable) && dynamic_cast<CControllableObject&>(*target).GetSelect() )  continue;
+        if ( !target->Implements(ObjectInterfaceType::Controllable) || !dynamic_cast<CControllableObject&>(*target).GetSelectable() )  continue;
 
         if (!target->Implements(ObjectInterfaceType::Old)) continue; // TODO: To be removed after COldObjectInterface is gone
 

--- a/src/ui/displayinfo.cpp
+++ b/src/ui/displayinfo.cpp
@@ -109,7 +109,7 @@ bool CDisplayInfo::EventProcess(const Event &event)
         if ( m_toto != nullptr )
         {
             assert(m_toto->Implements(ObjectInterfaceType::Movable));
-            CMotionToto* toto = static_cast<CMotionToto*>(dynamic_cast<CMovableObject*>(m_toto)->GetMotion());
+            CMotionToto* toto = static_cast<CMotionToto*>(dynamic_cast<CMovableObject&>(*m_toto).GetMotion());
             assert(toto != nullptr);
             toto->SetMousePos(event.mousePos);
         }
@@ -449,7 +449,7 @@ void CDisplayInfo::StartDisplayInfo(std::string filename, int index, bool bSoluc
         m_toto->SetDrawFront(true);
 
         assert(m_toto->Implements(ObjectInterfaceType::Movable));
-        CMotionToto* toto = static_cast<CMotionToto*>(dynamic_cast<CMovableObject*>(m_toto)->GetMotion());
+        CMotionToto* toto = static_cast<CMotionToto*>(dynamic_cast<CMovableObject&>(*m_toto).GetMotion());
         assert(toto != nullptr);
         toto->StartDisplayInfo();
     }
@@ -840,7 +840,7 @@ void CDisplayInfo::StopDisplayInfo()
     if ( m_toto != nullptr )
     {
         assert(m_toto->Implements(ObjectInterfaceType::Movable));
-        CMotionToto* toto = static_cast<CMotionToto*>(dynamic_cast<CMovableObject*>(m_toto)->GetMotion());
+        CMotionToto* toto = static_cast<CMotionToto*>(dynamic_cast<CMovableObject&>(*m_toto).GetMotion());
         assert(toto != nullptr);
         toto->StopDisplayInfo();
     }

--- a/src/ui/displaytext.cpp
+++ b/src/ui/displaytext.cpp
@@ -258,7 +258,7 @@ void CDisplayText::DisplayText(const char *text, Math::Vector goal, float height
     if ( toto != nullptr )
     {
         assert(toto->Implements(ObjectInterfaceType::Movable));
-        motion = dynamic_cast<CMovableObject*>(toto)->GetMotion();
+        motion = dynamic_cast<CMovableObject&>(*toto).GetMotion();
 
         if ( type == TT_ERROR )
         {

--- a/src/ui/mainshort.cpp
+++ b/src/ui/mainshort.cpp
@@ -150,7 +150,7 @@ bool CMainShort::CreateShortcuts()
     for (CObject* pObj : CObjectManager::GetInstancePointer()->GetAllObjects())
     {
         if ( !pObj->GetDetectable() )  continue;
-        if ( pObj->Implements(ObjectInterfaceType::Controllable) && !dynamic_cast<CControllableObject*>(pObj)->GetSelectable() )  continue;
+        if ( pObj->Implements(ObjectInterfaceType::Controllable) && !dynamic_cast<CControllableObject&>(*pObj).GetSelectable() )  continue;
         if ( pObj->GetProxyActivate() )  continue;
 
         int icon = GetShortcutIcon(pObj->GetType());
@@ -274,9 +274,9 @@ bool CMainShort::UpdateShortcuts()
         if ( pc != nullptr )
         {
             assert(m_shortcuts[i]->Implements(ObjectInterfaceType::Controllable));
-            pc->SetState(STATE_CHECK, dynamic_cast<CControllableObject*>(m_shortcuts[i])->GetSelect());
-            pc->SetState(STATE_RUN, m_shortcuts[i]->Implements(ObjectInterfaceType::Programmable) && dynamic_cast<CProgrammableObject*>(m_shortcuts[i])->IsProgram());
-            pc->SetState(STATE_DAMAGE, dynamic_cast<CDamageableObject*>(m_shortcuts[i])->IsDamaging());
+            pc->SetState(STATE_CHECK, dynamic_cast<CControllableObject&>(*m_shortcuts[i]).GetSelect());
+            pc->SetState(STATE_RUN, m_shortcuts[i]->Implements(ObjectInterfaceType::Programmable) && dynamic_cast<CProgrammableObject&>(*m_shortcuts[i]).IsProgram());
+            pc->SetState(STATE_DAMAGE, dynamic_cast<CDamageableObject&>(*m_shortcuts[i]).IsDamaging());
         }
     }
     return true;

--- a/src/ui/object_interface.cpp
+++ b/src/ui/object_interface.cpp
@@ -595,7 +595,7 @@ bool CObjectInterface::EventProcess(const Event &event)
                 ps = static_cast< CSlider* >(pw->SearchControl(EVENT_OBJECT_DIMSHIELD));
                 if ( ps != nullptr )
                 {
-                    dynamic_cast<CShielder*>(m_object)->SetShieldRadius((ps->GetVisibleValue()-(RADIUS_SHIELD_MIN/g_unit))/((RADIUS_SHIELD_MAX-RADIUS_SHIELD_MIN)/g_unit));
+                    dynamic_cast<CShielder&>(*m_object).SetShieldRadius((ps->GetVisibleValue()-(RADIUS_SHIELD_MIN/g_unit))/((RADIUS_SHIELD_MAX-RADIUS_SHIELD_MIN)/g_unit));
                 }
             }
         }
@@ -1826,7 +1826,7 @@ void CObjectInterface::UpdateInterface()
         ps = static_cast< CSlider* >(pw->SearchControl(EVENT_OBJECT_DIMSHIELD));
         if ( ps != nullptr )
         {
-            ps->SetVisibleValue((RADIUS_SHIELD_MIN/g_unit)+dynamic_cast<CShielder*>(m_object)->GetShieldRadius()*((RADIUS_SHIELD_MAX-RADIUS_SHIELD_MIN)/g_unit));
+            ps->SetVisibleValue((RADIUS_SHIELD_MIN/g_unit)+dynamic_cast<CShielder&>(*m_object).GetShieldRadius()*((RADIUS_SHIELD_MAX-RADIUS_SHIELD_MIN)/g_unit));
         }
     }
 


### PR DESCRIPTION
This is a follow-up to PR #1351.

> In simplest terms, the patch changes the dyncast ever so slightly to avoid
triggering a «"this" might be NULL»  diagnostic in gcc-11.
>
> It's casting to a reference rather than casting to a pointer.  This has the added
advantage that it makes it clear to anyone reading the code that the cast is
expected to succeed every time (as it should if I read the code correctly).