### PR TITLE
Make flatspace() only return points on dry land

### DIFF
--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -4227,6 +4227,7 @@ bool CRobotMain::FlatFreeSpace(glm::vec3 &center, float minFlat, float minRadius
 	    
             if (SearchNearestObject(m_objMan.get(), pos, exclu) < space) continue;
             if (m_terrain->GetFlatZoneRadius(pos, minFlat) < minFlat) continue;
+            if (m_terrain->GetFloorLevel(pos) < m_water->GetLevel()) continue;
             center = pos;
             return true;
         }

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -4225,11 +4225,8 @@ bool CRobotMain::FlatFreeSpace(glm::vec3 &center, float minFlat, float minRadius
             pos.y = 0.0f;
             m_terrain->AdjustToFloor(pos, true);
 	    
-            float dist = SearchNearestObject(m_objMan.get(), pos, exclu);
-	    if (dist < space) continue;
-            float flat = m_terrain->GetFlatZoneRadius(pos, minFlat);
-            if (flat < minFlat) continue;
-
+            if (SearchNearestObject(m_objMan.get(), pos, exclu) < space) continue;
+            if (m_terrain->GetFlatZoneRadius(pos, minFlat) < minFlat) continue;
             center = pos;
             return true;
         }

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -4227,15 +4227,11 @@ bool CRobotMain::FlatFreeSpace(glm::vec3 &center, float minFlat, float minRadius
             float dist = SearchNearestObject(m_objMan.get(), pos, exclu);
             if (dist >= space)
             {
-                float flat = m_terrain->GetFlatZoneRadius(pos, dist/2.0f);
-                if (flat >= dist/2.0f)
+                float flat = m_terrain->GetFlatZoneRadius(pos, minFlat);
+                if(flat >= minFlat)
                 {
-                    flat = m_terrain->GetFlatZoneRadius(pos, minFlat);
-                    if(flat >= minFlat)
-                    {
-                        center = pos;
-                        return true;
-                    }
+                    center = pos;
+                    return true;
                 }
             }
         }

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -4224,16 +4224,14 @@ bool CRobotMain::FlatFreeSpace(glm::vec3 &center, float minFlat, float minRadius
             pos.z = p.y;
             pos.y = 0.0f;
             m_terrain->AdjustToFloor(pos, true);
+	    
             float dist = SearchNearestObject(m_objMan.get(), pos, exclu);
-            if (dist >= space)
-            {
-                float flat = m_terrain->GetFlatZoneRadius(pos, minFlat);
-                if(flat >= minFlat)
-                {
-                    center = pos;
-                    return true;
-                }
-            }
+	    if (dist < space) continue;
+            float flat = m_terrain->GetFlatZoneRadius(pos, minFlat);
+            if (flat < minFlat) continue;
+
+            center = pos;
+            return true;
         }
     }
     return false;

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -4210,67 +4210,31 @@ bool CRobotMain::FreeSpace(glm::vec3 &center, float minRadius, float maxRadius,
 bool CRobotMain::FlatFreeSpace(glm::vec3 &center, float minFlat, float minRadius, float maxRadius,
                            float space, CObject *exclu)
 {
-    if (minRadius < maxRadius)  // from internal to external?
+    for (float radius = minRadius; radius <= maxRadius; radius += space)
     {
-        for (float radius = minRadius; radius <= maxRadius; radius += space)
+        float ia = space/radius;
+        for (float angle = 0.0f; angle < Math::PI*2.0f; angle += ia)
         {
-            float ia = space/radius;
-            for (float angle = 0.0f; angle < Math::PI*2.0f; angle += ia)
+            glm::vec2 p;
+            p.x = center.x+radius;
+            p.y = center.z;
+            p = Math::RotatePoint({ center.x, center.z }, angle, p);
+            glm::vec3 pos;
+            pos.x = p.x;
+            pos.z = p.y;
+            pos.y = 0.0f;
+            m_terrain->AdjustToFloor(pos, true);
+            float dist = SearchNearestObject(m_objMan.get(), pos, exclu);
+            if (dist >= space)
             {
-                glm::vec2 p;
-                p.x = center.x+radius;
-                p.y = center.z;
-                p = Math::RotatePoint({ center.x, center.z }, angle, p);
-                glm::vec3 pos;
-                pos.x = p.x;
-                pos.z = p.y;
-                pos.y = 0.0f;
-                m_terrain->AdjustToFloor(pos, true);
-                float dist = SearchNearestObject(m_objMan.get(), pos, exclu);
-                if (dist >= space)
+                float flat = m_terrain->GetFlatZoneRadius(pos, dist/2.0f);
+                if (flat >= dist/2.0f)
                 {
-                    float flat = m_terrain->GetFlatZoneRadius(pos, dist/2.0f);
-                    if (flat >= dist/2.0f)
+                    flat = m_terrain->GetFlatZoneRadius(pos, minFlat);
+                    if(flat >= minFlat)
                     {
-                        flat = m_terrain->GetFlatZoneRadius(pos, minFlat);
-                        if(flat >= minFlat)
-                        {
-                            center = pos;
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
-    }
-    else    // from external to internal?
-    {
-        for (float radius=maxRadius; radius >= minRadius; radius -= space)
-        {
-            float ia = space/radius;
-            for (float angle=0.0f ; angle<Math::PI*2.0f ; angle+=ia )
-            {
-                glm::vec2 p;
-                p.x = center.x+radius;
-                p.y = center.z;
-                p = Math::RotatePoint({ center.x, center.z }, angle, p);
-                glm::vec3 pos;
-                pos.x = p.x;
-                pos.z = p.y;
-                pos.y = 0.0f;
-                m_terrain->AdjustToFloor(pos, true);
-                float dist = SearchNearestObject(m_objMan.get(), pos, exclu);
-                if (dist >= space)
-                {
-                    float flat = m_terrain->GetFlatZoneRadius(pos, dist/2.0f);
-                    if (flat >= dist/2.0f)
-                    {
-                        flat = m_terrain->GetFlatZoneRadius(pos, minFlat);
-                        if(flat >= minFlat)
-                        {
-                            center = pos;
-                            return true;
-                        }
+                        center = pos;
+                        return true;
                     }
                 }
             }


### PR DESCRIPTION
Fixes #918.

1. flatspace() is documentad as a function that should be "Useful for finding a place for a building"
2. You can not build under water

Also fixes #1625 and does some refactoring while I'm at it.

What I left for future consideration (will not be included in this pull request): flatspace() should probably return `new point(nan, nan, nan)` if it does not find a suitable location instead of returning `center` as it does now. This would be consistent with what `space()` does in this situation.