### PR TITLE
Refactor fonts reloading

### DIFF
--- a/src/common/font_loader.cpp
+++ b/src/common/font_loader.cpp
@@ -33,36 +33,12 @@
 #include <memory>
 #include <utility>
 #include <cstring>
+#include <optional>
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/regex.hpp>
 
 namespace bp = boost::property_tree;
 
-const std::map<Gfx::FontType, std::string> DEFAULT_FONT =
-{
-    { Gfx::FONT_COMMON, "dvu_sans.ttf" },
-    { Gfx::FONT_COMMON_BOLD, "dvu_sans_bold.ttf" },
-    { Gfx::FONT_COMMON_ITALIC, "dvu_sans_italic.ttf" },
-    { Gfx::FONT_STUDIO, "dvu_sans_mono.ttf" },
-    { Gfx::FONT_STUDIO_BOLD, "dvu_sans_mono_bold.ttf" },
-    { Gfx::FONT_STUDIO_ITALIC, "dvu_sans_mono.ttf" }, //placeholder for future use, DejaVu Sans Mono doesn't have italic variant
-    { Gfx::FONT_SATCOM, "dvu_sans.ttf" },
-    { Gfx::FONT_SATCOM_BOLD, "dvu_sans_bold.ttf" },
-    { Gfx::FONT_SATCOM_ITALIC, "dvu_sans_italic.ttf" },
-};
-
-const std::map<Gfx::FontType, std::string> FONT_TYPE =
-{
-    { Gfx::FONT_COMMON, "FontCommon" },
-    { Gfx::FONT_COMMON_BOLD, "FontCommonBold" },
-    { Gfx::FONT_COMMON_ITALIC, "FontCommonItalic" },
-    { Gfx::FONT_STUDIO, "FontStudio" },
-    { Gfx::FONT_STUDIO_BOLD, "FontStudioBold" },
-    { Gfx::FONT_STUDIO_ITALIC, "FontStudioItalic" },
-    { Gfx::FONT_SATCOM, "FontSatCom" },
-    { Gfx::FONT_SATCOM_BOLD, "FontSatComBold" },
-    { Gfx::FONT_SATCOM_ITALIC, "FontSatComItalic" },
-};
 
 CFontLoader::CFontLoader()
 {
@@ -99,17 +75,10 @@ bool CFontLoader::Init()
     return true;
 }
 
-std::string CFontLoader::GetFont(Gfx::FontType type)
+std::optional<std::string> CFontLoader::GetFont(Gfx::FontType type) const
 {
-    return std::string("/fonts/") + m_propertyTree.get<std::string>(GetFontType(type), GetDefaultFont(type));
-}
-
-std::string CFontLoader::GetDefaultFont(Gfx::FontType type) const
-{
-    return DEFAULT_FONT.at(type);
-}
-
-std::string CFontLoader::GetFontType(Gfx::FontType type) const
-{
-    return FONT_TYPE.at(type);
+    auto font = m_propertyTree.get_optional<std::string>(ToString(type));
+    if (font)
+        return std::string("/fonts/") + *font;
+    return std::nullopt;
 }

--- a/src/common/font_loader.cpp
+++ b/src/common/font_loader.cpp
@@ -33,7 +33,6 @@
 #include <memory>
 #include <utility>
 #include <cstring>
-#include <optional>
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/regex.hpp>
 

--- a/src/common/font_loader.h
+++ b/src/common/font_loader.h
@@ -50,22 +50,10 @@ public:
     */
     bool Init();
 
-    /** Reads given font from file
-    * \return return path to font file
+    /** Reads given font path from file
+    * \return return path to font file if font type is configured
     */
-    std::string GetFont(Gfx::FontType type);
-
-    /** Const type method to read filenames of fonts from defaultFont map
-    * used as a fallback if it wasn't possible to read font from fonts.ini
-    * \return return filename of default path
-    */
-    std::string GetDefaultFont(Gfx::FontType type) const;
-
-    /** Const type method converting Gfx::FontType to string
-    * \return return id of font used in fonts.ini file
-    */
-
-    std::string GetFontType(Gfx::FontType type) const;
+    std::optional<std::string> GetFont(Gfx::FontType type) const;
 
 private:
     boost::property_tree::ptree m_propertyTree;

--- a/src/common/font_loader.h
+++ b/src/common/font_loader.h
@@ -31,6 +31,7 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include <string>
+#include <optional>
 
 /**
 * \class CFontLoader

--- a/src/graphics/engine/text.cpp
+++ b/src/graphics/engine/text.cpp
@@ -291,7 +291,7 @@ private:
     {
         if (auto font = fontLoader.GetFont(type))
         {
-            m_fonts[type] = MakeUnique<MultisizeFont>(std::move(*font));
+            m_fonts[type] = std::make_unique<MultisizeFont>(std::move(*font));
             return true;
         }
         m_error = "Error on loading fonts: font type " + ToString(type) + " is not configured";
@@ -319,7 +319,7 @@ private:
             return nullptr;
         }
         GetLogger()->Debug("Loaded font file %s (font size = %d)\n", multisizeFont->fileName.c_str(), pointSize);
-        auto newFont = MakeUnique<CachedFont>(std::move(file), pointSize);
+        auto newFont = std::make_unique<CachedFont>(std::move(file), pointSize);
         if (newFont->font == nullptr)
         {
             m_error = std::string("TTF_OpenFont error ") + std::string(TTF_GetError());
@@ -335,7 +335,7 @@ private:
         m_lastFontSize = pointSize;
     }
 
-    bool IsLastCachedFont(FontType font, int pointSize)
+    bool IsLastCachedFont(FontType font, int pointSize) const
     {
         return
             m_lastCachedFont != nullptr &&

--- a/src/graphics/engine/text.h
+++ b/src/graphics/engine/text.h
@@ -34,7 +34,6 @@
 #include <memory>
 #include <vector>
 
-
 // Graphics module namespace
 namespace Gfx
 {
@@ -69,37 +68,39 @@ typedef short FontMetaChar;
  *
  * Bitmask in lower 4 bits (mask 0x00f)
  */
