### PR TITLE
Update data submodule url per new github policies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "data"]
 	path = data
-	url = git://github.com/colobot/colobot-data.git
+	url = git@github.com:colobot/colobot-data.git


### PR DESCRIPTION
https://github.blog/2021-09-01-improving-git-protocol-security-github/#git-protocol-troubleshooting

`git://` is no longer supported, and connection attempts will time out. This PR replaces with `git@github.com:` which may require a configured SSH key. Another less secure but more accessible replacement would be `https://`