### PR TITLE
Allow unit-testing try-catch(condition)

### DIFF
--- a/CBot/src/CBot/CBotInstr/CBotCatch.h
+++ b/CBot/src/CBot/CBotInstr/CBotCatch.h
@@ -83,6 +83,7 @@ private:
     CBotInstr* m_cond;
     //! Following catch
     CBotCatch* m_next;
+    bool m_is_conditional;
 
     friend class CBotTry;
 };

--- a/CBot/src/CBot/CBotInstr/CBotTry.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotTry.cpp
@@ -101,8 +101,6 @@ bool CBotTry::Execute(CBotStack* &pj)
         }
 
         val = pile1->GetError();
-        if ( val == CBotNoErr && pile1->GetTimer() == 0 )           // mode step?
-            return false;                   // don't jump to the catch
 
         pile1->IncState();
         pile2->SetState(val);                                   // stores the error number

--- a/test/src/CBot/CBot_test.cpp
+++ b/test/src/CBot/CBot_test.cpp
@@ -3455,6 +3455,28 @@ TEST_F(CBotUT, TestTryCatch) {
         "}\n",
         CBotErrZeroDiv
     );
+
+    ExecuteTest(
+        "extern void ErrorCodeIsNotEvaluatedUnlessThereIsAnException() {\n"
+        "    try {\n"
+        "        for(int i = 0; i < 20; ++i); // Should give try an opportunity to check the condition\n"
+        "    } catch(1/0) { // This should not throw because it's never evaluated\n"
+        "    }\n"
+        "}\n"
+    );
+
+    ExecuteTest(
+        "extern void CatchZeroIsNotCatchTrue() {\n"
+        "    int result = 0;\n"
+        "    try {\n"
+        "        for(int i = 0; i < 20; ++i); // Should give try an opportunity to check the condition\n"
+        "        result = 1;\n"
+        "    } catch(0) { // Should not stop the body even though `0 == <the current error code>`\n"
+        "        result = 2;\n"
+        "    }\n"
+        "    ASSERT(result == 1);\n"
+        "}\n"
+    );
 }
 
 TEST_F(CBotUT, TestFinally) {

--- a/test/src/CBot/CBot_test.cpp
+++ b/test/src/CBot/CBot_test.cpp
@@ -3434,6 +3434,27 @@ TEST_F(CBotUT, TestTryCatch) {
         "}\n",
         CBotErrBadType1
     );
+
+    ExecuteTest(
+        "extern void TestTryCatchCondition() {\n"
+        "    int foo = 0;\n"
+        "    try {\n"
+        "        foo = 1;\n"
+        "        for(int i = 0; i < 20; ++i);  // Should give try an opportunity to check condition\n"
+        "        foo = 2;  // Should not get here\n"
+        "    } catch(foo == 1);\n"
+        "    ASSERT(foo == 1);\n"
+        "}\n"
+    );
+
+    ExecuteTest(
+        "extern void TestExcetionInCatchCondition() {\n"
+        "    try {\n"
+        "        for(int i = 0; i < 20; ++i); // Should give try an opportunity to check condition\n"
+        "    } catch(1/0 == 0);\n"
+        "}\n",
+        CBotErrZeroDiv
+    );
 }
 
 TEST_F(CBotUT, TestFinally) {


### PR DESCRIPTION
* This pull request lays the groundwork required before I tackle #474

1. We want to be able to unit-test try-catch(condition)
2. We don't want the player to have to manually single step through catch expressions when debugging code guarded by try-catch

Our CBot unit tests run in single-step mode. Our implementation of try-catch has a hack that prevents evaluation of catch conditions in single-step mode. We can't test code that we can't run.

https://github.com/colobot/colobot/blob/e00f99f9c625f79664d795a4b245f24c25987091/CBot/src/CBot/CBotInstr/CBotTry.cpp#L104-L105

I have removed the hack to enable unit-testing, but that caused a different problem - debugging code inside the body of try-catch became inconvenient because the player had to manually step through every catch expression after every single instruction in try body.

~A solution I have found is to have the debugger automatically step over the catch expressions.~

~**Edit**: I solved this by teaching CBotTry to step-over the catch conditions.~ [The previous implementation can be found here](https://github.com/hexagonrecursion/colobot/compare/e00f99f9c625f79664d795a4b245f24c25987091...try-step-v0).

**Edit:** I have realized that the players may want to be able to debug the condition of catch(bool) too. New solution: skip the evaluation of the expression in `catch(int)` unless there was an error. This also implements [CBOT enhancement proposal: untangle catch(int) and catch(bool)](https://github.com/colobot/colobot/discussions/1629). [The previous implementation can be found here](https://github.com/hexagonrecursion/colobot/compare/e00f99f9c625f79664d795a4b245f24c25987091...try-step-v1).

Here is how things work now:
```c++
try {
    //...
} catch(CBotErrZeroDiv) { // The expression `CBotErrZeroDiv` is not evaluated unless there was an exception.
} catch(CBotErrNull) { // Same
} catch(CBotErrOutArray) { // Same
} catch(x == 42) { // The expression `x == 42` is always evaluated, single stepping steps into it
}
```

The debugging of code guarded by catch(int) is not impacted. The debugging of code guarded by catch(int) does become less convenient, but I don't know what else I can do to improve this.

# Testing
## Before
```bash
git switch --detach 52804c5b4a76cb168c576543d19c7ea6a7e165b7
git restore --worktree --source HEAD^ CBot
(cd build/ && make && ./Colobot-UnitTests --gtest_filter=CBotUT.TestTryCatch)
...
Note: Google Test filter = CBotUT.TestTryCatch
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from CBotUT
[ DISABLED ] CBotUT.DISABLED_PublicClasses
[ DISABLED ] CBotUT.DISABLED_StringAsArray
[ RUN      ] CBotUT.TestTryCatch
/home/cdda/git/colobot-try-step/test/src/CBot/CBot_test.cpp:316: Failure
Failed
*** Failed test TestTryCatchCondition: CBot assertion failed
    while executing function TestTryCatchCondition (241-247)
Line 8:     ASSERT(foo == 1);

Variables:
  Block 1:
    foo = 2

/home/cdda/git/colobot-try-step/test/src/CBot/CBot_test.cpp:316: Failure
Failed
*** Failed test TestExcetionInCatchCondition: No runtime error, expected 6000


[  FAILED  ] CBotUT.TestTryCatch (13 ms)
[----------] 1 test from CBotUT (14 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (15 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] CBotUT.TestTryCatch

 1 FAILED TEST
```
## After
```bash
git restore .
(cd build/ && make && ./Colobot-UnitTests)
...
[==========] Running 201 tests from 20 test suites.
...
[==========] 201 tests from 20 test suites ran. (389 ms total)
[  PASSED  ] 201 tests.
```
## Before
```bash
git switch --detach 86351b8b7e24e8ee4c0513ed6c68e4c5a9b68a21
git restore --worktree --source HEAD^ CBot
(cd build/ && make && ./Colobot-UnitTests --gtest_filter=CBotUT.TestTryCatch)
...
Note: Google Test filter = CBotUT.TestTryCatch
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from CBotUT
[ DISABLED ] CBotUT.DISABLED_PublicClasses
[ DISABLED ] CBotUT.DISABLED_StringAsArray
[ RUN      ] CBotUT.TestTryCatch
/home/cdda/git/colobot-try-step/test/src/CBot/CBot_test.cpp:316: Failure
Failed
*** Failed test ErrorCodeIsNotEvaluatedUnlessThereIsAnException: RUNTIME ERROR - 6000
    at unknown location 181-182
Line 4:     } catch(1/0) { // This should not throw because it's never evaluated

Variables:

/home/cdda/git/colobot-try-step/test/src/CBot/CBot_test.cpp:316: Failure
Failed
*** Failed test CatchZeroIsNotCatchTrue: CBot assertion failed
    while executing function CatchZeroIsNotCatchTrue (303-309)
Line 9:     ASSERT(result == 1);

Variables:
  Block 1:
    result = 2

[  FAILED  ] CBotUT.TestTryCatch (21 ms)
[----------] 1 test from CBotUT (21 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (22 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] CBotUT.TestTryCatch

 1 FAILED TEST
```
## After
```bash
git restore .
(cd build/ && make && ./Colobot-UnitTests)
...
[==========] Running 201 tests from 20 test suites.
...
[==========] 201 tests from 20 test suites ran. (366 ms total)
[  PASSED  ] 201 tests.
```
## Valgrind
* [valgrind ./Colobot-UnitTests --- 0 errors](https://github.com/colobot/colobot/files/15331689/tmp-valgrind.txt)
* [valgrind ./Colobot-UnitTests --CBotUT_TestSaveState --- 0 errors](https://github.com/colobot/colobot/files/15331745/tmp-valgrind-save.txt)
