### PR TITLE
Better goto

### DIFF
--- a/src/object/task/taskgoto.cpp
+++ b/src/object/task/taskgoto.cpp
@@ -222,7 +222,7 @@ bool CTaskGoto::EventProcess(const Event &event)
             if ( m_bmCargoObject->GetType() == OBJECT_BASE )  dist = 12.0f;
         }
 
-        ret = BeamSearch(pos, goal, dist);
+        ret = PathFindingSearch(pos, goal, dist);
         if ( ret == ERR_OK )
         {
             if ( m_physics->GetLand() )  m_phase = TGP_BEAMWCOLD;
@@ -346,7 +346,7 @@ bool CTaskGoto::EventProcess(const Event &event)
         {
             m_physics->SetMotorSpeedX(0.0f);  // stops the advance
             m_physics->SetMotorSpeedZ(0.0f);  // stops the rotation
-            BeamStart();  // we start all
+            PathFindingStart();  // we start all
             return true;
         }
 
@@ -790,7 +790,7 @@ Error CTaskGoto::Start(Math::Vector goal, float altitude,
             }
         }
 
-        BeamStart();
+        PathFindingStart();
 
         if ( m_bmCargoObject == nullptr )
         {
@@ -826,7 +826,7 @@ Error CTaskGoto::IsEnded()
         {
             m_physics->SetMotorSpeedX(0.0f);  // stops the advance
             m_physics->SetMotorSpeedZ(0.0f);  // stops the rotation
-            BeamInit();
+            PathFindingInit();
             m_phase = TGP_BEAMSEARCH;  // will seek the path
         }
         return ERR_CONTINUE;
@@ -888,7 +888,7 @@ Error CTaskGoto::IsEnded()
             m_physics->SetMotorSpeedX(0.0f);  // stops the advance
             m_physics->SetMotorSpeedZ(0.0f);  // stops the rotation
 
-            m_bmIndex = BeamShortcut();
+            m_bmIndex = PathFindingShortcut();
 
             if ( m_bmIndex > m_bmTotal )
             {
@@ -1630,7 +1630,7 @@ void CTaskGoto::ComputeFlyingRepulse(float &dir)
 // Among all of the following, seek if there is one allowing to go directly to the crow flies.
 // If yes, skip all the unnecessary intermediate points.
 
-int CTaskGoto::BeamShortcut()
+int CTaskGoto::PathFindingShortcut()
 {
     int     i;
 
@@ -1647,7 +1647,7 @@ int CTaskGoto::BeamShortcut()
 
 // That's the big start.
 
-void CTaskGoto::BeamStart()
+void CTaskGoto::PathFindingStart()
 {
     Math::Vector    min, max;
 
@@ -1673,14 +1673,14 @@ void CTaskGoto::BeamStart()
     {
         m_physics->SetMotorSpeedX(0.0f);  // stops the advance
         m_physics->SetMotorSpeedZ(0.0f);  // stops the rotation
-        BeamInit();
+        PathFindingInit();
         m_phase = TGP_BEAMSEARCH;  // will seek the path
     }
 }
 
-// Initialization before the first BeamSearch.
+// Initialization before the first PathFindingSearch.
 
-void CTaskGoto::BeamInit()
+void CTaskGoto::PathFindingInit()
 {
     int     i;
 
@@ -1701,8 +1701,8 @@ void CTaskGoto::BeamInit()
 // ERR_CONTINUE if not done yet
 // goalRadius: distance at which we must approach the goal
 
-Error CTaskGoto::BeamSearch(const Math::Vector &start, const Math::Vector &goal,
-                            float goalRadius)
+Error CTaskGoto::PathFindingSearch(const Math::Vector &start, const Math::Vector &goal,
+                                   float goalRadius)
 {
     m_bmStep ++;
 

--- a/src/object/task/taskgoto.cpp
+++ b/src/object/task/taskgoto.cpp
@@ -48,7 +48,6 @@ const float FLY_DEF_HEIGHT  = 50.0f;    // default flying height
 
 // Settings that define goto() accuracy:
 const float BM_DIM_STEP     = 5.0f;     // Size of one pixel on the bitmap. Setting 5 means that 5x5 square (in game units) will be represented by 1 px on the bitmap. Decreasing this value will make a bigger bitmap, and may increase accuracy. TODO: Check how it actually impacts goto() accuracy
-const float BEAM_ACCURACY   = 5.0f;    // higher value = more accurate, but slower
 const float SAFETY_MARGIN   = 1.5f;     // Smallest distance between two objects. Smaller = less "no route to destination", but higher probability of collisions between objects.
 // Changing SAFETY_MARGIN (old value was 4.0f) seems to have fixed many issues with goto(). TODO: maybe we could make it even smaller? Did changing it introduce any new bugs?
 

--- a/src/object/task/taskgoto.cpp
+++ b/src/object/task/taskgoto.cpp
@@ -52,7 +52,7 @@ const float BEAM_ACCURACY   = 5.0f;    // higher value = more accurate, but slow
 const float SAFETY_MARGIN   = 1.5f;     // Smallest distance between two objects. Smaller = less "no route to destination", but higher probability of collisions between objects.
 // Changing SAFETY_MARGIN (old value was 4.0f) seems to have fixed many issues with goto(). TODO: maybe we could make it even smaller? Did changing it introduce any new bugs?
 
-const int NB_ITER = 2000;  // Maximum number of iterations you have the right to make before temporarily interrupt in order not to lower the framerate.
+const int NB_ITER = 200;  // Maximum number of iterations you have the right to make before temporarily interrupt in order not to lower the framerate.
 
 
 

--- a/src/object/task/taskgoto.h
+++ b/src/object/task/taskgoto.h
@@ -104,7 +104,7 @@ protected:
     void        BeamInit();
     Error       BeamSearch(const Math::Vector &start, const Math::Vector &goal, float goalRadius);
 
-    bool        BitmapTestLine(const Math::Vector &start, const Math::Vector &goal, float stepAngle, bool bSecond);
+    bool        BitmapTestLine(const Math::Vector &start, const Math::Vector &goal);
     void        BitmapObject();
     void        BitmapTerrain(const Math::Vector &min, const Math::Vector &max);
     void        BitmapTerrain(int minx, int miny, int maxx, int maxy);

--- a/src/object/task/taskgoto.h
+++ b/src/object/task/taskgoto.h
@@ -144,7 +144,7 @@ protected:
     int             m_bmLine = 0;       // increment line m_bmSize/8
     std::unique_ptr<unsigned char[]> m_bmArray;      // Bit table
     std::unique_ptr<int32_t[]> m_bfsDistances; // Distances to the goal for breadth-first search.
-    std::array<std::vector<uint32_t>, NUMQUEUEBUCKETS> m_bfsQueue; // Priority queue with indices to nodes. Nodes are sorted into buckets.
+    std::array<std::vector<uint32_t>, NUMQUEUEBUCKETS + 1> m_bfsQueue; // Priority queue with indices to nodes. Nodes are sorted into buckets. The last bucket contains oversized costs.
     int             m_bfsQueueMin = 0;  // Front of the queue. This value mod 8 is the index to the bucket with the next node to be expanded.
     int             m_bfsQueueCountPushed = 0; // Number of nodes inserted into the queue.
     int             m_bfsQueueCountPopped = 0; // Number of nodes extacted from the queue.

--- a/src/object/task/taskgoto.h
+++ b/src/object/task/taskgoto.h
@@ -23,7 +23,9 @@
 
 #include "math/vector.h"
 
+#include <array>
 #include <memory>
+#include <vector>
 
 namespace Math
 {
@@ -142,9 +144,12 @@ protected:
     int             m_bmLine = 0;       // increment line m_bmSize/8
     std::unique_ptr<unsigned char[]> m_bmArray;      // Bit table
     std::unique_ptr<int32_t[]> m_bfsDistances; // Distances to the goal for breadth-first search.
-    std::unique_ptr<uint32_t[]> m_bfsQueue;  // Nodes in the queue. Stored as indices.
-    int             m_bfsQueueBegin = 0;     // Front of the queue. This is the next node to be expanded.
-    int             m_bfsQueueEnd = 0;       // Back of the queue. This is where nodes are inserted.
+    std::array<std::vector<uint32_t>, 8> m_bfsQueue; // Priority queue with indices to nodes. Nodes are sorted into buckets.
+    int             m_bfsQueueMin = 0;  // Front of the queue. This value mod 8 is the index to the bucket with the next node to be expanded.
+    int             m_bfsQueueCountPushed = 0; // Number of nodes inserted into the queue.
+    int             m_bfsQueueCountPopped = 0; // Number of nodes extacted from the queue.
+    int             m_bfsQueueCountRepeated = 0; // Number of nodes re-inserted into the queue.
+    int             m_bfsQueueCountSkipped = 0; // Number of nodes skipped because of unexpected distance (likely re-added).
     int             m_bmMinX = 0, m_bmMinY = 0;
     int             m_bmMaxX = 0, m_bmMaxY = 0;
     int             m_bmTotal = 0;      // index of final point in m_bmPoints

--- a/src/object/task/taskgoto.h
+++ b/src/object/task/taskgoto.h
@@ -33,7 +33,7 @@ struct Point;
 
 class CObject;
 
-const int MAXPOINTS = 500;
+const int MAXPOINTS = 50000;
 
 
 enum TaskGotoGoal
@@ -103,8 +103,6 @@ protected:
     void        BeamStart();
     void        BeamInit();
     Error       BeamSearch(const Math::Vector &start, const Math::Vector &goal, float goalRadius);
-    Error       BeamExplore(const Math::Vector &prevPos, const Math::Vector &curPos, const Math::Vector &goalPos, float goalRadius, float angle, int nbDiv, float step, int i, int nbIter);
-    Math::Vector    BeamPoint(const Math::Vector &startPoint, const Math::Vector &goalPoint, float angle, float step);
 
     bool        BitmapTestLine(const Math::Vector &start, const Math::Vector &goal, float stepAngle, bool bSecond);
     void        BitmapObject();
@@ -117,6 +115,7 @@ protected:
     void        BitmapSetDot(int rank, int x, int y);
     void        BitmapClearDot(int rank, int x, int y);
     bool        BitmapTestDot(int rank, int x, int y);
+    bool        BitmapTestDotIsVisitable(int x, int y);
 
 protected:
     Math::Vector        m_goal;
@@ -141,10 +140,14 @@ protected:
     int             m_bmSize = 0;       // width or height of the table
     int             m_bmOffset = 0;     // m_bmSize/2
     int             m_bmLine = 0;       // increment line m_bmSize/8
-    std::unique_ptr<unsigned char[]> m_bmArray;      // bit table
+    std::unique_ptr<unsigned char[]> m_bmArray;      // Bit table
+    std::unique_ptr<int32_t[]> m_bfsDistances; // Distances to the goal for breadth-first search.
+    std::unique_ptr<uint32_t[]> m_bfsQueue;  // Nodes in the queue. Stored as indices.
+    int             m_bfsQueueBegin = 0;     // Front of the queue. This is the next node to be expanded.
+    int             m_bfsQueueEnd = 0;       // Back of the queue. This is where nodes are inserted.
     int             m_bmMinX = 0, m_bmMinY = 0;
     int             m_bmMaxX = 0, m_bmMaxY = 0;
-    int             m_bmTotal = 0;      // number of points in m_bmPoints
+    int             m_bmTotal = 0;      // index of final point in m_bmPoints
     int             m_bmIndex = 0;      // index in m_bmPoints
     Math::Vector        m_bmPoints[MAXPOINTS+2];
     signed char     m_bmIter[MAXPOINTS+2] = {};

--- a/src/object/task/taskgoto.h
+++ b/src/object/task/taskgoto.h
@@ -99,10 +99,10 @@ protected:
     void        ComputeRepulse(Math::Point &dir);
     void        ComputeFlyingRepulse(float &dir);
 
-    int         BeamShortcut();
-    void        BeamStart();
-    void        BeamInit();
-    Error       BeamSearch(const Math::Vector &start, const Math::Vector &goal, float goalRadius);
+    int         PathFindingShortcut();
+    void        PathFindingStart();
+    void        PathFindingInit();
+    Error       PathFindingSearch(const Math::Vector &start, const Math::Vector &goal, float goalRadius);
 
     bool        BitmapTestLine(const Math::Vector &start, const Math::Vector &goal);
     void        BitmapObject();

--- a/src/object/task/taskgoto.h
+++ b/src/object/task/taskgoto.h
@@ -36,7 +36,7 @@ struct Point;
 class CObject;
 
 const int MAXPOINTS = 50000;
-
+const int NUMQUEUEBUCKETS = 32;
 
 enum TaskGotoGoal
 {
@@ -144,7 +144,7 @@ protected:
     int             m_bmLine = 0;       // increment line m_bmSize/8
     std::unique_ptr<unsigned char[]> m_bmArray;      // Bit table
     std::unique_ptr<int32_t[]> m_bfsDistances; // Distances to the goal for breadth-first search.
-    std::array<std::vector<uint32_t>, 8> m_bfsQueue; // Priority queue with indices to nodes. Nodes are sorted into buckets.
+    std::array<std::vector<uint32_t>, NUMQUEUEBUCKETS> m_bfsQueue; // Priority queue with indices to nodes. Nodes are sorted into buckets.
     int             m_bfsQueueMin = 0;  // Front of the queue. This value mod 8 is the index to the bucket with the next node to be expanded.
     int             m_bfsQueueCountPushed = 0; // Number of nodes inserted into the queue.
     int             m_bfsQueueCountPopped = 0; // Number of nodes extacted from the queue.


### PR DESCRIPTION
This replaces beam search with ~~breadth-first~~ _A*_ search for pathfinding in goto, see https://github.com/colobot/colobot/issues/336. ~~This is still work in progress but it seems to work quite well so far.~~ _I have developed the algorithm to a state I am happy with._ Please test it!

## Extended description
Since this is a substantial change to a critical component in the game, I think it warrants an extended description. This should help during reviewing and also serve as a future reference when debugging or developing it further. **The most fundamental change in this PR is that it searches for paths in an explicit discrete grid instead of a state space search consisting of straight sections joined by turns.** This allows the search to be exhaustive because the number of nodes are finite.

### The grid (nodes)
The previous implementation used a grid to keep track of drivable areas. This grid has **not** been changed in this PR. It is now also used for the discretization of the possible positions. All intermediate positions between start and goal are aligned to this grid. The grid resolution is one grid cell per five in-game units. This resolution is now the main limitation of finding a path in crowded areas. Increasing the resolution increases memory usage and computational costs. The memory usage is mainly driven by storing distance estimates (upper bound from cell to start position) for all positions on the grid.

### The edges
I chose to use 8-way connectivity for modelling travelling from one node (grid cell) to another. This is not as limiting as it first seems because there is a shortcutting behavior that will drive straight to nodes further along the path if there is a straight line without obstacles. The costs are represented by integers instead of floats for increased performance and numerical stability. The main reason to use integer costs is that it allows for using a different queue when searching, more on that below. I am using 7 and 5 for diagonal and non-diagonal costs respectively. This is a reasonable approximation, 7/5 ~= sqrt(2), which underestimates the diagonal cost by 1%. The limited number of directions also affect the precision of the cost estimate. It may overestimate the cost up to 7.33%. I don't think this will lead to any issues, but if it does, it can be mitigated by adding eight more edges for a finer angular resolution and possibly increasing the scale of the integers, The extra edges would act as shortcuts for two regular steps, one diagonal and one non-diagonal.
 
### The search
There are plenty of algorithms for finding paths in discrete grids. Perhaps the most basic one is [breadth-first search](https://en.wikipedia.org/wiki/Breadth-first_search) which will find one of the paths with fewest edges. I implemented that first. In order to be able to find a path to any position in a circle close to the goal, the search is performed from goal position(s) to start position. This allows for several goal positions to be used. This is used for finding paths to objects, eg. `goto(radar(TitaniumCube).position);`.

The next step is  [Dijkstra's algorithm](https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm) which will find one of the paths with the lowest cost. Dijkstra's algorithm relies on using a priority queue for ordering the nodes to explore. A [binary heap](https://en.wikipedia.org/wiki/Binary_heap) is often used for this as it relatively simple, efficient and implementations are abundant. However, if the priorities are integers, a [Bucker queue](https://en.wikipedia.org/wiki/Bucket_queue) can be used instead with improved performance characteristics. This is known as Dial's algorithm and I chose to implement that variation.

The search algorithms described above expands nodes outwards in a symmetric fashion until it happens to find a path between start and goal. A heuristic can be added in order to guide the search and find a solution faster by sorting the queue by the upper bound of the cost of the full path that goes through a particular node. This is known as [A*](https://en.wikipedia.org/wiki/A*_search_algorithm) and is probably the most commonly used pathfinding algorithm in games. I have not seen it implemented with a bucket queue before but I would be surprised if I'm the first one to do it. The heuristic most commonly used with A* is the Euclidean distance ("as the crow flies") but since we are using 8-way connectivity I made it the minimal cost in that metric.

I also implemented a fallback behavior for the case of unexpectedly wide range of priorities. This code is never used in the game because the game never requests big enough `goalRadius` for it to activate. I did test it by reducing the number of buckets to make sure it works though. It does add a bit of complexity that could be avoided so I would kind of recommend myself to "kill your darlings" and replace it with an assert.

### Suggestions for future improvements
* Increase the resolution of the grid close to obstacles by using some kind of non-uniform grid.
* Look for shortcuts more often to follow the path more smoothly.
* Remove the "beamleak" behavior that moves the bot away from nearby obstacles before starting the search.