### PR TITLE
Use https URLs for git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "data"]
 	path = data
-	url = git://github.com/colobot/colobot-data.git
+	url = https://github.com/colobot/colobot-data.git
 	branch = .
 	update = rebase
 [submodule "lib/googletest"]
 	path = lib/googletest
-	url = git://github.com/google/googletest.git
+	url = https://github.com/google/googletest.git
 	ignore = all


### PR DESCRIPTION
As of March 15, 2022, [accessing GitHub via the unencrypted `git://` protocol has been disabled](https://github.blog/2021-09-01-improving-git-protocol-security-github/). This means that initializing submodules fails:

```
$ git submodule update --init --recursive
Submodule 'data' (git://github.com/colobot/colobot-data.git) registered for path 'data'
Submodule 'lib/googletest' (git://github.com/google/googletest.git) registered for path 'lib/googletest'
Cloning into '/home/tad/work/colobot/lib/googletest'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
fatal: clone of 'git://github.com/google/googletest.git' into submodule path '/home/tad/work/colobot/lib/googletest' failed
Failed to clone 'lib/googletest'. Retry scheduled
Cloning into '/home/tad/work/colobot/lib/googletest'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
fatal: clone of 'git://github.com/google/googletest.git' into submodule path '/home/tad/work/colobot/lib/googletest' failed
Failed to clone 'lib/googletest' a second time, aborting
```

Fix the issue by using `https://` URLs.