### PR TITLE
Silence unused variable warning

### DIFF
--- a/colobot-base/src/common/logger.h
+++ b/colobot-base/src/common/logger.h
@@ -184,6 +184,7 @@ private:
             format.remove_prefix(index + 2);
         };
 
+        (void)print;
         (print(args), ...);
 
         if (!format.empty())


### PR DESCRIPTION
My compiler was producing dozens of warnings like this:
```c++
In file included from /home/cdda/git/colobot-ai-crash/colobot-base/src/ui/studio.cpp:27:
/home/cdda/git/colobot-ai-crash/colobot-base/src/common/logger.h: In instantiation of ‘std::string CLogger::FormatMessage(std::string_view, Args&& ...) [with Args = {}; std::string = std::__cxx11::basic_string<char>; std::string_view = st
d::basic_string_view<char>]’:
/home/cdda/git/colobot-ai-crash/colobot-base/src/common/logger.h:133:43:   required from ‘void CLogger::Log(LogLevel, std::string_view, Args&& ...) [with Args = {}; std::string_view = std::basic_string_view<char>]’
/home/cdda/git/colobot-ai-crash/colobot-base/src/common/logger.h:112:12:   required from ‘void CLogger::Warn(std::string_view, Args&& ...) [with Args = {}; std::string_view = std::basic_string_view<char>]’
/home/cdda/git/colobot-ai-crash/colobot-base/src/object/crash_sphere.h:44:30:   required from here
/home/cdda/git/colobot-ai-crash/colobot-base/src/common/logger.h:167:14: warning: variable ‘print’ set but not used [-Wunused-but-set-variable]
  167 |         auto print = [&](auto&& arg)
      |              ^~~~~
```

It thinks print is unused if args is empty.