### PR TITLE
Allow camerafocus() to force first/third person view

### DIFF
--- a/colobot-base/src/script/scriptfunc.cpp
+++ b/colobot-base/src/script/scriptfunc.cpp
@@ -72,11 +72,11 @@
 
 using namespace CBot;
 
-enum CameraView
+enum class CameraView
 {
-    DefaultView,
-    FirstPersonView,
-    ThirdPersonView,
+    DEFAULT,
+    ONBOARD,
+    BACK,
 };
 
 CBotTypResult CScriptFunctions::cClassNull(CBotVar* thisclass, CBotVar* &var)
@@ -3239,7 +3239,7 @@ bool CScriptFunctions::rCameraFocus(CBotVar* var, CBotVar* result, int& exceptio
     CScript*    script = static_cast<CScript*>(user);
 
     CObject* object;
-    CameraView view = DefaultView;
+    CameraView view = CameraView::DEFAULT;
     if (var == nullptr)
     {
         object = script->m_object;
@@ -3258,12 +3258,12 @@ bool CScriptFunctions::rCameraFocus(CBotVar* var, CBotVar* result, int& exceptio
     {
         switch (view)
         {
-            case DefaultView:
+            case CameraView::DEFAULT:
                 break;
-            case FirstPersonView:
+            case CameraView::ONBOARD:
                 dynamic_cast<CControllableObject&>(*object).SetCameraType(Gfx::CAM_TYPE_ONBOARD);
                 break;
-            case ThirdPersonView:
+            case CameraView::BACK:
                 dynamic_cast<CControllableObject&>(*object).SetCameraType(Gfx::CAM_TYPE_BACK);
                 break;
         }
@@ -3570,9 +3570,9 @@ void CScriptFunctions::Init()
     CBotProgram::DefineNum("ResearchBuilder",       RESEARCH_BUILDER);
     CBotProgram::DefineNum("ResearchTarget",        RESEARCH_TARGET);
 
-    CBotProgram::DefineNum("DefaultView",           DefaultView);
-    CBotProgram::DefineNum("FirstPersonView",       FirstPersonView);
-    CBotProgram::DefineNum("ThirdPersonView",       ThirdPersonView);
+    CBotProgram::DefineNum("CameraDefault",         static_cast<int>(CameraView::DEFAULT));
+    CBotProgram::DefineNum("CameraOnboard",         static_cast<int>(CameraView::ONBOARD));
+    CBotProgram::DefineNum("CameraBack",            static_cast<int>(CameraView::BACK));
 
     CBotProgram::DefineNum("PolskiPortalColobota", 1337);
 

--- a/colobot-base/src/script/scriptfunc.h
+++ b/colobot-base/src/script/scriptfunc.h
@@ -80,6 +80,7 @@ private:
     static CBot::CBotTypResult cTopo(CBot::CBotVar* &var, void* user);
     static CBot::CBotTypResult cMessage(CBot::CBotVar* &var, void* user);
     static CBot::CBotTypResult cPenDown(CBot::CBotVar* &var, void* user);
+    static CBot::CBotTypResult cCameraFocus(CBot::CBotVar* &var, void* user);
     static CBot::CBotTypResult cIsBusy(CBot::CBotVar* &var, void* user);
     static CBot::CBotTypResult cFactory(CBot::CBotVar* &var, void* user);
     static CBot::CBotTypResult cResearch(CBot::CBotVar* &var, void* user);


### PR DESCRIPTION
We have an instruction called `camerafocus(object o)`. Unfortunately this instruction does not let us choose between first person view and third person view. This pull request adds an optional argument `camerafocus(object o, [int view])` and three constants:
* `camerafocus(obj, DefaultView)` is equivalent to `camerafocus(obj)`
* `camerafocus(obj, FirstPersonView)` selects the object and switches to the first person view
* `camerafocus(obj, ThirdPersonView)` selects the object and switches to the third person view