### PR TITLE
fix SatCom content offset on screens with high resolution / small font size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ Makefile
 /src/libcolobotbase.a
 
 # Ignore the generated documentation
+CMakeDoxyfile.in
+CMakeDoxygenDefaults.cmake
 /doc
 /Doxyfile
 

--- a/src/ui/controls/edit.cpp
+++ b/src/ui/controls/edit.cpp
@@ -955,7 +955,7 @@ void CEdit::Draw()
 
         if ( i >= m_lineFirst+m_lineVisible )  break;
 
-        pos.x = m_pos.x+(7.5f/640.0f)*(m_fontSize/Gfx::FONT_SIZE_SMALL);
+        pos.x = m_pos.x+(7.5f/640.0f);
         if ( m_bAutoIndent )
         {
             const char *s = "\t";  // line | dotted
@@ -1117,7 +1117,7 @@ void CEdit::Draw()
         {
             if ( i == m_lineTotal-1 || m_cursor1 < m_lineOffset[i+1] )
             {
-                pos.x = m_pos.x+(7.5f/640.0f)*(m_fontSize/Gfx::FONT_SIZE_SMALL);
+                pos.x = m_pos.x+(7.5f/640.0f);
                 if ( m_bAutoIndent )
                 {
                     pos.x += indentLength*m_lineIndent[i];


### PR DESCRIPTION
Built from master branch:
![image](https://user-images.githubusercontent.com/17983323/135277284-db89b1e8-71b3-45df-a89c-68ff64b16dad.png)
Fixed:
![image](https://user-images.githubusercontent.com/17983323/135277837-09172613-3814-411d-948a-b39f209a800d.png)
I've observed no negative impact on code editor, should fix https://github.com/colobot/colobot/issues/1463