### PR TITLE
Fix compiler warnings in restext.cpp

### DIFF
--- a/colobot-base/src/common/restext.cpp
+++ b/colobot-base/src/common/restext.cpp
@@ -41,6 +41,12 @@ const char* stringsObject[OBJECT_MAX]   = { nullptr };
 const char* stringsErr[ERR_MAX]         = { nullptr };
 const char* stringsCbot[CBot::CBotErrMAX]         = { nullptr };
 
+static int InputSlot2EventType(InputSlot s)
+{
+    static_assert(EVENT_INTERFACE_KEY + static_cast<int>(INPUT_SLOT_MAX) < EVENT_INTERFACE_KEY_END);
+    return EVENT_INTERFACE_KEY + static_cast<int>(s);
+}
+
 /* Macro to mark which texts are translatable by gettext
  * It doesn't do anything at compile-time, as all texts represented here are used later
  * in explicit call to gettext(), but it is used by xgettext executable to filter extracted
@@ -252,36 +258,35 @@ void InitializeRestext()
     stringsEvent[EVENT_INTERFACE_VSYNC]     = TR("Vertical Synchronization\\Limits the number of frames per second to display frequency");
 
     stringsEvent[EVENT_INTERFACE_KDEF]      = TR("Standard controls\\Standard key functions");
-    assert(INPUT_SLOT_MAX < EVENT_INTERFACE_KEY_END-EVENT_INTERFACE_KEY);
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_LEFT]        = TR("Turn left\\turns the bot to the left");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_RIGHT]       = TR("Turn right\\turns the bot to the right");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_UP]          = TR("Forward\\Moves forward");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_DOWN]        = TR("Backward\\Moves backward");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_GUP]         = TR("Climb\\Increases the power of the jet");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_GDOWN]       = TR("Descend\\Reduces the power of the jet");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CAMERA]      = TR("Change camera\\Switches between onboard camera and following camera");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_DESEL]       = TR("Previous object\\Selects the previous object");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_ACTION]      = TR("Standard action\\Standard action of the bot (take/grab, shoot, sniff, etc)");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CAM_LEFT]    = TR("Camera left\\Turns the camera left");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CAM_RIGHT]   = TR("Camera right\\Turns the camera right");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CAM_UP]      = TR("Camera up\\Turns the camera up");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CAM_DOWN]    = TR("Camera down\\Turns the camera down");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CAM_NEAR]    = TR("Camera closer\\Moves the camera forward");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CAM_AWAY]    = TR("Camera back\\Moves the camera backward");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CAM_ALT]     = TR("Alternative camera mode\\Move sideways instead of rotating (in free camera)");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_NEXT]        = TR("Next object\\Selects the next object");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_HUMAN]       = TR("Select the astronaut\\Selects the astronaut");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_QUIT]        = TR("Quit\\Quit the current mission or exercise");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_HELP]        = TR("Instructions\\Shows the instructions for the current mission");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_PROG]        = TR("Programming help\\Gives more detailed help with programming");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_VISIT]       = TR("Origin of last message\\Shows where the last message was sent from");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_SPEED_DEC]   = TR("Lower speed\\Decrease speed by half");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_SPEED_RESET] = TR("Standard speed\\Reset speed to normal");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_SPEED_INC]   = TR("Higher speed\\Doubles speed");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_QUICKSAVE]   = TR("Quick save\\Immediately save game");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_QUICKLOAD]   = TR("Quick load\\Immediately load game");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_PAUSE]       = TR("Pause\\Pause the game without opening menu");
-    stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CMDLINE]     = TR("Cheat console\\Show cheat console");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_LEFT)]        = TR("Turn left\\turns the bot to the left");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_RIGHT)]       = TR("Turn right\\turns the bot to the right");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_UP)]          = TR("Forward\\Moves forward");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_DOWN)]        = TR("Backward\\Moves backward");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_GUP)]         = TR("Climb\\Increases the power of the jet");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_GDOWN)]       = TR("Descend\\Reduces the power of the jet");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_CAMERA)]      = TR("Change camera\\Switches between onboard camera and following camera");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_DESEL)]       = TR("Previous object\\Selects the previous object");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_ACTION)]      = TR("Standard action\\Standard action of the bot (take/grab, shoot, sniff, etc)");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_CAM_LEFT)]    = TR("Camera left\\Turns the camera left");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_CAM_RIGHT)]   = TR("Camera right\\Turns the camera right");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_CAM_UP)]      = TR("Camera up\\Turns the camera up");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_CAM_DOWN)]    = TR("Camera down\\Turns the camera down");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_CAM_NEAR)]    = TR("Camera closer\\Moves the camera forward");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_CAM_AWAY)]    = TR("Camera back\\Moves the camera backward");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_CAM_ALT)]     = TR("Alternative camera mode\\Move sideways instead of rotating (in free camera)");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_NEXT)]        = TR("Next object\\Selects the next object");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_HUMAN)]       = TR("Select the astronaut\\Selects the astronaut");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_QUIT)]        = TR("Quit\\Quit the current mission or exercise");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_HELP)]        = TR("Instructions\\Shows the instructions for the current mission");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_PROG)]        = TR("Programming help\\Gives more detailed help with programming");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_VISIT)]       = TR("Origin of last message\\Shows where the last message was sent from");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_SPEED_DEC)]   = TR("Lower speed\\Decrease speed by half");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_SPEED_RESET)] = TR("Standard speed\\Reset speed to normal");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_SPEED_INC)]   = TR("Higher speed\\Doubles speed");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_QUICKSAVE)]   = TR("Quick save\\Immediately save game");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_QUICKLOAD)]   = TR("Quick load\\Immediately load game");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_PAUSE)]       = TR("Pause\\Pause the game without opening menu");
+    stringsEvent[InputSlot2EventType(INPUT_SLOT_CMDLINE)]     = TR("Cheat console\\Show cheat console");
 
     stringsEvent[EVENT_INTERFACE_VOLSOUND]  = TR("Sound effects:\\Volume of engines, voice, shooting, etc.");
     stringsEvent[EVENT_INTERFACE_VOLMUSIC]  = TR("Background sound:\\Volume of audio tracks");


### PR DESCRIPTION
```c++
colobot-base/src/common/restext.cpp: In function ‘void InitializeRestext()’:
colobot-base/src/common/restext.cpp:256:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  256 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_LEFT]        = TR("Turn left\\turns the bot to the left");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:257:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  257 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_RIGHT]       = TR("Turn right\\turns the bot to the right");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:258:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  258 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_UP]          = TR("Forward\\Moves forward");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:259:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  259 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_DOWN]        = TR("Backward\\Moves backward");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:260:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  260 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_GUP]         = TR("Climb\\Increases the power of the jet");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:261:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  261 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_GDOWN]       = TR("Descend\\Reduces the power of the jet");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:262:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  262 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CAMERA]      = TR("Change camera\\Switches between onboard camera and following camera");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:263:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  263 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_DESEL]       = TR("Previous object\\Selects the previous object");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:264:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  264 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_ACTION]      = TR("Standard action\\Standard action of the bot (take/grab, shoot, sniff, etc)");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:265:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  265 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CAM_LEFT]    = TR("Camera left\\Turns the camera left");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:266:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  266 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CAM_RIGHT]   = TR("Camera right\\Turns the camera right");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:267:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  267 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CAM_UP]      = TR("Camera up\\Turns the camera up");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:268:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  268 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CAM_DOWN]    = TR("Camera down\\Turns the camera down");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:269:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  269 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CAM_NEAR]    = TR("Camera closer\\Moves the camera forward");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:270:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  270 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CAM_AWAY]    = TR("Camera back\\Moves the camera backward");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:271:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  271 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CAM_ALT]     = TR("Alternative camera mode\\Move sideways instead of rotating (in free camera)");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:272:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  272 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_NEXT]        = TR("Next object\\Selects the next object");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:273:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  273 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_HUMAN]       = TR("Select the astronaut\\Selects the astronaut");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:274:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  274 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_QUIT]        = TR("Quit\\Quit the current mission or exercise");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:275:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  275 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_HELP]        = TR("Instructions\\Shows the instructions for the current mission");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:276:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  276 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_PROG]        = TR("Programming help\\Gives more detailed help with programming");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:277:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  277 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_VISIT]       = TR("Origin of last message\\Shows where the last message was sent from");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:278:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  278 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_SPEED_DEC]   = TR("Lower speed\\Decrease speed by half");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:279:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  279 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_SPEED_RESET] = TR("Standard speed\\Reset speed to normal");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:280:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  280 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_SPEED_INC]   = TR("Higher speed\\Doubles speed");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:281:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  281 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_QUICKSAVE]   = TR("Quick save\\Immediately save game");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:282:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  282 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_QUICKLOAD]   = TR("Quick load\\Immediately load game");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:283:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  283 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_PAUSE]       = TR("Pause\\Pause the game without opening menu");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
colobot-base/src/common/restext.cpp:284:37: error: arithmetic between different enumeration types ‘EventType’ and ‘InputSlot’ is deprecated [-Werror=deprecated-enum-enum-conversion]
  284 |     stringsEvent[EVENT_INTERFACE_KEY+INPUT_SLOT_CMDLINE]     = TR("Cheat console\\Show cheat console");
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
```