### PR TITLE
Updated checkout and upload-artifact actions to node16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,6 @@ jobs:
         container: ['']
       fail-fast: false
     steps:
-    - name: Switch to gcc-9
-      run: sudo apt install gcc-9 g++-9 && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9 && sudo update-alternatives --set gcc /usr/bin/gcc-9
-      if: matrix.host_os == 'ubuntu-18.04'
     - name: Install Colobot dependencies
       run: sudo apt-get update && sudo apt-get install -y --no-install-recommends build-essential cmake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsndfile1-dev libvorbis-dev libogg-dev libpng-dev libglew-dev libopenal-dev libphysfs-dev gettext git po4a vorbis-tools librsvg2-bin xmlstarlet libglm-dev libmpg123-dev
       if: matrix.container == ''

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install Colobot dependencies
       run: sudo apt-get update && sudo apt-get install -y --no-install-recommends build-essential cmake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsndfile1-dev libvorbis-dev libogg-dev libpng-dev libglew-dev libopenal-dev libphysfs-dev gettext git po4a vorbis-tools librsvg2-bin xmlstarlet libglm-dev libmpg123-dev
       if: matrix.container == ''
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Checkout the Google Test submodule
       run: git submodule update --init -- lib/googletest
     - name: Checkout the nlohmann json submodule
@@ -90,7 +90,7 @@ jobs:
     - name: Install Colobot dependencies
       run: brew install cmake sdl2 sdl2_image sdl2_ttf glew physfs flac libsndfile libvorbis vorbis-tools gettext libicns librsvg wget xmlstarlet glm
       if: matrix.container == ''
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Checkout the Google Test submodule
       run: git submodule update --init -- lib/googletest
     - name: Checkout the nlohmann json submodule
@@ -123,7 +123,7 @@ jobs:
           - arch: x86
             vcpkg_triplet: 'x86-windows-static'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Checkout the Google Test submodule
       run: git submodule update --init -- lib/googletest
     - name: Checkout the nlohmann json submodule
@@ -196,7 +196,7 @@ jobs:
     steps:
     - name: Install Colobot dependencies
       run: sudo apt-get update && sudo apt-get install -y --no-install-recommends build-essential cmake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsndfile1-dev libvorbis-dev libogg-dev libpng-dev libglew-dev libopenal-dev libphysfs-dev gettext git po4a vorbis-tools librsvg2-bin xmlstarlet doxygen graphviz libglm-dev libmpg123-dev
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Create build directory
       run: cmake -E make_directory build
     - name: Checkout the nlohmann json submodule

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       run: patchelf --set-rpath '.' install/colobot
       if: matrix.target_os == 'linux'
     - name: Upload build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{matrix.target_os}}-debug
         path: install
@@ -61,7 +61,7 @@ jobs:
         cp -p Colobot-x86_64.AppImage appimage/colobot
       if: matrix.target_os == 'linux'
     - name: Upload AppImage
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{matrix.target_os}}-debug-AppImage
         path: build/appimage
@@ -72,7 +72,7 @@ jobs:
       run: ./Colobot-UnitTests --gtest_output=xml:gtestresults.xml
       if: matrix.target_os == 'linux'
     - name: Upload test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Test results (${{ matrix.target_os }}, ${{ matrix.host_os }})
         path: build/gtestresults.xml
@@ -108,7 +108,7 @@ jobs:
       run: ./Colobot-UnitTests --gtest_output=xml:gtestresults.xml
       if: matrix.target_os == 'macos'
     - name: Upload test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Test results (${{ matrix.target_os }}, ${{ matrix.host_os }})
         path: build/gtestresults.xml
@@ -179,7 +179,7 @@ jobs:
     - name: Install
       run: cmake --build --preset Windows-CI --target install
     - name: Upload build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: windows-msvc-debug-${{ matrix.arch }}
         path: install
@@ -187,7 +187,7 @@ jobs:
       working-directory: build
       run: ./Colobot-UnitTests --gtest_output=xml:gtestresults.xml
     - name: Upload test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: 'Test results (windows, MSVC, ${{ matrix.arch }})'
         path: build/gtestresults.xml
@@ -208,7 +208,7 @@ jobs:
       working-directory: build
       run: make doc
     - name: Upload docs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: doc
         path: build/doc


### PR DESCRIPTION
There are still seanmiddleditch/gha-setup-ninja and seanmiddleditch/gha-setup-vsdevenv actions that uses node12. There are pending PRs fixing it, but they're still not merged. They should be updated by themselves, unless repo owner decides to make it on non-master branch.

If the owner won't update it before deprecation of node12, we'll have to find alternatives.

Also removed step with upgrading gcc to gcc-9 on Ubuntu 18.04. Since we don't use this runner anymore, the step was disabled anyway.