### PR TITLE
Save level-supplied programs when saving the game

### DIFF
--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -4782,7 +4782,7 @@ bool CRobotMain::IOWriteScene(const std::filesystem::path& filename,
     if (!ostr.is_open()) return false;
 
     bool bError = false;
-    long version = 1;
+    long version = 2;
     CBot::WriteLong(ostr, version);                 // version of COLOBOT
     version = CBot::CBotProgram::GetVersion();
     CBot::WriteLong(ostr, version);                 // version of CBOT
@@ -5018,7 +5018,7 @@ CObject* CRobotMain::IOReadScene(const std::filesystem::path& filename,
         bool bError = false;
         long version = 0;
         CBot::ReadLong(istr, version);             // version of COLOBOT
-        if (version == 1)
+        if (version == 2)
         {
             CBot::ReadLong(istr, version);         // version of CBOT
             if (version == CBot::CBotProgram::GetVersion())

--- a/colobot-base/src/object/auto/autoegg.cpp
+++ b/colobot-base/src/object/auto/autoegg.cpp
@@ -198,7 +198,6 @@ bool CAutoEgg::EventProcess(const Event &event)
             Program* program = programStorage->AddProgram();
             programStorage->ReadProgram(program, StrUtils::ToString(InjectLevelPathsForCurrentLevel(m_alienProgramName, "ai")));
             program->readOnly = true;
-            program->filename = m_alienProgramName;
             programmable->RunProgram(program);
         }
         Init();

--- a/colobot-base/src/object/auto/autofactory.cpp
+++ b/colobot-base/src/object/auto/autofactory.cpp
@@ -680,7 +680,6 @@ bool CAutoFactory::CreateVehicle()
             Program* prog = programStorage->AddProgram();
             programStorage->ReadProgram(prog, StrUtils::ToString(InjectLevelPathsForCurrentLevel(name, "ai")));
             prog->readOnly = true;
-            prog->filename = name;
         }
     }
 

--- a/colobot-base/src/object/interface/program_storage_object.h
+++ b/colobot-base/src/object/interface/program_storage_object.h
@@ -33,7 +33,6 @@ struct Program
     std::unique_ptr<CScript> script;
     bool        readOnly = false;
     bool        runnable = true;
-    std::string filename;
 };
 
 /**

--- a/colobot-base/src/script/scriptfunc.cpp
+++ b/colobot-base/src/script/scriptfunc.cpp
@@ -1713,7 +1713,6 @@ bool CScriptFunctions::rProduce(CBotVar* var, CBotVar* result, int& exception, v
             Program* program = programStorage->AddProgram();
             programStorage->ReadProgram(program, name2.c_str());
             program->readOnly = true;
-            program->filename = name;
             dynamic_cast<CProgrammableObject&>(*object).RunProgram(program);
         }
     }


### PR DESCRIPTION
CBot scripts that are loaded from the game level or from a mod (such as the scripts implementing enemy AI) may change from one version of the game or mod to the next.

Instead of preserving those scripts as part of the save file we were only storing file names and loading new modified versions of those scripts when when loading a save.

When saving the game we save the current execution state of all running programs. Attempting to continue running the program from where we left off after the source code changed may cause the script to behave strangely or even cause **the whole game** to crash.

I fixed this by saving all scripts when saving the game. This way the saved execution state always matches the source code.

* Fixes https://github.com/colobot/colobot/issues/1623
* Undoes "Never save copy of programs from level files when saving scene" 4182be321695306385543c0584cb780959ceb25e

Legacy save files do not contain some of the source code that was available when the game was saved. The version of the mod/game may have changed since - we don't know. Those files may (in general) contain classes and public functions. To make sure that loading a legacy save file does not crash the game we discard the current execution state of all scripts and start them over from the beginning.

Unlike player-written programs, level-supplied programs are not saved to be loaded when the level is restarted. This should prevent re-introduction of https://github.com/colobot/colobot/issues/534