### PR TITLE
Replace deprecated PHYSFS functions with their modern counterparts

### DIFF
--- a/src/common/resources/inputstreambuffer.cpp
+++ b/src/common/resources/inputstreambuffer.cpp
@@ -79,7 +79,7 @@ std::streambuf::int_type CInputStreamBuffer::underflow()
     if (PHYSFS_eof(m_file))
         return traits_type::eof();
 
-    PHYSFS_sint64 read_count = PHYSFS_read(m_file, m_buffer.get(), sizeof(char), m_bufferSize);
+    PHYSFS_sint64 read_count = PHYSFS_readBytes(m_file, m_buffer.get(), sizeof(char) * m_bufferSize);
     if (read_count <= 0)
         return traits_type::eof();
 

--- a/src/common/resources/outputstreambuffer.cpp
+++ b/src/common/resources/outputstreambuffer.cpp
@@ -78,7 +78,7 @@ std::streambuf::int_type COutputStreamBuffer::overflow(std::streambuf::int_type 
         return 0;
 
     // save buffer
-    PHYSFS_sint64 bytes_written = PHYSFS_write(m_file, pbase(), 1, pptr() - pbase());
+    PHYSFS_sint64 bytes_written = PHYSFS_writeBytes(m_file, pbase(), pptr() - pbase());
     if (bytes_written <= 0)
         return traits_type::eof();
 
@@ -86,7 +86,7 @@ std::streambuf::int_type COutputStreamBuffer::overflow(std::streambuf::int_type 
     // write final char
     if (ch != traits_type::eof())
     {
-        bytes_written = PHYSFS_write(m_file, &ch, 1, 1);
+        bytes_written = PHYSFS_writeBytes(m_file, &ch, 1);
         if (bytes_written <= 0)
             return traits_type::eof();
     }

--- a/src/common/resources/resourcemanager.cpp
+++ b/src/common/resources/resourcemanager.cpp
@@ -38,7 +38,8 @@ CResourceManager::CResourceManager(const char *argv0)
 {
     if (!PHYSFS_init(argv0))
     {
-        GetLogger()->Error("Error while initializing physfs: %s\n", PHYSFS_getLastError());
+        PHYSFS_ErrorCode errorCode = PHYSFS_getLastErrorCode();
+        GetLogger()->Error("Error while initializing physfs: %s\n", PHYSFS_getErrorByCode(errorCode));
         assert(false);
     }
     PHYSFS_permitSymbolicLinks(1);
@@ -51,7 +52,8 @@ CResourceManager::~CResourceManager()
     {
         if (!PHYSFS_deinit())
         {
-            GetLogger()->Error("Error while deinitializing physfs: %s\n", PHYSFS_getLastError());
+            PHYSFS_ErrorCode errorCode = PHYSFS_getLastErrorCode();
+            GetLogger()->Error("Error while deinitializing physfs: %s\n", PHYSFS_getErrorByCode(errorCode));
         }
     }
 }
@@ -66,7 +68,8 @@ bool CResourceManager::AddLocation(const std::string &location, bool prepend, co
 {
     if (!PHYSFS_mount(location.c_str(), mountPoint.c_str(), prepend ? 0 : 1))
     {
-        GetLogger()->Error("Error while mounting \"%s\": %s\n", location.c_str(), PHYSFS_getLastError());
+        PHYSFS_ErrorCode errorCode = PHYSFS_getLastErrorCode();
+        GetLogger()->Error("Error while mounting \"%s\": %s\n", location.c_str(), PHYSFS_getErrorByCode(errorCode));
         return false;
     }
 
@@ -76,9 +79,10 @@ bool CResourceManager::AddLocation(const std::string &location, bool prepend, co
 
 bool CResourceManager::RemoveLocation(const std::string &location)
 {
-    if (!PHYSFS_removeFromSearchPath(location.c_str()))
+    if (!PHYSFS_unmount(location.c_str()))
     {
-        GetLogger()->Error("Error while unmounting \"%s\": %s\n", location.c_str(), PHYSFS_getLastError());
+        PHYSFS_ErrorCode errorCode = PHYSFS_getLastErrorCode();
+        GetLogger()->Error("Error while unmounting \"%s\": %s\n", location.c_str(), PHYSFS_getErrorByCode(errorCode));
         return false;
     }
 
@@ -106,7 +110,8 @@ bool CResourceManager::SetSaveLocation(const std::string &location)
 {
     if (!PHYSFS_setWriteDir(location.c_str()))
     {
-        GetLogger()->Error("Error while setting save location to \"%s\": %s\n", location.c_str(), PHYSFS_getLastError());
+        PHYSFS_ErrorCode errorCode = PHYSFS_getLastErrorCode();
+        GetLogger()->Error("Error while setting save location to \"%s\": %s\n", location.c_str(), PHYSFS_getErrorByCode(errorCode));
         return false;
     }
 
@@ -151,7 +156,9 @@ bool CResourceManager::DirectoryExists(const std::string& directory)
 {
     if (PHYSFS_isInit())
     {
-        return PHYSFS_exists(CleanPath(directory).c_str()) && PHYSFS_isDirectory(CleanPath(directory).c_str());
+        PHYSFS_Stat statbuf;
+        PHYSFS_stat(CleanPath(directory).c_str(), &statbuf);
+        return (PHYSFS_exists(CleanPath(directory).c_str()) && (statbuf.filetype == PHYSFS_FILETYPE_DIRECTORY));
     }
     return false;
 }
@@ -192,8 +199,10 @@ std::vector<std::string> CResourceManager::ListFiles(const std::string &director
         {
             if (excludeDirs)
             {
+                PHYSFS_Stat statbuf;
                 std::string path = CleanPath(directory) + "/" + (*i);
-                if (PHYSFS_isDirectory(path.c_str())) continue;
+                PHYSFS_stat(path.c_str(), &statbuf);
+                if (statbuf.filetype == PHYSFS_FILETYPE_DIRECTORY) continue;
             }
             result.push_back(*i);
         }
@@ -214,8 +223,10 @@ std::vector<std::string> CResourceManager::ListDirectories(const std::string &di
 
         for (char **i = files; *i != nullptr; i++)
         {
+            PHYSFS_Stat statbuf;
             std::string path = CleanPath(directory) + "/" + (*i);
-            if (PHYSFS_isDirectory(path.c_str()))
+            PHYSFS_stat(path.c_str(), &statbuf);
+            if (statbuf.filetype == PHYSFS_FILETYPE_DIRECTORY)
             {
                 result.push_back(*i);
             }
@@ -244,7 +255,9 @@ long long CResourceManager::GetLastModificationTime(const std::string& filename)
 {
     if (PHYSFS_isInit())
     {
-        return PHYSFS_getLastModTime(CleanPath(filename).c_str());
+        PHYSFS_Stat statbuf;
+        PHYSFS_stat(CleanPath(filename).c_str(), &statbuf);
+        return statbuf.modtime;
     }
     return -1;
 }

--- a/src/common/resources/sdl_file_wrapper.cpp
+++ b/src/common/resources/sdl_file_wrapper.cpp
@@ -160,7 +160,7 @@ size_t CSDLFileWrapper::SDLRead(SDL_RWops *context, void *ptr, size_t size, size
         PHYSFS_File *file = static_cast<PHYSFS_File *>(context->hidden.unknown.data1);
         SDL_memset(ptr, 0, size * maxnum);
 
-        auto result = PHYSFS_read(file, ptr, size, maxnum);
+        auto result = PHYSFS_readBytes(file, ptr, size * maxnum);
         return (result >= 0) ? result : 0;
     }
 

--- a/src/common/resources/sdl_memory_wrapper.cpp
+++ b/src/common/resources/sdl_memory_wrapper.cpp
@@ -46,7 +46,7 @@ CSDLMemoryWrapper::CSDLMemoryWrapper(const std::string& filename)
 
     PHYSFS_sint64 length = PHYSFS_fileLength(file);
     m_buffer = MakeUniqueArray<char>(length);
-    if (PHYSFS_read(file, m_buffer.get(), 1, length) != length)
+    if (PHYSFS_readBytes(file, m_buffer.get(), length) != length)
     {
         GetLogger()->Error("Unable to read data for \"%s\"\n", filename.c_str());
         PHYSFS_close(file);

--- a/src/common/resources/sndfile_wrapper.cpp
+++ b/src/common/resources/sndfile_wrapper.cpp
@@ -47,7 +47,8 @@ CSNDFileWrapper::CSNDFileWrapper(const std::string& filename)
     }
     else
     {
-        m_last_error = std::string(PHYSFS_getLastError());
+        PHYSFS_ErrorCode errorCode = PHYSFS_getLastErrorCode();
+        m_last_error = std::string(PHYSFS_getErrorByCode(errorCode));
     }
 }
 
@@ -97,7 +98,7 @@ sf_count_t CSNDFileWrapper::SNDLength(void *data)
 
 sf_count_t CSNDFileWrapper::SNDRead(void *ptr, sf_count_t count, void *data)
 {
-    return PHYSFS_read(static_cast<PHYSFS_File *>(data), ptr, 1, count);
+    return PHYSFS_readBytes(static_cast<PHYSFS_File *>(data), ptr, count);
 }
 
 
@@ -129,5 +130,5 @@ sf_count_t CSNDFileWrapper::SNDTell(void *data)
 
 sf_count_t CSNDFileWrapper::SNDWrite(const void *ptr, sf_count_t count, void *data)
 {
-    return PHYSFS_write(static_cast<PHYSFS_File *>(data), ptr, 1, count);
+    return PHYSFS_writeBytes(static_cast<PHYSFS_File *>(data), ptr, count);
 }

--- a/src/graphics/opengl/glutil.cpp
+++ b/src/graphics/opengl/glutil.cpp
@@ -479,7 +479,7 @@ GLint LoadShader(GLint type, const char* filename)
 
     GLchar source[65536];
     GLchar *sources[] = { source };
-    int length = PHYSFS_read(file, source, 1, 65536);
+    int length = PHYSFS_readBytes(file, source, 65536);
     source[length] = '\0';
 
     PHYSFS_close(file);


### PR DESCRIPTION
This PR replaces old, deprecated physfs functions with newer, supported ones.
Package managers in supported OSes should have recent enough versions of physfs library, so there is no need to keep the deprecated function calls anymore.
Closes #1573 