### PR TITLE
Ubuntu 22.04 build: use the provided deps, not the submodules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,16 @@ jobs:
     - name: Install Colobot dependencies
       run: sudo apt-get update && sudo apt-get install -y --no-install-recommends build-essential cmake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsndfile1-dev libvorbis-dev libogg-dev libpng-dev libglew-dev libopenal-dev libphysfs-dev gettext git po4a vorbis-tools librsvg2-bin xmlstarlet libglm-dev libmpg123-dev
       if: matrix.container == ''
+    - name: Install recent libgtest-dev and nlohmann-json3-dev
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libgtest-dev nlohmann-json3-dev
+      if: matrix.container == '' && matrix.host_os == 'ubuntu-22.04'
     - uses: actions/checkout@v3
     - name: Checkout the Google Test submodule
       run: git submodule update --init -- lib/googletest
+      if: matrix.host_os != 'ubuntu-22.04'
     - name: Checkout the nlohmann json submodule
       run: git submodule update --init -- lib/json
+      if: matrix.host_os != 'ubuntu-22.04'
     - name: Create build directory
       run: cmake -E make_directory build
     - name: Run CMake (for Linux)


### PR DESCRIPTION
This matches what is done in the Debian packaging (and avoid depending on the submodules)