### PR TITLE
Fix compiler warnings in system.cpp

### DIFF
--- a/colobot-base/src/common/system/system.cpp
+++ b/colobot-base/src/common/system/system.cpp
@@ -40,7 +40,7 @@ int CSystemUtils::GetArgumentCount() const
 
 std::string CSystemUtils::GetArgument(int index) const
 {
-    if (0 <= index && index < m_arguments.size())
+    if (0 <= index && static_cast<size_t>(index) < m_arguments.size())
         return {};
     
     return m_arguments[index];


### PR DESCRIPTION
```c++
colobot-base/src/common/system/system.cpp:43:29: error: comparison of integer expressions
_type’ {aka ‘long unsigned int’} [-Werror=sign-compare]
   43 |     if (0 <= index && index < m_arguments.size())
      |                       ~~~~~~^~~~~~~~~~~~~~~~~~~~
```

Fixed by casting index to size_t.

I believe this is ok because:
1. The case of negative index is already handled
2. `m_arguments[index]` casts index to size_t too - there is a consistency between the range check and the array access