### PR TITLE
Fix unused variables

### DIFF
--- a/colobot-base/src/graphics/engine/engine.cpp
+++ b/colobot-base/src/graphics/engine/engine.cpp
@@ -855,10 +855,10 @@ void CEngine::DebugObject(int objRank)
 
     for (int l2 = 0; l2 < static_cast<int>( p1.next.size() ); l2++)
     {
+        /*
         EngineBaseObjDataTier& p2 = p1.next[l2];
         l->Debug("  l2:");
 
-        /*
         l->Debug("   tex1: %s (id: %u)\n", p2.tex1Name.c_str(), p2.tex1.id);
         l->Debug("   tex2: %s (id: %u)\n", p2.tex2Name.c_str(), p2.tex2.id);
 
@@ -2029,24 +2029,6 @@ bool CEngine::LoadAllTextures()
     return ok;
 }
 
-static bool IsExcludeColor(glm::vec2* exclude, int x, int y)
-{
-    int i = 0;
-    while ( exclude[i+0].x != 0.0f || exclude[i+0].y != 0.0f ||
-            exclude[i+1].y != 0.0f || exclude[i+1].y != 0.0f )
-    {
-        if ( x >= static_cast<int>(exclude[i+0].x*256.0f) &&
-             x <  static_cast<int>(exclude[i+1].x*256.0f) &&
-             y >= static_cast<int>(exclude[i+0].y*256.0f) &&
-             y <  static_cast<int>(exclude[i+1].y*256.0f) )
-            return true;  // exclude
-
-        i += 2;
-    }
-
-    return false;  // point to include
-}
-
 void CEngine::DeleteTexture(const std::string& texName)
 {
     auto it = m_texNameMap.find(texName);
@@ -3115,7 +3097,6 @@ void CEngine::Draw3DScene()
 
     if (m_debugGoto)
     {
-        glm::mat4 worldMatrix = glm::mat4(1.0f);
         objectRenderer->SetTransparency(TransparencyMode::NONE);
         objectRenderer->SetLighting(false);
         objectRenderer->SetModelMatrix(glm::mat4(1.0f));
@@ -3685,8 +3666,6 @@ void CEngine::DrawInterface()
         renderer->SetTriplanarMode(m_triplanarMode);
         renderer->SetTriplanarScale(m_triplanarScale);
 
-        auto projectionViewMatrix = m_matProj * m_matView;
-
         for (int objRank = 0; objRank < static_cast<int>(m_objects.size()); objRank++)
         {
             if (! m_objects[objRank].used)
@@ -3698,8 +3677,8 @@ void CEngine::DrawInterface()
             if (! m_objects[objRank].drawFront)
                 continue;
 
-            auto combinedMatrix = projectionViewMatrix * m_objects[objRank].transform;
-
+            //auto projectionViewMatrix = m_matProj * m_matView;
+            //auto combinedMatrix = projectionViewMatrix * m_objects[objRank].transform;
             //if (! IsVisible(combinedMatrix, objRank))
             //    continue;
 
@@ -4094,7 +4073,7 @@ void CEngine::DrawShadowSpots()
 {
     m_device->SetDepthMask(false);
 
-    glm::mat4 matrix = glm::mat4(1.0f);
+    //glm::mat4 matrix = glm::mat4(1.0f);
     //m_device->SetTransform(TRANSFORM_WORLD, matrix);
 
     // TODO: create a separate texture
@@ -4253,13 +4232,6 @@ void CEngine::DrawShadowSpots()
 
         IntColor white(255, 255, 255, 255);
 
-        Vertex3D vertex[4] =
-        {
-            { corner[1], white, { ts.x, ts.y } },
-            { corner[0], white, { ti.x, ts.y } },
-            { corner[3], white, { ts.x, ti.y } },
-            { corner[2], white, { ti.x, ti.y } }
-        };
 
         float intensity = (0.5f+m_shadowSpots[i].intensity*0.5f)*hFactor;
 
@@ -4277,6 +4249,13 @@ void CEngine::DrawShadowSpots()
             //SetState(ENG_RSTATE_TTEXTURE_WHITE, Color(intensity, intensity, intensity, intensity));
         }
 
+        //Vertex3D vertex[4] =
+        //{
+        //    { corner[1], white, { ts.x, ts.y } },
+        //    { corner[0], white, { ti.x, ts.y } },
+        //    { corner[3], white, { ts.x, ti.y } },
+        //    { corner[2], white, { ti.x, ti.y } }
+        //};
         //m_device->DrawPrimitive(PrimitiveType::TRIANGLE_STRIP, vertex, 4);
         AddStatisticTriangle(2);
     }
@@ -4333,8 +4312,6 @@ void CEngine::DrawBackgroundImage()
     p1.y = 0.0f;
     p2.x = 1.0f;
     p2.y = 1.0f;
-
-    glm::vec3 n = glm::vec3(0.0f, 0.0f, -1.0f);  // normal
 
     float u1, u2, v1, v2;
     if (m_backgroundFull)
@@ -4432,8 +4409,6 @@ void CEngine::DrawForegroundImage()
 {
     if (m_foregroundName.empty())
         return;
-
-    glm::vec3 n = glm::vec3(0.0f, 0.0f, -1.0f);  // normal
 
     glm::vec2 p1(0.0f, 0.0f);
     glm::vec2 p2(1.0f, 1.0f);

--- a/colobot-base/src/graphics/engine/lightman.cpp
+++ b/colobot-base/src/graphics/engine/lightman.cpp
@@ -480,20 +480,22 @@ void CLightManager::UpdateDeviceLights(EngineObjectType type)
             break;
     }
 
+    /*
     for (int i = 0; i < static_cast<int>( m_lightMap.size() ); ++i)
     {
         int rank = m_lightMap[i];
         if (rank != -1)
         {
             Light light = m_dynLights[rank].light;
-            //m_device->SetLight(i, light);
-            //m_device->SetLightEnabled(i, true);
+            m_device->SetLight(i, light);
+            m_device->SetLightEnabled(i, true);
         }
         else
         {
-            //m_device->SetLightEnabled(i, false);
+            m_device->SetLightEnabled(i, false);
         }
     }
+    */
 }
 
 // -----------

