### PR TITLE
Enchance lunar units

### DIFF
--- a/src/object/object_factory.cpp
+++ b/src/object/object_factory.cpp
@@ -2504,9 +2504,9 @@ CObjectUPtr CObjectFactory::CreateApollo(const ObjectCreateParams& params)
         obj->SetObjectParent(5, 0);
         m_oldModelManager->AddModelReference("apollol3.mod", false, rank, obj->GetTeam());  // ladder
 
-//?     m_terrain->AddBuildingLevel(pos, 10.0f, 13.0f, 12.0f, 0.0f);
+        m_terrain->AddBuildingLevel(pos, 10.0f, 13.0f, 12.0f, 0.0f);
 
-        obj->AddCrashSphere(CrashSphere(Math::Vector(  0.0f, 4.0f,   0.0f), 9.0f, SOUND_BOUMm, 0.45f));
+        obj->AddCrashSphere(CrashSphere(Math::Vector(  0.0f, 2.0f,   0.0f), 9.0f, SOUND_BOUMm, 0.45f));
         obj->AddCrashSphere(CrashSphere(Math::Vector( 11.0f, 5.0f,   0.0f), 3.0f, SOUND_BOUMm, 0.45f));
         obj->AddCrashSphere(CrashSphere(Math::Vector(-11.0f, 5.0f,   0.0f), 3.0f, SOUND_BOUMm, 0.45f));
         obj->AddCrashSphere(CrashSphere(Math::Vector(  0.0f, 5.0f, -11.0f), 3.0f, SOUND_BOUMm, 0.45f));

--- a/src/object/task/taskflag.cpp
+++ b/src/object/task/taskflag.cpp
@@ -131,6 +131,7 @@ Error CTaskFlag::Start(TaskFlagOrder order, int rank)
         case OBJECT_MOBILEts:
         case OBJECT_MOBILEfs:
         case OBJECT_MOBILEis:
+        case OBJECT_APOLLO2:
         {
             int i = m_sound->Play(SOUND_MANIP, m_object->GetPosition(), 0.0f, 0.3f, true);
             m_sound->AddEnvelope(i, 0.5f, 1.0f, 0.1f, SOPER_CONTINUE);
@@ -198,7 +199,7 @@ CObject* CTaskFlag::SearchNearest(Math::Vector pos, ObjectType type)
     std::vector<ObjectType> types;
     if(type == OBJECT_NULL)
     {
-        types = {OBJECT_FLAGb, OBJECT_FLAGr, OBJECT_FLAGg, OBJECT_FLAGy, OBJECT_FLAGv};
+        types = {OBJECT_FLAGb, OBJECT_FLAGr, OBJECT_FLAGg, OBJECT_FLAGy, OBJECT_FLAGv, OBJECT_APOLLO3};
     }
     else
     {
@@ -221,7 +222,8 @@ int CTaskFlag::CountObject(ObjectType type)
                  oType != OBJECT_FLAGr &&
                  oType != OBJECT_FLAGg &&
                  oType != OBJECT_FLAGy &&
-                 oType != OBJECT_FLAGv )  continue;
+                 oType != OBJECT_FLAGv &&
+                 oType != OBJECT_APOLLO3 )  continue;
         }
         else
         {
@@ -255,6 +257,10 @@ Error CTaskFlag::CreateFlag(int rank)
             pos = Transform(*mat, Math::Vector(4.0f, 0.0f, 0.0f));
             break;
 
+        case OBJECT_APOLLO2:
+            pos = Transform(*mat, Math::Vector(9.5f, 0.0f, 0.0f));
+            break;
+
         default:
             pos = Transform(*mat, Math::Vector(6.0f, 0.0f, 0.0f));
             break;
@@ -271,6 +277,11 @@ Error CTaskFlag::CreateFlag(int rank)
     }
 
     ObjectType type = table[rank];
+    if ( m_object->GetType() == OBJECT_APOLLO2 )
+    {
+        type = OBJECT_APOLLO3;
+    }
+
     if ( CountObject(type) >= 5 )
     {
         return ERR_FLAG_CREATE;

--- a/src/object/task/taskrecover.cpp
+++ b/src/object/task/taskrecover.cpp
@@ -373,5 +373,5 @@ bool CTaskRecover::Abort()
 
 CObject* CTaskRecover::SearchRuin()
 {
-    return CObjectManager::GetInstancePointer()->FindNearest(nullptr, m_recoverPos, {OBJECT_RUINmobilew1, OBJECT_RUINmobilew2, OBJECT_RUINmobilet1, OBJECT_RUINmobilet2, OBJECT_RUINmobiler1, OBJECT_RUINmobiler2}, 40.0f/g_unit);
+    return CObjectManager::GetInstancePointer()->FindNearest(nullptr, m_recoverPos, {OBJECT_RUINmobilew1, OBJECT_RUINmobilew2, OBJECT_RUINmobilet1, OBJECT_RUINmobilet2, OBJECT_RUINmobiler1, OBJECT_RUINmobiler2, OBJECT_APOLLO4}, 40.0f/g_unit);
 }

--- a/src/ui/object_interface.cpp
+++ b/src/ui/object_interface.cpp
@@ -1151,6 +1151,21 @@ bool CObjectInterface::CreateInterface(bool bSelect)
         }
     }
 
+    if ( type == OBJECT_APOLLO2 &&  // ApolloJeep
+         !m_object->GetTrainer() )
+    {
+        if ( m_main->IsBuildingEnabled(BUILD_FLAG) )
+        {
+            pos.x = ox+sx*10.1f;
+            pos.y = oy+sy*0.5f;
+            pw->CreateButton(pos, dim, 64+54, EVENT_OBJECT_FCREATE);
+
+            pos.x = ox+sx*11.1f;
+            pos.y = oy+sy*0.5f;
+            pw->CreateButton(pos, dim, 64+55, EVENT_OBJECT_FDELETE);
+        }
+    }
+
     if ( type == OBJECT_MOBILErt &&  // Terraformer?
          !m_object->GetTrainer() )
     {


### PR DESCRIPTION
This PR add minor tweaks for lunar objects.

Apollo Lunar Excursion Module (LEM, OBJECT_APOLLO1):
* flat surface is now walkable (ladder is still not usable, you need to fly & land on the top)

Apollo Lunar Roving Vehicle (LRV, OBJECT_APOLLO2):
* now can produce flags
* unlike other flag creating units, this one always produce american flags (OBJECT_APOLLO3) instead of colored B/G/R/Y/V flags.

Small on-ground piece of Apollo mission remains (OBJECT_APOLLO4):
* now can be recycled

![изображение](https://user-images.githubusercontent.com/5786428/188335041-f356ed1c-1d71-4c71-93dd-553fb6b361c9.png)
![изображение](https://user-images.githubusercontent.com/5786428/188339845-85283db2-efaf-4327-b092-5fc292b9b300.png)
![изображение](https://user-images.githubusercontent.com/5786428/188517648-09c66254-ea4b-43b3-824f-57ade78bf53c.png)

