### PR TITLE
ENGINE: Fix operator < for COldModelManager::FileInfo

### DIFF
--- a/src/graphics/engine/oldmodelmanager.h
+++ b/src/graphics/engine/oldmodelmanager.h
@@ -114,6 +114,8 @@ private:
 
             if (variant < other.variant)
                 return true;
+            if (variant > other.variant)
+                return false;
 
             return !mirrored && mirrored != other.mirrored;
         }


### PR DESCRIPTION
There was a rare case when Old Model Manager's model base object list was not working correctly.

Testcase:
CreateObject pos=10;0 dir=1.5 type=LeggedTrainer selectable=1 team=1 CreateObject pos=-10;0 dir=0.25 type=LeggedTrainer selectable=1 team=2

Expected result (after fix): models are displayed correctly Actual result (before fix): some legs are missing, instead of them giant surfaces are floating high above the model

The reason was is failing to find the element that was just created and added with `m_models.find(FileInfo(fileName, mirrored, team))` This happened for objects that had mirrored body parts (at least Ants, Wasps and all Legged units were affected) in case they were assigned to several teams. Everyone were missing some legs since the `modelManager->AddModelReference("ant6.mod", true, rank, m_object->GetTeam())` Wasps were also usually missing some wings.