### PR TITLE
Added try/catch/finally/throw unit tests.

### DIFF
--- a/test/src/CBot/CBot_test.cpp
+++ b/test/src/CBot/CBot_test.cpp
@@ -3327,3 +3327,175 @@ TEST_F(CBotUT, ClassTestSaveInheritedMembers)
         "}\n"
     );
 }
+
+TEST_F(CBotUT, TestTryCatch) {
+    ExecuteTest(
+        "extern void TestCatchNotExecutedNormally() {\n"
+        "    bool caught = false;\n"
+        "    bool tried = false;\n"
+        "    try {\n"
+        "        tried = true;\n"
+        "    } catch(CBotErrZeroDiv) {\n"
+        "        caught = true;\n"
+        "    }\n"
+        "    ASSERT(caught == false);\n"
+        "    ASSERT(tried == true);\n"
+        "}\n"
+    );
+    ExecuteTest(
+        "extern void TestCatchExecutedOnError() {\n"
+        "    bool caught = false;\n"
+        "    bool tried = false;\n"
+        "    try {\n"
+        "        tried = true;"
+        "        5/0;"
+        "        ASSERT(false);\n"
+        "    } catch(CBotErrZeroDiv) {\n"
+        "        caught = true;\n"
+        "    }\n"
+        "    ASSERT(caught == true);\n"
+        "    ASSERT(tried == true);\n"
+        "}\n"
+    );
+    ExecuteTest(
+        "extern void TestCatchOnlyOneErrorType() {\n"
+        "    try {\n"
+        "        5/0;"
+        "        ASSERT(false);\n"
+        "    } catch(CBotErrNull) {\n"
+        "        ASSERT(false);\n"
+        "    }\n"
+        "    ASSERT(false);\n"
+        "}\n",
+        CBotErrZeroDiv
+    );
+    ExecuteTest(
+        "void divzero() {5/0;}\n"
+        "extern void TestCatchFromOtherFunction() {\n"
+        "    bool caught = false;\n"
+        "    bool tried = false;\n"
+        "    try {\n"
+        "        tried = true;"
+        "        divzero();"
+        "        ASSERT(false);\n"
+        "    } catch(CBotErrZeroDiv) {\n"
+        "        caught = true;\n"
+        "    }\n"
+        "    ASSERT(caught == true);\n"
+        "    ASSERT(tried == true);\n"
+        "}\n"
+    );
+    ExecuteTest(
+        "void divzero() {5/0;}\n"
+        "extern void TestCatchOnlyOneErrorTypeFromOtherFunction() {\n"
+        "    try {\n"
+        "        divzero();"
+        "        ASSERT(false);\n"
+        "    } catch(CBotErrNull) {\n"
+        "        ASSERT(false);\n"
+        "    }\n"
+        "    ASSERT(false);\n"
+        "}\n",
+        CBotErrZeroDiv
+    );
+    ExecuteTest(
+        "void thrownull() {throw CBotErrNull;}\n"
+        "extern void TestThrowCaught() {\n"
+        "    bool caught = false;\n"
+        "    bool tried = false;\n"
+        "    try {\n"
+        "        tried = true;"
+        "        thrownull();"
+        "        ASSERT(false);\n"
+        "    } catch(CBotErrNull) {\n"
+        "        caught = true;\n"
+        "    }\n"
+        "    ASSERT(caught == true);\n"
+        "    ASSERT(tried == true);\n"
+        "}\n"
+    );
+    ExecuteTest(
+        "void thrownull() {throw CBotErrNull;}\n"
+        "extern void TestThrowUncaught() {\n"
+        "    try {\n"
+        "        thrownull();"
+        "        ASSERT(false);\n"
+        "    } catch(CBotErrZeroDiv) {\n"
+        "        ASSERT(false);\n"
+        "    }\n"
+        "    ASSERT(false);\n"
+        "}\n",
+        CBotErrNull
+    );
+
+    ExecuteTest(
+        "extern void TestThrowWrongType() {\n"
+        "    throw true;"
+        "}\n",
+        CBotErrBadType1
+    );
+}
+
+TEST_F(CBotUT, TestFinally) {
+    ExecuteTest(
+        "extern void TestFinallyExecutedNormally() {\n"
+        "    bool caught = false;\n"
+        "    bool tried = false;\n"
+        "    bool finally_ran = false;\n"
+        "    try {\n"
+        "        tried = true;\n"
+        "    } catch(CBotErrZeroDiv) {\n"
+        "        caught = true;\n"
+        "    } finally {\n"
+        "        finally_ran = true;\n"
+        "    }\n"
+        "    ASSERT(caught == false);\n"
+        "    ASSERT(tried == true);\n"
+        "    ASSERT(finally_ran == true);\n"
+        "}\n"
+    );
+    ExecuteTest(
+        "extern void TestFinallyExecutedOnError() {\n"
+        "    bool caught = false;\n"
+        "    bool tried = false;\n"
+        "    bool finally_ran = false;\n"
+        "    try {\n"
+        "        tried = true;"
+        "        5/0;"
+        "        ASSERT(false);\n"
+        "    } catch(CBotErrZeroDiv) {\n"
+        "        caught = true;\n"
+        "    } finally {\n"
+        "        finally_ran = true;\n"
+        "    }\n"
+        "    ASSERT(caught == true);\n"
+        "    ASSERT(tried == true);\n"
+        "    ASSERT(finally_ran == true);\n"
+        "}\n"
+    );
+    ExecuteTest(
+        "extern void TestFinallyOverrideError() {\n"
+        "    try {\n"
+        "        5/0;"
+        "        ASSERT(false);\n"
+        "    } catch(CBotErrZeroDiv) {\n"
+        "        throw CBotErrNull;\n"
+        "    }\n"
+        "    ASSERT(false);\n"
+        "}\n",
+        CBotErrNull
+    );
+
+    // code coverage
+    ExecuteTest(
+        "extern void TestCompileErrorInFinally() {\n"
+        "    try {\n"
+        "        5/0;"
+        "    } finally {\n"
+        "        1 - \"hello\";"
+        "    }\n"
+        "    ASSERT(false);\n"
+        "}\n",
+        CBotErrBadType2
+    );
+}


### PR DESCRIPTION
Edit: @melex750 asked my to cherry-pick [some tests for try...catch(int)](https://github.com/immibis/colobot/commit/b36075f7e131d9dd20261a86681e874ab4c7ef85). Because this does not depend on my patches I submitted this as a separate pull request.

Once this is merged I will [continue fixing things that need to be fixed before try...catch(bool) can be fixed](https://github.com/hexagonrecursion/colobot/compare/rebase-test...hexagonrecursion:colobot:remove-try-hack)