### PR TITLE
Remove no-op

### DIFF
--- a/CBot/src/CBot/CBotStack.cpp
+++ b/CBot/src/CBot/CBotStack.cpp
@@ -596,9 +596,6 @@ bool CBotStack::ExecuteCall(long& nIdent, CBotToken* token, CBotVar** ppVar, con
 
     // first looks by the identifier
 
-    res = m_prog->GetExternalCalls()->DoCall(nullptr, nullptr, ppVar, this, rettype);
-    if (res >= 0) return res;
-
     res = CBotFunction::DoCall(m_prog, m_prog->GetFunctions(), nIdent, "", ppVar, this, token);
     if (res >= 0) return res;
 


### PR DESCRIPTION
This two lines of code used to have a purpose, but refactroing (8e01a208c1f12ce4297d89985d5d605cb653e729) turned them into a no-op

https://github.com/colobot/colobot/blob/c56d240a0f8a65d5645c2454be95f93dde067658/CBot/src/CBot/CBotStack.cpp#L599-L600

is no-op because `DoCall(nullptr, ...)` returns -1

https://github.com/colobot/colobot/blob/c56d240a0f8a65d5645c2454be95f93dde067658/CBot/src/CBot/CBotExternalCall.cpp#L74-L78