### PR TITLE
Fix missing linking to sndfile with OPENAL_SOUND=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,10 +303,11 @@ find_package(Boost COMPONENTS system filesystem regex REQUIRED)
 
 find_package(GLEW REQUIRED)
 
+find_package(LibSndFile REQUIRED)
+
 if (OPENAL_SOUND)
     find_package(OpenAL REQUIRED)
     include_directories(${OPENAL_INCLUDE_DIR})
-    find_package(LibSndFile REQUIRED)
 endif()
 
 


### PR DESCRIPTION
Fix the CMake files to use sndfile even if OPENAL_SOUND is disabled.
The package code (via sndfile_wrapper.cpp) uses sndfile unconditionally,
and it currently fails to build with -DOPENAL_SOUND=OFF:

    [293/293] Linking CXX executable colobot
    FAILED: colobot
    : && /usr/bin/c++ -std=gnu++11 -Wall -Werror -Wold-style-cast -pedantic-errors -Wmissing-declarations -Wno-error=deprecated-declarations -Wsuggest-override  -g -O0 -rdynamic src/CMakeFiles/colobot.dir/app/main.cpp.o -o colobot -L/tmp/colobot/src/CBot -Wl,-rpath,/tmp/colobot/src/CBot:/tmp/colobot/build/src/CBot:  src/libcolobotbase.a  src/CBot/libCBot.so  lib/localename/liblocalename.a  -Wl,-Bstatic  -lSDL2main  -Wl,-Bdynamic  -lSDL2  -lpthread  -lSDL2_image  -lSDL2_ttf  -lGL  -lGLU  -lpng  -lz  -lGLEW  /usr/lib64/libboost_system.so.1.76.0  /usr/lib64/libboost_filesystem.so.1.76.0  /usr/lib64/libboost_regex.so.1.76.0  -lphysfs && :
    /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/libcolobotbase.a(sndfile_wrapper.cpp.o): undefined reference to symbol 'sf_close@@libsndfile.so.1.0'
    /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libsndfile.so.1: error adding symbols: DSO missing from command line
    collect2: error: ld returned 1 exit status
    ninja: build stopped: subcommand failed.