### PR TITLE
Enchance Portico unit

### DIFF
--- a/src/object/auto/automush.cpp
+++ b/src/object/auto/automush.cpp
@@ -279,6 +279,7 @@ bool CAutoMush::SearchTarget()
              type != OBJECT_LABO     &&
              type != OBJECT_NUCLEAR  &&
              type != OBJECT_PARA     &&
+             type != OBJECT_PORTICO  &&
              type != OBJECT_HUMAN    )  continue;
 
        Math::Vector oPos = obj->GetPosition();

--- a/src/object/auto/autoportico.cpp
+++ b/src/object/auto/autoportico.cpp
@@ -432,3 +432,9 @@ void CAutoPortico::UpdateTrackMapping(float left, float right)
                                   Gfx::ENG_TEX_MAPPING_X,
                                   left, 8.0f, 8.0f, 192.0f, 256.0f);
 }
+
+bool CAutoPortico::CreateInterface(bool bSelect)
+{
+    // Everything is done at CObjectInterface::CreateInterface
+    return false;
+}

--- a/src/object/auto/autoportico.h
+++ b/src/object/auto/autoportico.h
@@ -50,6 +50,7 @@ public:
     bool        EventProcess(const Event &event) override;
     bool        Abort() override;
     Error       GetError() override;
+    bool        CreateInterface(bool bSelect) override;
 
 protected:
     void        UpdateTrackMapping(float left, float right);

--- a/src/object/auto/autoportico.h
+++ b/src/object/auto/autoportico.h
@@ -63,7 +63,8 @@ protected:
     float           m_lastParticle = 0.0f;
     Math::Vector        m_finalPos;
     Math::Vector        m_startPos;
-    float           m_posTrack = 0.0f;
+    float           m_posTrackLeft = 0.0f;
+    float           m_posTrackRight = 0.0f;
     int             m_param = 0;
     int             m_soundChannel = 0;
 };

