### PR TITLE
Fix use-after-free in CBotTypResul' operator=

### DIFF
--- a/CBot/src/CBot/CBotTypResult.h
+++ b/CBot/src/CBot/CBotTypResult.h
@@ -22,6 +22,7 @@
 #include "CBot/CBotEnums.h"
 
 #include <string>
+#include <memory>
 
 namespace CBot
 {
@@ -78,7 +79,7 @@ public:
      * \param type type of created result, see ::CBotType
      * \param elem type of array elements
      */
-    CBotTypResult(int type, CBotTypResult elem);
+    CBotTypResult(int type, const CBotTypResult& elem);
 
     /**
      * \brief Copy constructor
@@ -88,12 +89,7 @@ public:
     /**
      * \brief Default constructor
      */
-    CBotTypResult();
-
-    /**
-     * \brief Destructor
-     */
-    ~CBotTypResult();
+    CBotTypResult() = default;
 
     /**
      * \brief Mode for GetType()
@@ -141,7 +137,7 @@ public:
     /**
      * \brief Get type of array elements (for ::CBotTypArrayBody or ::CBotTypArrayPointer)
      */
-    CBotTypResult& GetTypElem() const;
+    const CBotTypResult& GetTypElem() const;
 
 
     /**
@@ -167,15 +163,15 @@ public:
      * \brief Get this type name as string
      * \returns This type name as string
      */
-    std::string ToString();
+    std::string ToString() const;
 
 private:
-    int               m_type;   //!< type, see ::CBotType and ::CBotError
-    CBotTypResult*    m_next;   //!< type of array element
-    CBotClass*        m_class;  //!< class type
-    int               m_limite; //!< array limit
-    friend class    CBotVarClass;
-    friend class    CBotVarPointer;
+    int m_type = 0;   //!< type, see ::CBotType and ::CBotError
+    std::unique_ptr<CBotTypResult> m_elementType;   //!< type of array element
+    CBotClass* m_class = nullptr;  //!< class type
+    int m_limite = -1;  //!< array limit
+    friend class CBotVarClass;
+    friend class CBotVarPointer;
 };
 
 } // namespace CBot


### PR DESCRIPTION
This pull request fixes a use after free bug that happens when compiling functions that take a multidimensional array as a parameter.

## To reproduce the bug
1. Compile colobot with [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html)
2. Try to compile this CBot code:
    ```c++
    void Bug(int[][] arr)
    {
    }
    ```
