### PR TITLE
Make try interrupt goto()

### DIFF
--- a/CBot/src/CBot/CBotExternalCall.cpp
+++ b/CBot/src/CBot/CBotExternalCall.cpp
@@ -158,6 +158,7 @@ bool CBotExternalCallDefault::Run(CBotVar* thisVar, CBotStack* pStack)
 
     int exception = CBotNoErr; // TODO: Change to CBotError
     bool res = m_rExec(args, result, exception, pStack->GetUserPtr());
+    pStack->SetExternalCallSuspended(!res && exception == CBotNoErr);
 
     if (!res)
     {

--- a/CBot/src/CBot/CBotInstr/CBotTry.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotTry.cpp
@@ -101,8 +101,6 @@ bool CBotTry::Execute(CBotStack* &pj)
         }
 
         val = pile1->GetError();
-        if ( val == CBotNoErr && pile1->GetTimer() == 0 )           // mode step?
-            return false;                   // don't jump to the catch
 
         pile1->IncState();
         pile2->SetState(val);                                   // stores the error number

--- a/CBot/src/CBot/CBotInstr/CBotTry.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotTry.cpp
@@ -126,7 +126,7 @@ bool CBotTry::Execute(CBotStack* &pj)
         {
             // ask to the catch block if it feels concerned
             if ( !pc->TestCatch(pile2, val) ) return false;     // suspend !
-            if (pile2->GetVal() != 0)
+            if (pile2->GetVal() != 0 && pile1->IsChildSuspended())
             {
                 CBotProgram::CancelExternal(pj);
             }

--- a/CBot/src/CBot/CBotInstr/CBotTry.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotTry.cpp
@@ -126,6 +126,10 @@ bool CBotTry::Execute(CBotStack* &pj)
         {
             // ask to the catch block if it feels concerned
             if ( !pc->TestCatch(pile2, val) ) return false;     // suspend !
+            if (pile2->GetVal() != 0)
+            {
+                CBotProgram::CancelExternal(pj);
+            }
             pile1->IncState();
         }
         if ( --state <= 0 )

--- a/CBot/src/CBot/CBotProgram.cpp
+++ b/CBot/src/CBot/CBotProgram.cpp
@@ -35,6 +35,7 @@ namespace CBot
 {
 
 std::unique_ptr<CBotExternalCallList> CBotProgram::m_externalCalls;
+void (*CBotProgram::m_cancelExternal) (void* pUser) = 0;
 
 CBotProgram::CBotProgram()
 {
@@ -421,6 +422,17 @@ void CBotProgram::Free()
 const std::unique_ptr<CBotExternalCallList>& CBotProgram::GetExternalCalls()
 {
     return m_externalCalls;
+}
+
+void CBotProgram::SetCancelExternal(void cancel(void* pUser)) {
+    m_cancelExternal = cancel;
+}
+
+void CBotProgram::CancelExternal(CBotStack* s)
+{
+    if(m_cancelExternal) {
+        m_cancelExternal(s->GetUserPtr());
+    }
 }
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotProgram.h
+++ b/CBot/src/CBot/CBotProgram.h
@@ -331,9 +331,14 @@ public:
      */
     static const std::unique_ptr<CBotExternalCallList>& GetExternalCalls();
 
+    static void SetCancelExternal(void cancel(void* pUser));
+
+    static void CancelExternal(CBotStack*);
+
 private:
     //! All external calls
     static std::unique_ptr<CBotExternalCallList> m_externalCalls;
+    static void (*m_cancelExternal) (void* pUser);
     //! All user-defined functions
     std::list<CBotFunction*> m_functions{};
     //! The entry point function

--- a/CBot/src/CBot/CBotStack.cpp
+++ b/CBot/src/CBot/CBotStack.cpp
@@ -144,6 +144,7 @@ CBotStack* CBotStack::AddStack(CBotInstr* instr, BlockVisibilityType bBlock)
     p->m_call   = nullptr;
     p->m_func   = IsFunction::NO;
     p->m_callFinished = false;
+    p->m_externalCallSuspended = false;
     return p;
 }
 
@@ -183,6 +184,7 @@ CBotStack* CBotStack::AddStack2(BlockVisibilityType bBlock)
     p->m_block = bBlock;
     p->m_prog = m_prog;
     p->m_step = 0;
+    p->m_externalCallSuspended = false;
     return    p;
 }
 
@@ -1014,6 +1016,19 @@ bool CBotVar::RestoreState(std::istream &istr, CBotVar* &pVar)
 bool CBotStack::IsCallFinished()
 {
     return m_callFinished;
+}
+
+void CBotStack::SetExternalCallSuspended(bool val)
+{
+    m_externalCallSuspended = val;
+}
+
+bool CBotStack::IsChildSuspended()
+{
+    if ( m_externalCallSuspended ) return true;
+    if ( m_next && m_next->IsChildSuspended() ) return true;
+    if ( m_next2 && m_next2->IsChildSuspended() ) return true;
+    return false;
 }
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotStack.h
+++ b/CBot/src/CBot/CBotStack.h
@@ -463,6 +463,9 @@ public:
 
     bool            IsCallFinished();
 
+    void SetExternalCallSuspended(bool);
+    bool IsChildSuspended();
+
 private:
     CBotStack*        m_next;
     CBotStack*        m_next2;
@@ -491,6 +494,7 @@ private:
     CBotExternalCall* m_call;
 
     bool m_callFinished;
+    bool m_externalCallSuspended;
 };
 
 } // namespace CBot