-enum FontType
+enum FontType : unsigned char
 {
     //! Flag for bold font subtype
-    FONT_BOLD       = 0x04,
+    FONT_BOLD       = 0b0000'01'00,
     //! Flag for italic font subtype
-    FONT_ITALIC     = 0x08,
+    FONT_ITALIC     = 0b0000'10'00,
 
     //! Default colobot font used for interface
-    FONT_COMMON    = 0x00,
+    FONT_COMMON    = 0b0000'00'00,
     //! Alias for bold colobot font
     FONT_COMMON_BOLD = FONT_COMMON | FONT_BOLD,
     //! Alias for italic colobot font
     FONT_COMMON_ITALIC = FONT_COMMON | FONT_ITALIC,
 
     //! Studio font used mainly in code editor
-    FONT_STUDIO    = 0x01,
+    FONT_STUDIO    = 0b0000'00'01,
     //! Alias for bold studio font
     FONT_STUDIO_BOLD = FONT_STUDIO | FONT_BOLD,
     //! Alias for italic studio font (at this point not used anywhere)
     FONT_STUDIO_ITALIC = FONT_STUDIO | FONT_ITALIC,
 
     //! SatCom font used for interface (currently bold and italic wariants aren't used anywhere)
-    FONT_SATCOM = 0x02,
+    FONT_SATCOM = 0b0000'00'10,
     //! Alias for bold satcom font
     FONT_SATCOM_BOLD = FONT_SATCOM | FONT_BOLD,
     //! Alias for italic satcom font
     FONT_SATCOM_ITALIC = FONT_SATCOM | FONT_ITALIC,
 
     //! Pseudo-font loaded from textures for buttons, icons, etc.
-    FONT_BUTTON     = 0x03,
+    FONT_BUTTON     = 0b0000'00'11,
 };
+
+std::string ToString(FontType);
 
 /**
  * \enum FontTitle
@@ -204,6 +205,7 @@ struct CharTexture
 };
 
 // Definition is private - in text.cpp
+class FontsCache;
 struct CachedFont;
 struct MultisizeFont;
 struct FontTexture;
@@ -323,7 +325,8 @@ public:
     Math::IntPoint GetFontTextureSize();
 
 protected:
-    CachedFont* GetOrOpenFont(FontType font, float size);
+    int GetFontPointSize(float size) const;
+    CachedFont* GetOrOpenFont(FontType type, float size);
     CharTexture CreateCharTexture(UTF8Char ch, CachedFont* font);
     FontTexture* GetOrCreateFontTexture(Math::IntPoint tileSize);
     FontTexture CreateFontTexture(Math::IntPoint tileSize);
@@ -349,12 +352,8 @@ protected:
     float        m_defaultSize;
     int          m_tabSize;
 
-    std::map<FontType, std::unique_ptr<MultisizeFont>> m_fonts;
+    std::unique_ptr<FontsCache> m_fontsCache;
     std::vector<FontTexture> m_fontTextures;
-
-    FontType     m_lastFontType;
-    int          m_lastFontSize;
-    CachedFont*  m_lastCachedFont;
 
     class CQuadBatch;
     std::unique_ptr<CQuadBatch> m_quadBatch;


### PR DESCRIPTION
* Remove hardcoded default font name.
  This means the `fonts/fonts.ini` file is now mandatory
  and must contain definition of all 9 font types.
  Old mods relying on an incomplete `fonts.ini` file might break.
  A separate PR creating the required `fonts/fonts.ini` file
  should be merged before this pull request.
* Simplify `CFontLoader`.
    * Return `std::optional` instead of returning a default.
    * Remove the now unnecessary `std::map`s.
    * Remove the now unnecessary `GetFontType` method.
* Improve Gfx::FontType.
    * Provide `ToString` function for the enum, which is now
      used for logs and by `CFontLoader`.
    * Provide `ToBoldFontType` and `ToItalicFontType` functions.
    * Replace hex literals with binary literals for readability.
* Move font caching related code to a new private class `FontsCache`.
    * Add neccessary changes because of changes made in `CFontLoader`.
    * Add minor code improvements like renames and formatting.
    * Split the code into smaller functions for readability.
    * Simplify the `CText` class.
* Apply the rule of 5 to the `CachedFont` structure.

Edit: merge that https://github.com/colobot/colobot-data/pull/74 and then update data submodule before merging this PR.