### PR TITLE
Fix LC_MESSAGES parsing (regression in dev)

### DIFF
--- a/colobot-base/src/app/app.cpp
+++ b/colobot-base/src/app/app.cpp
@@ -1851,7 +1851,8 @@ void CApplication::SetLanguage(Language language)
         const char* currentEnvLang = gl_locale_name(LC_MESSAGES, "LC_MESSAGES");
         if (currentEnvLang != nullptr)
         {
-            envLang = std::string(currentEnvLang);
+            // Take only the two first chars; to support "fr_CH" or "en_US;en"
+            envLang = std::string(currentEnvLang).substr(0,2);
         }
     }
 


### PR DESCRIPTION
We need only to compare the two first characters for Colobot's locale comparison purposes.

This fixes locale variations (such as 'fr_CH;fr', or 'en_US').

Addresses a regression introduced in 611d5e2f26d095954b47ea0758c12f30e8ad1823