--- a/colobot-base/src/script/scriptfunc.cpp
+++ b/colobot-base/src/script/scriptfunc.cpp
@@ -3438,6 +3438,10 @@ private:
 };
 
 
+void CScriptFunctions::Cancel (void* user) {
+	CScript*    script = static_cast<CScript*>(user);
+	script->m_taskExecutor->StopForegroundTask();
+}
 
 // Initializes all functions for module CBOT.
 
@@ -3464,6 +3468,7 @@ void CScriptFunctions::Init()
         CBotProgram::DefineNum(TraceColorName(color).c_str(), static_cast<int>(color));
     }
 
+    CBotProgram::SetCancelExternal(Cancel);
     CBotProgram::DefineNum("InFront",    TMA_FFRONT);
     CBotProgram::DefineNum("Behind",     TMA_FBACK);
     CBotProgram::DefineNum("EnergyCell", TMA_POWER);

--- a/colobot-base/src/script/scriptfunc.h
+++ b/colobot-base/src/script/scriptfunc.h
@@ -52,6 +52,8 @@ public:
     static bool CheckOpenFiles();
 
 private:
+    static void Cancel (void* user);
+
     static CBot::CBotTypResult cEndMission(CBot::CBotVar* &var, void* user);
     static CBot::CBotTypResult cPlayMusic(CBot::CBotVar* &var, void* user);
     static CBot::CBotTypResult cGetObject(CBot::CBotVar* &var, void* user);

--- a/test/src/CBot/CBot_test.cpp
+++ b/test/src/CBot/CBot_test.cpp
@@ -37,7 +37,7 @@ public:
         CBotProgram::AddFunction("FAIL", rFail, cFail);
         CBotProgram::AddFunction("ASSERT", rAssert, cAssert);
         CBotProgram::AddFunction("SUSPEND", rSuspend, cSuspend);
-        CBotProgram::AddFunction("ASSERT_NOT_SUSPENDED", rAssertNotSuspended, cSuspend);
+        CBotProgram::AddFunction("ASSERT_EXTERNAL_NOT_RUNNING", rAssertExternalNotRunning, cSuspend);
         CBotProgram::SetCancelExternal(Cancel);
     }
 
@@ -111,15 +111,15 @@ private:
 
     static bool rSuspend(CBotVar* var, CBotVar* result, int& exception, void* user)
     {
-        bool *suspended = static_cast<bool*>(user);
-        *suspended = true;
+        bool *is_external_running = static_cast<bool*>(user);
+        *is_external_running = true;
         return false;
     }
 
-    static bool rAssertNotSuspended(CBotVar* var, CBotVar* result, int& exception, void* user)
+    static bool rAssertExternalNotRunning(CBotVar* var, CBotVar* result, int& exception, void* user)
     {
-        bool *suspended = static_cast<bool*>(user);
-        if (*suspended)
+        bool *is_external_running = static_cast<bool*>(user);
+        if (*is_external_running)
         {
             throw CBotTestFail("CBot assertion failed");
         }
@@ -128,8 +128,8 @@ private:
 
     static void Cancel(void* user)
     {
-        bool *suspended = static_cast<bool*>(user);
-        *suspended = false;
+        bool *is_external_running = static_cast<bool*>(user);
+        *is_external_running = false;
     }
 
     // Modified version of PutList from src/script/script.cpp
@@ -3370,7 +3370,7 @@ TEST_F(CBotUT, CatchShouldCancelExternalCalls)
         "    try {\n"
         "        SUSPEND();\n"
         "    } catch(true) {\n"
-        "        ASSERT_NOT_SUSPENDED();\n"
+        "        ASSERT_EXTERNAL_NOT_RUNNING();\n"
         "    }\n"
         "}\n",
         CBotNoErr,


### PR DESCRIPTION
Fixes #474
It should now also interrupt: move(), turn(), wait(), ...

After this is merged I will add docs for both forms of try ... catch because they are now in a usable state