--- a/src/object/object.cpp
+++ b/src/object/object.cpp
@@ -115,7 +115,10 @@ bool CObject::CanCollideWith(CObject* other)
 {
     ObjectType otherType = other->GetType();
     if (m_type == OBJECT_WORM) return false;
-    if (otherType == OBJECT_WORM) return false;
+    if (otherType == OBJECT_WORM)
+    {
+        if (m_type != OBJECT_PORTICO) return false;
+    }
     if (m_type == OBJECT_MOTHER)
     {
         if (otherType == OBJECT_ANT) return false;

--- a/src/object/old_object.cpp
+++ b/src/object/old_object.cpp
@@ -853,6 +853,7 @@ void COldObject::SetType(ObjectType type)
          m_type == OBJECT_LABO     ||
          m_type == OBJECT_NUCLEAR  ||
          m_type == OBJECT_PARA     ||
+         m_type == OBJECT_PORTICO  ||
          m_type == OBJECT_MOTHER    )
     {
         m_implementedInterfaces[static_cast<int>(ObjectInterfaceType::Damageable)] = true;

--- a/src/object/old_object.cpp
+++ b/src/object/old_object.cpp
@@ -408,6 +408,7 @@ bool COldObject::DamageObject(DamageType type, float force, CObject* killer)
             // Calculate the shield lost by the explosion
             loss = force * magnifyDamage;
             if (m_type == OBJECT_HUMAN) loss /= 2.5f; // Me is more resistant
+            if (m_type == OBJECT_PORTICO) loss /= 10.0f; // Portico is very resistant
             if (loss > 1.0f) loss = 1.0f;
 
             // Decreases the the shield

--- a/src/object/old_object.cpp
+++ b/src/object/old_object.cpp
@@ -936,6 +936,7 @@ void COldObject::SetType(ObjectType type)
     // TODO: You have been hacked!
     if (m_type == OBJECT_HUMAN    ||
         m_type == OBJECT_TOTO     ||
+        m_type == OBJECT_PORTICO  ||
         m_type == OBJECT_MOBILEfa ||
         m_type == OBJECT_MOBILEta ||
         m_type == OBJECT_MOBILEwa ||

--- a/src/object/subclass/base_building.cpp
+++ b/src/object/subclass/base_building.cpp
@@ -198,7 +198,7 @@ std::unique_ptr<CBaseBuilding> CBaseBuilding::Create(
         modelManager->AddModelReference("portico7.mod", false, rank, params.team);
         obj->SetPartPosition(11, Math::Vector(0.0f, 4.5f, 1.9f));
 
-        obj->AddCrashSphere(CrashSphere(Math::Vector(  0.0f, 28.0f,   0.0f), 45.5f, SOUND_BOUMm, 0.45f));
+        obj->AddCrashSphere(CrashSphere(Math::Vector(  0.0f, 52.0f,   0.0f), 42.0f, SOUND_BOUMm, 0.45f));
         obj->AddCrashSphere(CrashSphere(Math::Vector( 27.0f, 10.0f, -42.0f), 15.0f, SOUND_BOUMm, 0.45f));
         obj->AddCrashSphere(CrashSphere(Math::Vector(  0.0f, 10.0f, -42.0f), 15.0f, SOUND_BOUMm, 0.45f));
         obj->AddCrashSphere(CrashSphere(Math::Vector(-27.0f, 10.0f, -42.0f), 15.0f, SOUND_BOUMm, 0.45f));

--- a/src/physics/physics.cpp
+++ b/src/physics/physics.cpp
@@ -2590,6 +2590,11 @@ int CPhysics::ObjectAdapt(const Math::Vector &pos, const Math::Vector &angle)
                             {
                                 // no damage
                             }
+                            else if (pObj->GetType() == OBJECT_MOTHER)
+                            {
+                                dynamic_cast<CDamageableObject*>(pObj)->DamageObject(DamageType::Phazer);
+                                break;
+                            }
                             else if (pObj->Implements(ObjectInterfaceType::Destroyable))
                             {
                                 if (pObj->Implements(ObjectInterfaceType::Fragile))

--- a/src/physics/physics.cpp
+++ b/src/physics/physics.cpp
@@ -2632,7 +2632,7 @@ int CPhysics::ObjectAdapt(const Math::Vector &pos, const Math::Vector &angle)
 
 
                         CPhysics* ph = nullptr;
-                        if (pObj->Implements(ObjectInterfaceType::Movable))
+                        if (pObj->Implements(ObjectInterfaceType::Movable) && pObj->GetType() != OBJECT_PORTICO)
                             ph = dynamic_cast<CMovableObject&>(*pObj).GetPhysics();
                         if ( ph != nullptr )
                         {

--- a/src/physics/physics.cpp
+++ b/src/physics/physics.cpp
@@ -2583,9 +2583,24 @@ int CPhysics::ObjectAdapt(const Math::Vector &pos, const Math::Vector &angle)
                     {
                         if (iType == OBJECT_PORTICO)
                         {
-                            if (pObj->Implements(ObjectInterfaceType::Damageable))
+                            if( pObj->GetType() == OBJECT_BASE   ||
+                                pObj->GetType() == OBJECT_SAFE   ||
+                                pObj->GetType() == OBJECT_TREE5  ||
+                                pObj->GetType() == OBJECT_PORTICO )
                             {
-                                dynamic_cast<CDestroyableObject*>(pObj)->DamageObject(DamageType::Explosive);
+                                // no damage
+                            }
+                            else if (pObj->Implements(ObjectInterfaceType::Destroyable))
+                            {
+                                if (pObj->Implements(ObjectInterfaceType::Fragile))
+                                    dynamic_cast<CDestroyableObject*>(pObj)->DestroyObject(DestructionType::Explosion);
+                                else
+                                    dynamic_cast<CDamageableObject*>(pObj)->DamageObject(DamageType::Explosive);
+                                break;
+                            }
+                            else
+                            {
+                                m_engine->GetPyroManager()->Create(Gfx::PT_FRAGT, pObj);
                                 break;
                             }
                         }

--- a/src/physics/physics.cpp
+++ b/src/physics/physics.cpp
@@ -2581,6 +2581,15 @@ int CPhysics::ObjectAdapt(const Math::Vector &pos, const Math::Vector &angle)
                     distance = Math::Distance(oPos, iiPos);
                     if ( distance >= iRad+oRad )  // view (*)
                     {
+                        if (iType == OBJECT_PORTICO)
+                        {
+                            if (pObj->Implements(ObjectInterfaceType::Damageable))
+                            {
+                                dynamic_cast<CDestroyableObject*>(pObj)->DamageObject(DamageType::Explosive);
+                                break;
+                            }
+                        }
+
                         m_bCollision = true;
                         m_bObstacle = true;
 

--- a/src/ui/controls/map.cpp
+++ b/src/ui/controls/map.cpp
@@ -851,6 +851,7 @@ void CMap::DrawObjectIcon(Math::Point pos, Math::Point dim, MapColor color,
             case OBJECT_TARGET1:    icon = 45; break;
             case OBJECT_BASE:       icon = 43; break;
             case OBJECT_HUMAN:      icon = 8; break;
+            case OBJECT_PORTICO:    icon = 48; break;
             case OBJECT_MOBILEfa:   icon = 11; break;
             case OBJECT_MOBILEta:   icon = 10; break;
             case OBJECT_MOBILEwa:   icon = 9; break;

--- a/src/ui/controls/map.cpp
+++ b/src/ui/controls/map.cpp
@@ -1251,6 +1251,7 @@ void CMap::UpdateObject(CObject* pObj)
         color = MAPCOLOR_BBOX;
     }
     if ( type == OBJECT_HUMAN    ||
+         type == OBJECT_PORTICO  ||
          type == OBJECT_MOBILEwa ||
          type == OBJECT_MOBILEta ||
          type == OBJECT_MOBILEfa ||

--- a/src/ui/debug_menu.cpp
+++ b/src/ui/debug_menu.cpp
@@ -454,6 +454,8 @@ bool CDebugMenu::HandleTeleport(Math::Point mousePos)
 
 void CDebugMenu::HandleFrameUpdate(const Event &event)
 {
+    if (!IsActive()) return;
+
     std::string str = "-";
     Math::Vector pos;
     int obj;

--- a/src/ui/mainshort.cpp
+++ b/src/ui/mainshort.cpp
@@ -209,6 +209,7 @@ int CMainShort::GetShortcutIcon(ObjectType type)
         switch ( type )
         {
             case OBJECT_HUMAN:      icon =  8; break;
+            case OBJECT_PORTICO:    icon = 48; break;
             case OBJECT_MOBILEfa:   icon = 11; break;
             case OBJECT_MOBILEta:   icon = 10; break;
             case OBJECT_MOBILEwa:   icon =  9; break;

--- a/src/ui/object_interface.cpp
+++ b/src/ui/object_interface.cpp
@@ -878,6 +878,7 @@ bool CObjectInterface::CreateInterface(bool bSelect)
          type == OBJECT_MOBILErp ||
          type == OBJECT_MOBILEst ||
          type == OBJECT_MOBILEdr ||
+         type == OBJECT_PORTICO  ||
          type == OBJECT_MOTHER   ||
          type == OBJECT_ANT      ||
          type == OBJECT_SPIDER   ||
@@ -1927,6 +1928,7 @@ void CObjectInterface::UpdateInterface()
 
     if ( type == OBJECT_HUMAN    ||
          type == OBJECT_TECH     ||
+         type == OBJECT_PORTICO  ||
          type == OBJECT_MOBILEfa ||
          type == OBJECT_MOBILEta ||
          type == OBJECT_MOBILEwa ||


### PR DESCRIPTION
This PR makes Portico:
* Programmable and movable
* Damageable, destroyable, shielded
* More resistant to bullets using a hack similar to OBJECT_HUMAN's
* Controllable with UI
* Animated during free movement
* Have free space to walk between tracks (by moving central crashsphere upper)
* Absolutely resistant to incoming collisions, so that enemies won't be able to push it back
* Crashing everything it collides with by causing explosions

This PR also change CPhysics::ObjectAdapt to check ALL Crash Spheres of m_object instead of using GetFirstCrashSphere().
I have checked existing bots and insects and it seems that in version 0.2 all the movable objects has exactly one crashsphere, so this change should not affect performance of existing levels.

Here is this change in action:
[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/9Rf0WUrDPhY/0.jpg)](https://www.youtube.com/watch?v=9Rf0WUrDPhY)