### PR TITLE
Fix build with GCC 13

### DIFF
--- a/src/CBot/CBotFileUtils.h
+++ b/src/CBot/CBotFileUtils.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes so some are no longer transitively included.

See https://gnu.org/software/gcc/gcc-13/porting_to.html.

Bug: https://bugs.gentoo.org/899034