### PR TITLE
Fix green mushrooms scaling damage per second based on the "number of particles" setting

### DIFF
--- a/colobot-base/src/object/auto/automush.cpp
+++ b/colobot-base/src/object/auto/automush.cpp
@@ -144,9 +144,9 @@ bool CAutoMush::EventProcess(const Event &event)
             factor = 1.0f-m_progress;
             size = 1.0f+(1.0f-m_progress)*0.3f;
 
-            if ( m_lastParticle+m_engine->ParticleAdapt(0.05f) <= m_time )
+            if ( m_lastParticle <= m_time )
             {
-                m_lastParticle = m_time;
+                m_lastParticle += 0.05;
 
                 for ( i=0 ; i<10 ; i++ )
                 {


### PR DESCRIPTION
# The problem
* Fixes #1013

It appears that mushrooms are supposed to spawn 10 particles every 0.05 seconds when `m_phase == AMP_FIRE`. This are the same particles that the alien ants shoot. You take damage when hit by one of those particles.

The bug was that 0.05 was scaled based on the "number of particles" setting. This caused mushrooms to be more dangerous at 200% particles, less dangerous at 50% particles and harmless at 0% particles.

# Proposed solution
Disable scaling of the particle spawn interval for mushrooms. This should give mushrooms consistent damage per second.

# Notes
It appears this bug was present in the initial commit
https://github.com/colobot/colobot/blob/a4c804b49ec872b71bd5a0167c3ad45704a3cc30/src/automush.cpp#L144-L146