--- a/colobot-base/src/graphics/engine/lightning.cpp
+++ b/colobot-base/src/graphics/engine/lightning.cpp
@@ -241,7 +241,6 @@ void CLightning::Draw()
     glm::vec3 p1 = m_pos;
     glm::vec3 eye = m_engine->GetEyePt();
     float a = Math::RotateAngle(eye.x-p1.x, eye.z-p1.z);
-    glm::vec3 n = glm::normalize(p1-eye);
 
     glm::vec3 corner[4];
     VertexParticle vertex[4];

--- a/colobot-base/src/graphics/engine/particle.cpp
+++ b/colobot-base/src/graphics/engine/particle.cpp
@@ -2617,8 +2617,6 @@ void CParticle::TrackDraw(int i, ParticleType type)
 
         glm::vec3 p2 = m_track[i].pos[h];
 
-        glm::vec3 n = glm::normalize(p1-eye);
-
         glm::vec2 rot;
 
         glm::vec3 p = p1;

--- a/colobot-base/src/graphics/engine/text.cpp
+++ b/colobot-base/src/graphics/engine/text.cpp
@@ -1212,9 +1212,8 @@ void CText::DrawCharAndAdjustPos(UTF8Char ch, FontType font, float size, glm::iv
 {
     if (font == FONT_BUTTON)
     {
-        glm::ivec2 windowSize = m_engine->GetWindowSize();
         int height = GetHeightInt(FONT_COMMON, size);
-        int width = height;// * (static_cast<float>(windowSize.y)/windowSize.x);
+        int width = height;
 
         glm::ivec2 p1(pos.x, pos.y - height);
         glm::ivec2 p2(pos.x + width, pos.y);
@@ -1240,8 +1239,6 @@ void CText::DrawCharAndAdjustPos(UTF8Char ch, FontType font, float size, glm::iv
         uv1.y += dp;
         uv2.x -= dp;
         uv2.y -= dp;
-
-        Gfx::IntColor col = Gfx::ColorToIntColor(color);
 
         Gfx::Vertex2D vertices[4];
 


### PR DESCRIPTION
Leftover from c3780091281174d7552b4200041c6fa85b4850ac:

```c++
colobot-base/src/graphics/engine/engine.cpp: In member function ‘void Gfx::CEngine::DebugObject(int)’:
colobot-base/src/graphics/engine/engine.cpp:858:32: error: unused variable ‘p2’ [-Werror=unused-variable]
  858 |         EngineBaseObjDataTier& p2 = p1.next[l2];
```

Leftover from 750a470b9a8570d74c57c251ee94841045af2c4a:

```c++
colobot-base/src/graphics/engine/engine.cpp: In member function ‘void Gfx::CEngine::Draw3DScene()’:
colobot-base/src/graphics/engine/engine.cpp:3118:19: error: variable ‘worldMatrix’ set but not used [-Werror=unused-but-set-variable]
 3118 |         glm::mat4 worldMatrix = glm::mat4(1.0f);
```

Leftover from 710f448477753e6f3ab41dcb6f793402cc5980fa:

```c++
colobot-base/src/graphics/engine/engine.cpp: In member function ‘void Gfx::CEngine::DrawInterface()’:
colobot-base/src/graphics/engine/engine.cpp:3687:14: error: variable ‘projectionViewMatrix’ set but not used [-Werror=unused-but-set-variable]
 3687 |         auto projectionViewMatrix = m_matProj * m_matView;
      |              ^~~~~~~~~~~~~~~~~~~~

colobot-base/src/graphics/engine/engine.cpp: In member function ‘void Gfx::CEngine::DrawInterface()’:
colobot-base/src/graphics/engine/engine.cpp:3700:18: error: variable ‘combinedMatrix’ set but not used [-Werror=unused-but-set-variable]
 3700 |             auto combinedMatrix = projectionViewMatrix * m_objects[objRank].transform;
      |                  ^~~~~~~~~~~~~~
```

Leftover from 750a470b9a8570d74c57c251ee94841045af2c4a:

```c++
colobot-base/src/graphics/engine/engine.cpp: In member function ‘void Gfx::CEngine::DrawShadowSpots()’:
colobot-base/src/graphics/engine/engine.cpp:4255:18: error: unused variable ‘vertex’ [-Werror=unused-variable]
 4255 |         Vertex3D vertex[4] =
      |                  ^~~~~~
```

Leftover from 37bdc8665fb7bc1618bcaa2f59a8ddb6b4b2387f:

```c++
colobot-base/src/graphics/engine/engine.cpp:4096:15: error: variable ‘matrix’ set but not used [-Werror=unused-but-set-variable]
 4096 |     glm::mat4 matrix = glm::mat4(1.0f);
      |               ^~~~~~
```

Leftover from 465fe59dfbd60ffa22610958420c24a835712d3c:

```c++
colobot-base/src/graphics/engine/engine.cpp: In member function ‘void Gfx::CEngine::DrawBackgroundImage()’:
colobot-base/src/graphics/engine/engine.cpp:4336:15: error: variable ‘n’ set but not used [-Werror=unused-but-set-variable]
 4336 |     glm::vec3 n = glm::vec3(0.0f, 0.0f, -1.0f);  // normal
      |               ^
```

Leftover from 37bdc8665fb7bc1618bcaa2f59a8ddb6b4b2387f:

```c++
colobot-base/src/graphics/engine/engine.cpp: In member function ‘void Gfx::CEngine::DrawForegroundImage()’:
colobot-base/src/graphics/engine/engine.cpp:4435:15: error: variable ‘n’ set but not used [-Werror=unused-but-set-variable]
 4435 |     glm::vec3 n = glm::vec3(0.0f, 0.0f, -1.0f);  // normal
      |               ^
```

Leftover from e839f0dec7d7e13fd8abdddf0c28e955cc32b698:

```c++
colobot-base/src/graphics/engine/engine.cpp: At global scope:
colobot-base/src/graphics/engine/engine.cpp:2032:13: error: ‘bool Gfx::IsExcludeColor(glm::vec2*, int, int)’ defined but not used [-Werror=un
used-function]
 2032 | static bool IsExcludeColor(glm::vec2* exclude, int x, int y)
      |             ^~~~~~~~~~~~~~
```

Leftover from 0908e10ff6735989b1f850ec70baa9920da899b4:

```c++
colobot-base/src/graphics/engine/lightman.cpp: In member function ‘void Gfx::CLightManager::UpdateDeviceLights(Gfx::EngineObjectType)’:
colobot-base/src/graphics/engine/lightman.cpp:488:19: error: variable ‘light’ set but not used [-Werror=unused-but-set-variable]
  488 |             Light light = m_dynLights[rank].light;
      |                   ^~~~~
```

Leftover from 750a470b9a8570d74c57c251ee94841045af2c4a:

```c++
colobot-base/src/graphics/engine/lightning.cpp: In member function ‘void Gfx::CLightning::Draw()’:
colobot-base/src/graphics/engine/lightning.cpp:244:15: error: variable ‘n’ set but not used [-Werror=unused-but-set-variable]
  244 |     glm::vec3 n = glm::normalize(p1-eye);
      |               ^
```

Leftover from 048393f448ee8f065f8291da1eba5ccd634b9e80:
```c++
colobot-base/src/graphics/engine/particle.cpp: In member function ‘void Gfx::CParticle::TrackDraw(int, Gfx::ParticleType)’
:
colobot-base/src/graphics/engine/particle.cpp:2620:19: error: variable ‘n’ set but not used [-Werror=unused-but-set-variab
le]
 2620 |         glm::vec3 n = glm::normalize(p1-eye);
      |                   ^
```

Leftover from 86caad3d45a46159072ee9aba218c3107fd780a4:
```c++
colobot-base/src/graphics/engine/text.cpp: In member function ‘void Gfx::CText::DrawCharAndAdjustPos(Gfx::UTF8Char, Gfx::FontType, float, glm::ivec2&, Gfx::Color)’:
colobot-base/src/graphics/engine/text.cpp:1215:20: error: variable ‘windowSize’ set but not used [-Werror=unused-but-set-variable]
 1215 |         glm::ivec2 windowSize = m_engine->GetWindowSize();
      |                    ^~~~~~~~~~
colobot-base/src/graphics/engine/text.cpp:1244:23: error: variable ‘col’ set but not used [-Werror=unused-but-set-variable]
 1244 |         Gfx::IntColor col = Gfx::ColorToIntColor(color);
      |                       ^~~
```