### PR TITLE
Add workaround for numpad home/end keys etc

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -1425,7 +1425,7 @@ Event CApplication::CreateVirtualEvent(const Event& sourceEvent)
     if ((sourceEvent.type == EVENT_KEY_DOWN) || (sourceEvent.type == EVENT_KEY_UP))
     {
         auto sourceData = sourceEvent.GetData<KeyEventData>();
-        auto virtualKey = GetVirtualKey(sourceData->key);
+        auto virtualKey = GetVirtualKey(sourceData->key, sourceEvent.kmodState);
 
         if (virtualKey == sourceData->key)
         {

--- a/src/common/key.cpp
+++ b/src/common/key.cpp
@@ -19,7 +19,7 @@
 
 #include "common/key.h"
 
-unsigned int GetVirtualKey(unsigned int key)
+unsigned int GetVirtualKey(unsigned int key, unsigned int kmodState)
 {
     if(key == KEY(LCTRL) || key == KEY(RCTRL))
         return VIRTUAL_KMOD(CTRL);
@@ -32,6 +32,27 @@ unsigned int GetVirtualKey(unsigned int key)
 
     if(key == KEY(KP_ENTER))
         return KEY(RETURN);
+
+    // Remap keypad navigation keys as a workaround for the SDL issue: https://github.com/libsdl-org/SDL/issues/1766
+    if ((kmodState & KEY_MOD(NUM)) == 0)
+    {
+        if(key == KEY(KP_7))
+            return KEY(HOME);
+        if(key == KEY(KP_1))
+            return KEY(END);
+        if(key == KEY(KP_9))
+            return KEY(PAGEUP);
+        if(key == KEY(KP_3))
+            return KEY(PAGEDOWN);
+        if(key == KEY(KP_4))
+            return KEY(LEFT);
+        if(key == KEY(KP_6))
+            return KEY(RIGHT);
+        if(key == KEY(KP_8))
+            return KEY(UP);
+        if(key == KEY(KP_2))
+            return KEY(DOWN);
+    }
 
     return key;
 }

--- a/src/common/key.h
+++ b/src/common/key.h
@@ -62,7 +62,7 @@ enum VirtualKmod
 #define VIRTUAL_KMOD(x) VIRTUAL_KMOD_ ## x
 
 //! Converts individual codes to virtual keys if needed
-unsigned int GetVirtualKey(unsigned int key);
+unsigned int GetVirtualKey(unsigned int key, unsigned int kmodState);
 
 // Virtual key code generated on joystick button presses
 // num is number of joystick button

--- a/src/ui/controls/key.cpp
+++ b/src/ui/controls/key.cpp
@@ -75,7 +75,7 @@ bool CKey::EventProcess(const Event &event)
     if (event.type == EVENT_KEY_DOWN && m_catch)
     {
         m_catch = false;
-        unsigned int key = GetVirtualKey(event.GetData<KeyEventData>()->key);
+        unsigned int key = GetVirtualKey(event.GetData<KeyEventData>()->key, event.kmodState);
 
         if (TestKey(key)) // impossible ?
         {


### PR DESCRIPTION
SDL is not reporting numpad keys correctly when numlock is off. This is a workaround to make numpad home, end etc usable in the in-game editor. It seem to be a know issue in SDL: https://github.com/libsdl-org/SDL/issues/1766