### PR TITLE
Add glm and wget as build dependncies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,7 +57,9 @@ You will need:
  * libogg
  * OpenAL (OpenAL-Soft)
  * PhysFS
- * oggenc (to generate music files)
+ * glm
+ * wget (to download music files)
+ * oggenc (to transcode music files)
 
 On Ubuntu (and probably any other Debian-based system), you can use the following command to install all required packages:
 ```


### PR DESCRIPTION
On Arch I installed `glm`. I wasn't able to update the Ubuntu instructions, which might require `libglm-dev` or similar.

I'll be making a PR against the data repo to use curl as an alternative to wget, but for now it's required.