### PR TITLE
Add unlocking Phazer research after completing missions chapter 9 and fix missing research icons

### DIFF
--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -3777,6 +3777,8 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
             m_build |= m_playerProfile->GetFreeGameBuildUnlock();
         }
 
+        m_researchEnable |= m_researchDone[0];
+
         if (!resetObject)
         {
             m_short->SetMode(false);  // vehicles?

--- a/src/level/robotmain.cpp
+++ b/src/level/robotmain.cpp
@@ -3777,6 +3777,12 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
             m_build |= m_playerProfile->GetFreeGameBuildUnlock();
         }
 
+        if (~m_researchDone[0] & RESEARCH_PHAZER && (m_levelCategory == LevelCategory::FreeGame || m_levelCategory == LevelCategory::GamePlus) && m_playerProfile->GetLevelPassed(LevelCategory::Missions, 9, 0))
+        {
+            m_build |= BUILD_RESEARCH;
+            m_researchEnable |= RESEARCH_PHAZER;
+        }
+
         m_researchEnable |= m_researchDone[0];
 
         if (!resetObject)


### PR DESCRIPTION
* Add unlocking Phazer research in Missions+ and Free game as a reward completing Missions chapter 9
* Fix missing icons of done-but-not-enabled research programs by enabling them on level load. Icons will still be missing when cheating.