### PR TITLE
Fix the build instructions

### DIFF
--- a/docs/README-dev.md
+++ b/docs/README-dev.md
@@ -61,7 +61,6 @@ Note that the recommended way of building the project is to use separate build d
   git clone https://github.com/colobot/colobot.git
   cd colobot
   git submodule update --init
-  ln --symbolic ../colobot-base/src/graphics/opengl33/shaders/ data/  # ON BRANCH master RUN THIS INSTEAD: ln --symbolic ../src/graphics/opengl/shaders/ data/
   mkdir build
   cd build
   cmake -D TRANSLATIONS=OFF ../  # You can't compile translations unless you have python2

--- a/docs/README-dev.md
+++ b/docs/README-dev.md
@@ -66,7 +66,7 @@ Note that the recommended way of building the project is to use separate build d
   # You can't compile translations unless you have python2
   cmake -D TRANSLATIONS=OFF -D COLOBOT_DEVELOPMENT_MODE=ON ..
   make
-  ./colobot -datadir ../data
+  ./colobot -datadir data/
 ```
 
 ## Tests organization

--- a/docs/README-dev.md
+++ b/docs/README-dev.md
@@ -58,9 +58,8 @@ Because of the above, include paths in source should always feature the full pat
 Note that the recommended way of building the project is to use separate build directory, where CMake will generate all targets. In this way, you can keep a clean source directory. The following shell commands illustrate this usage:
 
 ```sh
-  git clone https://github.com/colobot/colobot.git
+  git clone --recursive https://github.com/colobot/colobot.git
   cd colobot
-  git submodule update --init
   mkdir build
   cd build
   # You can't compile translations unless you have python2

--- a/docs/README-dev.md
+++ b/docs/README-dev.md
@@ -62,8 +62,7 @@ Note that the recommended way of building the project is to use separate build d
   cd colobot
   mkdir build
   cd build
-  # You can't compile translations unless you have python2
-  cmake -D TRANSLATIONS=OFF -D COLOBOT_DEVELOPMENT_MODE=ON ..
+  cmake -D COLOBOT_DEVELOPMENT_MODE=ON ..
   make
   ./colobot -datadir data/
 ```

--- a/docs/README-dev.md
+++ b/docs/README-dev.md
@@ -63,7 +63,8 @@ Note that the recommended way of building the project is to use separate build d
   git submodule update --init
   mkdir build
   cd build
-  cmake -D TRANSLATIONS=OFF ../  # You can't compile translations unless you have python2
+  # You can't compile translations unless you have python2
+  cmake -D TRANSLATIONS=OFF -D COLOBOT_DEVELOPMENT_MODE=ON ..
   make
   ./colobot -datadir ../data
 ```

--- a/docs/README-dev.md
+++ b/docs/README-dev.md
@@ -60,9 +60,8 @@ Note that the recommended way of building the project is to use separate build d
 ```sh
   git clone https://github.com/colobot/colobot.git
   cd colobot
-  git switch master  # or dev (see above)
   git submodule update --init
-  ln --symbolic ../src/graphics/opengl/shaders/ data/  # ON BRANCH dev RUN THIS INSTEAD: ln --symbolic ../colobot-base/graphics/opengl33/shaders/ data/  
+  ln --symbolic ../colobot-base/graphics/opengl33/shaders/ data/  # ON BRANCH master RUN THIS INSTEAD: ln --symbolic ../src/graphics/opengl/shaders/ data/
   mkdir build
   cd build
   cmake -D TRANSLATIONS=OFF ../  # You can't compile translations unless you have python2

--- a/docs/README-dev.md
+++ b/docs/README-dev.md
@@ -61,7 +61,7 @@ Note that the recommended way of building the project is to use separate build d
   git clone https://github.com/colobot/colobot.git
   cd colobot
   git submodule update --init
-  ln --symbolic ../colobot-base/graphics/opengl33/shaders/ data/  # ON BRANCH master RUN THIS INSTEAD: ln --symbolic ../src/graphics/opengl/shaders/ data/
+  ln --symbolic ../colobot-base/src/graphics/opengl33/shaders/ data/  # ON BRANCH master RUN THIS INSTEAD: ln --symbolic ../src/graphics/opengl/shaders/ data/
   mkdir build
   cd build
   cmake -D TRANSLATIONS=OFF ../  # You can't compile translations unless you have python2

--- a/docs/README-dev.md
+++ b/docs/README-dev.md
@@ -58,10 +58,14 @@ Because of the above, include paths in source should always feature the full pat
 Note that the recommended way of building the project is to use separate build directory, where CMake will generate all targets. In this way, you can keep a clean source directory. The following shell commands illustrate this usage:
 
 ```sh
-  cd <colobot_repository>
+  git clone https://github.com/colobot/colobot.git
+  cd colobot
+  git switch master  # or dev (see above)
+  git submodule update --init
+  ln --symbolic ../src/graphics/opengl/shaders/ data/  # ON BRANCH dev RUN THIS INSTEAD: ln --symbolic ../colobot-base/graphics/opengl33/shaders/ data/  
   mkdir build
   cd build
-  cmake ../
+  cmake -D TRANSLATIONS=OFF ../  # You can't compile translations unless you have python2
   make
   ./colobot -datadir ../data
 ```

--- a/docs/README-dev.md
+++ b/docs/README-dev.md
@@ -60,9 +60,10 @@ Note that the recommended way of building the project is to use separate build d
 ```sh
   cd <colobot_repository>
   mkdir build
+  cd build
   cmake ../
   make
-  bin/colobot -datadir ../data
+  ./colobot -datadir ../data
 ```
 
 ## Tests organization


### PR DESCRIPTION
I have managed to compile the game, despite incorrect build instructions and other difficulties.

1. This three lines assume we are inside <colobot_repository>/build/ but we never changed into it:
```
cmake ../
make
colobot -datadir ../data
```
2. There was no <colobot_repository>/build/bin/ directory. The executable was in <colobot_repository>/build/

Edit: building the game and getting it to run required a lot of trial-and-error (especially the dev branch). I added more complete build instructions to reduce the trial-and-error for future contributors.

Design philosophy:
* Concrete is easier to understand than abstract
* [Skipping steps you think are obvious will lead to contributors being stumped](https://en.wikipedia.org/wiki/Illusion_of_transparency)

Note: the instructions are missing a step: the installation of dependencies. I do **not** intend to add this step in this pull request.

* fixes #1631