## Expected
No AddressSanitizer errors
## Got
```c++

=================================================================
==10990==ERROR: AddressSanitizer: heap-use-after-free on address 0x6030023d8fe8 at pc 0x55fbf634a9d8 bp 0x7ffc7c77af60 sp 0x7ffc7c77af50
READ of size 8 at 0x6030023d8fe8 thread T0
    #0 0x55fbf634a9d7 in CBot::CBotTypResult::operator=(CBot::CBotTypResult const&) /home/cdda/git/colobot/CBot/src/CBot/CBotTypResult.cpp:173
    #1 0x55fbf634fb67 in CBot::CBotVar::Create(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CBot::CBotTypResult) /home/cdda/git/colobot/CBot/src/CBot/CBotVar/CBotVar.cpp:295
    #2 0x55fbf62e3752 in CBot::CBotDefParam::Compile(CBot::CBotToken*&, CBot::CBotCStack*) /home/cdda/git/colobot/CBot/src/CBot/CBotDefParam.cpp:105
    #3 0x55fbf62fa0d4 in CBot::CBotFunction::Compile1(CBot::CBotToken*&, CBot::CBotCStack*, CBot::CBotClass*) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotFunction.cpp:331
    #4 0x55fbf6329ad0 in CBot::CBotProgram::Compile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::
allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, void*) /home/cdda/git/colobot/CBot/src/CBot/CBotProgram.cpp:101
    #5 0x55fbf621c61d in CScript::Compile() /home/cdda/git/colobot/colobot-base/src/script/script.cpp:239
    #6 0x55fbf621b244 in CScript::GetScript(Ui::CEdit*) /home/cdda/git/colobot/colobot-base/src/script/script.cpp:120
    #7 0x55fbf5e7095f in Ui::CStudio::EventProcess(Event const&) /home/cdda/git/colobot/colobot-base/src/ui/studio.cpp:201
    #8 0x55fbf5e55398 in Ui::CObjectInterface::EventProcess(Event const&) /home/cdda/git/colobot/colobot-base/src/ui/object_interface.cpp:240
    #9 0x55fbf5d35fd6 in COldObject::EventProcess(Event const&) /home/cdda/git/colobot/colobot-base/src/object/old_object.cpp:2306
    #10 0x55fbf5c04f94 in CRobotMain::EventObject(Event const&) /home/cdda/git/colobot/colobot-base/src/level/robotmain.cpp:2693
    #11 0x55fbf5bf5b0b in CRobotMain::ProcessEvent(Event&) /home/cdda/git/colobot/colobot-base/src/level/robotmain.cpp:1160
    #12 0x55fbf590b707 in CController::ProcessEvent(Event&) /home/cdda/git/colobot/colobot-base/src/app/controller.cpp:53
    #13 0x55fbf58bfede in CApplication::Run() /home/cdda/git/colobot/colobot-base/src/app/app.cpp:1169
    #14 0x55fbf58a6b07 in main /home/cdda/git/colobot/colobot-app/src/main.cpp:173
    #15 0x7f180d3a1d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #16 0x7f180d3a1e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #17 0x55fbf58a5aa4 in _start (/home/cdda/git/colobot/build-asan/colobot+0x1acaa4)

0x6030023d8fe8 is located 8 bytes inside of 32-byte region [0x6030023d8fe0,0x6030023d9000)
freed by thread T0 here:
    #0 0x7f180de6c24f in operator delete(void*, unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:172
    #1 0x55fbf634a9a5 in CBot::CBotTypResult::operator=(CBot::CBotTypResult const&) /home/cdda/git/colobot/CBot/src/CBot/CBotTypResult.cpp:172
    #2 0x55fbf634fb67 in CBot::CBotVar::Create(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CBot::CBotTypResult) /home/cdda/git/colobot/CBot/src/CBot/CBotVar/CBotVar.cpp:295
    #3 0x55fbf62e3752 in CBot::CBotDefParam::Compile(CBot::CBotToken*&, CBot::CBotCStack*) /home/cdda/git/colobot/CBot/src/CBot/CBotDefParam.cpp:105
    #4 0x55fbf62fa0d4 in CBot::CBotFunction::Compile1(CBot::CBotToken*&, CBot::CBotCStack*, CBot::CBotClass*) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotFunction.cpp:331
    #5 0x55fbf6329ad0 in CBot::CBotProgram::Compile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::
allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, void*) /home/cdda/git/colobot/CBot/src/CBot/CBotProgram.cpp:101
    #6 0x55fbf621c61d in CScript::Compile() /home/cdda/git/colobot/colobot-base/src/script/script.cpp:239
    #7 0x55fbf621b244 in CScript::GetScript(Ui::CEdit*) /home/cdda/git/colobot/colobot-base/src/script/script.cpp:120
    #8 0x55fbf5e7095f in Ui::CStudio::EventProcess(Event const&) /home/cdda/git/colobot/colobot-base/src/ui/studio.cpp:201
    #9 0x55fbf5e55398 in Ui::CObjectInterface::EventProcess(Event const&) /home/cdda/git/colobot/colobot-base/src/ui/object_interface.cpp:240
    #10 0x55fbf5d35fd6 in COldObject::EventProcess(Event const&) /home/cdda/git/colobot/colobot-base/src/object/old_object.cpp:2306
    #11 0x55fbf5c04f94 in CRobotMain::EventObject(Event const&) /home/cdda/git/colobot/colobot-base/src/level/robotmain.cpp:2693
    #12 0x55fbf5bf5b0b in CRobotMain::ProcessEvent(Event&) /home/cdda/git/colobot/colobot-base/src/level/robotmain.cpp:1160
    #13 0x55fbf590b707 in CController::ProcessEvent(Event&) /home/cdda/git/colobot/colobot-base/src/app/controller.cpp:53
    #14 0x55fbf58bfede in CApplication::Run() /home/cdda/git/colobot/colobot-base/src/app/app.cpp:1169
    #15 0x55fbf58a6b07 in main /home/cdda/git/colobot/colobot-app/src/main.cpp:173
    #16 0x7f180d3a1d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

previously allocated by thread T0 here:
    #0 0x7f180de6b1e7 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x55fbf634a0c7 in CBot::CBotTypResult::CBotTypResult(CBot::CBotTypResult const&) /home/cdda/git/colobot/CBot/src/CBot/CBotTypResult.cpp:86
    #2 0x55fbf62e370d in CBot::CBotDefParam::Compile(CBot::CBotToken*&, CBot::CBotCStack*) /home/cdda/git/colobot/CBot/src/CBot/CBotDefParam.cpp:105
    #3 0x55fbf62fa0d4 in CBot::CBotFunction::Compile1(CBot::CBotToken*&, CBot::CBotCStack*, CBot::CBotClass*) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotFunction.cpp:331
    #4 0x55fbf6329ad0 in CBot::CBotProgram::Compile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::
allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, void*) /home/cdda/git/colobot/CBot/src/CBot/CBotProgram.cpp:101
    #5 0x55fbf621c61d in CScript::Compile() /home/cdda/git/colobot/colobot-base/src/script/script.cpp:239
    #6 0x55fbf621b244 in CScript::GetScript(Ui::CEdit*) /home/cdda/git/colobot/colobot-base/src/script/script.cpp:120
    #7 0x55fbf5e7095f in Ui::CStudio::EventProcess(Event const&) /home/cdda/git/colobot/colobot-base/src/ui/studio.cpp:201
    #8 0x55fbf5e55398 in Ui::CObjectInterface::EventProcess(Event const&) /home/cdda/git/colobot/colobot-base/src/ui/object_interface.cpp:240
    #9 0x55fbf5d35fd6 in COldObject::EventProcess(Event const&) /home/cdda/git/colobot/colobot-base/src/object/old_object.cpp:2306
    #10 0x55fbf5c04f94 in CRobotMain::EventObject(Event const&) /home/cdda/git/colobot/colobot-base/src/level/robotmain.cpp:2693
    #11 0x55fbf5bf5b0b in CRobotMain::ProcessEvent(Event&) /home/cdda/git/colobot/colobot-base/src/level/robotmain.cpp:1160
    #12 0x55fbf590b707 in CController::ProcessEvent(Event&) /home/cdda/git/colobot/colobot-base/src/app/controller.cpp:53
    #13 0x55fbf58bfede in CApplication::Run() /home/cdda/git/colobot/colobot-base/src/app/app.cpp:1169
    #14 0x55fbf58a6b07 in main /home/cdda/git/colobot/colobot-app/src/main.cpp:173
    #15 0x7f180d3a1d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: heap-use-after-free /home/cdda/git/colobot/CBot/src/CBot/CBotTypResult.cpp:173 in CBot::CBotTypResult::operator=(CBot::CBotTypResult const&)
Shadow bytes around the buggy address:
  0x0c06804731a0: fa fa fd fd fd fd fa fa 00 00 00 04 fa fa fd fd
  0x0c06804731b0: fd fd fa fa fd fd fd fd fa fa fd fd fd fd fa fa
  0x0c06804731c0: fd fd fd fd fa fa fd fd fd fd fa fa fd fd fd fd
  0x0c06804731d0: fa fa fd fd fd fd fa fa fd fd fd fd fa fa fd fd
  0x0c06804731e0: fd fd fa fa 00 00 00 00 fa fa 00 00 00 00 fa fa
=>0x0c06804731f0: 00 00 00 00 fa fa 00 00 00 00 fa fa fd[fd]fd fd
  0x0c0680473200: fa fa fd fd fd fd fa fa 00 00 00 00 fa fa 00 00
  0x0c0680473210: 00 00 fa fa 00 00 00 00 fa fa 00 00 00 00 fa fa
  0x0c0680473220: 00 00 00 00 fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0680473230: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0680473240: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==10990==ABORTING
```
## The cause of the bug
Note: I changed object addresses for reader convinence.
```
type is 0x1111
0x1111->m_next is 0x2222
0x2222->m_next is 0x3333
0x3333->m_next is null

type.GetTypElem() returns 0x2222
```

The bug happens in the middle of executing this line:
https://github.com/colobot/colobot/blob/1f9cd7af5b1abc08acc34f6911b6e9cc944a46a4/CBot/src/CBot/CBotVar/CBotVar.cpp#L214

The bug happens in this function:
```
this is 0x1111
this->m_next is 0x2222
src is 0x2222
src->m_next is 0x3333 (and therefore src.m_next != nullptr is true)

We delete this->m_next, but this->m_next is src. When we use src, we get use-after-free.
```
https://github.com/colobot/colobot/blob/1f9cd7af5b1abc08acc34f6911b6e9cc944a46a4/CBot/src/CBot/CBotTypResult.cpp#L165-L181

## Proposed solution

~Use the copy-swap idiom~