### PR TITLE
Add missing <cstdint> includes

### DIFF
--- a/src/CBot/CBotFileUtils.h
+++ b/src/CBot/CBotFileUtils.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 

--- a/src/CBot/CBotInstr/CBotExprLitChar.h
+++ b/src/CBot/CBotInstr/CBotExprLitChar.h
@@ -21,6 +21,8 @@
 
 #include "CBot/CBotInstr/CBotInstr.h"
 
+#include <cstdint>
+
 namespace CBot
 {
 

--- a/src/CBot/CBotStack.cpp
+++ b/src/CBot/CBotStack.cpp
@@ -30,6 +30,7 @@
 #include "CBot/CBotExternalCall.h"
 
 #include <cassert>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 

--- a/src/CBot/CBotVar/CBotVar.h
+++ b/src/CBot/CBotVar/CBotVar.h
@@ -24,6 +24,7 @@
 #include "CBot/CBotEnums.h"
 #include "CBot/CBotUtils.h"
 
+#include <cstdint>
 #include <string>
 
 namespace CBot

--- a/src/object/task/taskgoto.h
+++ b/src/object/task/taskgoto.h
@@ -24,6 +24,7 @@
 #include "math/vector.h"
 
 #include <array>
+#include <cstdint>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
Some parts of the code used the fixed-size type `uint32_t`, which is defined in `stdint.h` / `cstdint` - without including said header file. With GCC13, the inter-header dependencies seem to have changed and the file is no longer included transitively, requiring an explicit `#include`.