### PR TITLE
Fix a SEGFAULT in the logger

### DIFF
--- a/colobot-app/src/main.cpp
+++ b/colobot-app/src/main.cpp
@@ -163,7 +163,7 @@ int main(int argc, char *argv[])
     LocalFree(wargv);
     #endif
 
-    logger.Info("%s starting\n", Version::FULL_NAME);
+    logger.Info("%s starting\n", std::string(Version::FULL_NAME).data());
 
     CSignalHandlers::Init(systemUtils.get());
 

--- a/colobot-base/app/app.cpp
+++ b/colobot-base/app/app.cpp
@@ -303,7 +303,7 @@ ParseArgsStatus CApplication::ParseArguments(int argc, char *argv[])
             case OPT_HELP:
             {
                 GetLogger()->Message("\n");
-                GetLogger()->Message("%s\n", Version::FULL_NAME);
+                GetLogger()->Message("%s\n", std::string(Version::FULL_NAME).data());
                 GetLogger()->Message("\n");
                 GetLogger()->Message("List of available options and environment variables:\n");
                 GetLogger()->Message("  -help               this help\n");


### PR DESCRIPTION
# What happened

I built the latest dev (f07b7a1b60cd5685d7cd5f5677669423281fefa0) from source. After applying a fix for #1617 it compiled, but it crashed with SEGFAULT on when I tried to start the game. Trace from gdb:

```c++
Program received signal SIGSEGV, Segmentation fault.
#0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:65
#1  0x00007ffff7552d15 in __vfprintf_internal (s=s@entry=0x7fffffffbd30, format=0x5555559690d1 "%s starting\n", ap=0x7fffffffe430, mode_flags=<optimized out>) at vfprintf-internal.c:1688
#2  0x00007ffff7553ea2 in buffered_vfprintf (s=s@entry=0x7ffff76c75c0 <_IO_2_1_stderr_>, format=format@entry=0x5555559690d1 "%s starting\n", args=args@entry=0x7fffffffe430, mode_flags=mode_flags@entry=0) at vfprintf-internal.c:2377
#3  0x00007ffff7550d24 in __vfprintf_internal (s=0x7ffff76c75c0 <_IO_2_1_stderr_>, format=0x5555559690d1 "%s starting\n", ap=0x7fffffffe430, mode_flags=0) at vfprintf-internal.c:1346
#4  0x00005555555e61e0 in CLogger::Log (this=0x7fffffffe580, type=LOG_INFO, str=0x5555559690d1 "%s starting\n", args=0x7fffffffe470) at colobot/colobot-base/common/logger.cpp:71
#5  0x00005555555e6482 in CLogger::Info (this=0x7fffffffe580, str=0x5555559690d1 "%s starting\n") at colobot/colobot-base/common/logger.cpp:96
#6  0x000055555558e737 in main (argc=2, argv=0x7fffffffe998) at colobot/colobot-app/src/main.cpp:166
```

# The problem

printf("%s", ...) is VERY fragile. It expects `char *` or `const char *`. Anythng else (e.g. std::string_view) is undefined behaviour.

Because printf() uses C variadic arguments most implicit conversions do NOT happen - the compiler does not know what type to convert the argument to.

Even if implicit conversions did work in variadic functions (they do not except for "default argument promotions") std::string_view can not be implicitly converted to char * because std::string_view is not NUL-terminated.

# Proposed solution

Convert std::string_view to NUL-terminated char * before passing it to the logger.

# Bug introduced in

f9714c35f7969d5ed6e6612f7516d7128e9d49fa

# System information

ubuntu 20.04 (in a container)
Package: g++
Version: 4:9.3.0-1ubuntu2
Package: binutils (dpkg-query says this provides /usr/bin/ld) Version: 2.34-6ubuntu1.6