### PR TITLE
Fix crashes in SatCom on some \button characters

### DIFF
--- a/src/graphics/engine/text.cpp
+++ b/src/graphics/engine/text.cpp
@@ -459,7 +459,7 @@ float CText::GetStringWidth(const std::string &text,
         width += GetCharWidth(ch, font, size, width);
 
         index += len;
-        fmtIndex++;
+        fmtIndex += len;
     }
 
     return width;
@@ -607,7 +607,7 @@ int CText::Justify(const std::string &text, std::vector<FontMetaChar>::iterator 
         }
 
         index += len;
-        fmtIndex++;
+        fmtIndex += len;
     }
 
     return index;
@@ -685,7 +685,7 @@ int CText::Detect(const std::string &text, std::vector<FontMetaChar>::iterator f
 
         pos += width;
         index += len;
-        fmtIndex++;
+        fmtIndex += len;
     }
 
     return index;


### PR DESCRIPTION
The issue is that the \button fragments in SatCom are replaced with
invalid UTF-8 bytes, hence those bytes need to be handled as a special
case when checking for UTF-8 character length.

When the text is processed e.g. in `Gfx::CText::Justify`, there are
generally two arrays: `text` and `format`. The second one is interpreted
as a font for a given character, e.g. `text[i]` has font `format[i]`.

Now, in the loops the index for `text` is increased by the length of
the character, e.g. 1 to 4 bytes, whereas index for `format` is
only incremented. It seems there's an assumption that `format` treats
multibyte characters as one byte, which doesn't seem to be true by
looking at the process of filling up the `format` array. This can result
in using wrong font e.g. FONT_SATCOM for the \button character which
should be FONT_BUTTON, hence the `StrUtils::Utf8CharSizeAt` method
complains about unexpected continuation byte via exception, causing
the crash.

Incrementing the index by the UTF-8 length seems to have fixed the
issue. However, I am not sure if I haven't broken anything else by this
and if I analyzed the intended behaviour correctly.
Gfx::CText needs a major refactor IMHO.

Fixes #1356 hopefully.