### PR TITLE
Fix unused variables 3

### DIFF
--- a/colobot-base/src/object/motion/motionhuman.cpp
+++ b/colobot-base/src/object/motion/motionhuman.cpp
@@ -612,7 +612,7 @@ bool CMotionHuman::EventProcess(const Event &event)
 bool CMotionHuman::EventFrame(const Event &event)
 {
     glm::vec3    dir, actual, pos, speed, pf;
-    glm::vec2       center, dim, p2;
+    glm::vec2    dim, p2;
     float       s, a, prog, rTime[2], lTime[2], time, rot, hr, hl;
     float       al, ar, af;
     float       tSt[9], tNd[9];

--- a/colobot-base/src/object/motion/motionvehicle.cpp
+++ b/colobot-base/src/object/motion/motionvehicle.cpp
@@ -1384,7 +1384,7 @@ bool CMotionVehicle::EventProcess(const Event &event)
 bool CMotionVehicle::EventFrame(const Event &event)
 {
     Character*  character;
-    glm::vec3    pos, angle, floor;
+    glm::vec3    pos, angle;
     ObjectType  type;
     float       s, a, speedBL, speedBR, speedFL, speedFR, h, a1, a2;
     float       back, front, dist, radius, limit[2];
@@ -1932,8 +1932,6 @@ bool CMotionVehicle::EventFrameInsect(const Event &event)
 
 bool CMotionVehicle::EventFrameCanoni(const Event &event)
 {
-    glm::vec3    pos, speed;
-    glm::vec2     dim;
     float       zoom, angle, factor;
     bool        bOnBoard = false;
 

--- a/colobot-base/src/object/old_object.cpp
+++ b/colobot-base/src/object/old_object.cpp
@@ -1068,8 +1068,6 @@ int COldObject::GetOption()
 
 void COldObject::Write(CLevelParserLine* line)
 {
-    glm::vec3    pos;
-
     line->AddParam("camera", std::make_unique<CLevelParserParam>(GetCameraType()));
 
     if ( GetCameraLock() )
@@ -1937,7 +1935,7 @@ bool COldObject::CreateShadowCircle(float radius, float intensity,
 
 bool COldObject::UpdateTransformObject(int part, bool bForceUpdate)
 {
-    glm::vec3    position, angle, eye;
+    glm::vec3    position, angle;
     bool        bModif = false;
     int         parent;
 
@@ -2128,34 +2126,6 @@ void COldObject::UpdateEnergyMapping()
         return;
 
     m_lastEnergy = GetEnergyLevel();
-
-    float a = 0.0f, b = 0.0f;
-
-    if ( m_type == OBJECT_POWER  ||
-         m_type == OBJECT_ATOMIC )
-    {
-        a = 2.0f;
-        b = 0.0f;  // dimensions of the battery (according to y)
-    }
-    else if ( m_type == OBJECT_STATION )
-    {
-        a = 10.0f;
-        b =  4.0f;  // dimensions of the battery (according to y)
-    }
-    else if ( m_type == OBJECT_ENERGY )
-    {
-        a = 9.0f;
-        b = 3.0f;  // dimensions of the battery (according to y)
-    }
-
-    float i = 0.50f+0.25f*GetEnergyLevel();  // origin
-    float s = i+0.25f;  // width
-
-    float au = (s-i)/(b-a);
-    float bu = s-b*(s-i)/(b-a);
-
-    std::string teamStr = StrUtils::ToString<int>(GetTeam());
-    if(GetTeam() == 0) teamStr = "";
 
     m_engine->SetUVTransform(m_objectPart[0].object, "energy",
         { 0.0f, 0.25f * (GetEnergyLevel() - 1.0f) }, { 1.0f, 1.0f });


### PR DESCRIPTION
## Error 1
```c++
/home/cdda/git/colobot/colobot-base/src/object/motion/motionhuman.cpp: In member function ‘bool CMotionHuman::EventFrame(const Event&)’:
/home/cdda/git/colobot/colobot-base/src/object/motion/motionhuman.cpp:615:21: error: unused variable ‘center’ [-Werror=unused-variable]
  615 |     glm::vec2       center, dim, p2;
      |                     ^~~~~~
/home/cdda/git/colobot/colobot-base/src/object/motion/motionvehicle.cpp: In member function ‘bool CMotionVehicle::EventFrame(const Event&)’:
/home/cdda/git/colobot/colobot-base/src/object/motion/motionvehicle.cpp:1387:30: error: unused variable ‘floor’ [-Werror=unused-variable]
 1387 |     glm::vec3    pos, angle, floor;
      |                              ^~~~~
```
### Explanation

Unused since the initial commit

https://github.com/colobot/colobot/blob/a4c804b49ec872b71bd5a0167c3ad45704a3cc30/src/motionhuman.cpp#L722
https://github.com/colobot/colobot/blob/a4c804b49ec872b71bd5a0167c3ad45704a3cc30/src/motionvehicle.cpp#L1375

## Error 2

```c++
/home/cdda/git/colobot/colobot-base/src/object/motion/motionvehicle.cpp: In member function ‘bool CMotionVehicle::EventFrameCanoni(const Event&)’:
/home/cdda/git/colobot/colobot-base/src/object/motion/motionvehicle.cpp:1935:18: error: unused variable ‘pos’ [-Werror=unused-variable]
 1935 |     glm::vec3    pos, speed;
      |                  ^~~
/home/cdda/git/colobot/colobot-base/src/object/motion/motionvehicle.cpp:1935:23: error: unused variable ‘speed’ [-Werror=unused-variable]
 1935 |     glm::vec3    pos, speed;
      |                       ^~~~~
/home/cdda/git/colobot/colobot-base/src/object/motion/motionvehicle.cpp:1936:19: error: unused variable ‘dim’ [-Werror=unused-variable]
 1936 |     glm::vec2     dim;
      |                   ^~~
```

### Explanation

commit 60797f72d3e3bfba811cc93c53a93b2ed508ed76
```diff
-#if 0
-    m_lastTimeCanon -= event.rTime;
-    if ( m_lastTimeCanon <= 0.0f )
-    {
-        m_lastTimeCanon = m_engine->ParticuleAdapt(0.5f+Math::Rand()*0.5f);
-
-        pos = m_object->GetPosition();
-        pos.y += 8.0f;
-        speed.y = 7.0f+Math::Rand()*3.0f;
-        speed.x = (Math::Rand()-0.5f)*2.0f;
-        speed.z = 2.0f+Math::Rand()*2.0f;
-        if ( Math::Rand() < 0.5f )  speed.z = -speed.z;
-        mat = m_object->GetRotateMatrix(0);
-        speed = Transform(*mat, speed);
-        dim.x = Math::Rand()*0.1f+0.1f;
-        if ( bOnBoard )  dim.x *= 0.4f;
-        dim.y = dim.x;
-        m_particule->CreateParticule(pos, speed, dim, PARTIORGANIC2, 2.0f, 10.0f);
-    }
-#endif
```

## Error 3

```c++
/home/cdda/git/colobot/colobot-base/src/object/old_object.cpp: In member function ‘virtual void COldObject::Write(CLevelParserLine*)’:
/home/cdda/git/colobot/colobot-base/src/object/old_object.cpp:1071:18: error: unused variable ‘pos’ [-Werror=unused-variable]
 1071 |     glm::vec3    pos;
      |                  ^~~
```

### Explanation

commit 3dade17f89445559c093bf38af5c8f48114866ca
```diff
-        pos = GetResetPosition()/g_unit;
-        sprintf(name, " resetPos=%.2f;%.2f;%.2f", pos.x, pos.y, pos.z);
-        strcat(line, name);
-
-        pos = GetResetAngle()/(Math::PI/180.0f);
-        sprintf(name, " resetAngle=%.2f;%.2f;%.2f", pos.x, pos.y, pos.z);
-        strcat(line, name);
```

## Error 4

```c++
/home/cdda/git/colobot/colobot-base/src/object/old_object.cpp: In member function ‘bool COldObject::UpdateTransformObject(int, bool)’:
/home/cdda/git/colobot/colobot-base/src/object/old_object.cpp:1940:35: error: unused variable ‘eye’ [-Werror=unused-variable]
 1940 |     glm::vec3    position, angle, eye;
      |                                   ^~~
```

### Explanation

Unused since the initial commit

https://github.com/colobot/colobot/blob/a4c804b49ec872b71bd5a0167c3ad45704a3cc30/src/object.cpp#L5839

## Error 5

```c++
/home/cdda/git/colobot/colobot-base/src/object/old_object.cpp: In member function ‘void COldObject::UpdateEnergyMapping()’:
/home/cdda/git/colobot/colobot-base/src/object/old_object.cpp:2154:11: error: unused variable ‘au’ [-Werror=unused-variable]
 2154 |     float au = (s-i)/(b-a);
      |           ^~
/home/cdda/git/colobot/colobot-base/src/object/old_object.cpp:2155:11: error: unused variable ‘bu’ [-Werror=unused-variable]
 2155 |     float bu = s-b*(s-i)/(b-a);
      |           ^~
```

### Explanation

commit 7d9badb542adb1cd505a005d1832efbe8133e483
```diff
-    m_engine->ChangeTextureMapping(m_objectPart[0].object,
-                                   Gfx::ENG_RSTATE_PART3, "objects/lemt.png"+teamStr, "",
-                                   Gfx::EngineTextureMapping::ONE_Y,
-                                   au, bu, 1.0f, 0.0f);
+
+    m_engine->SetUVTransform(m_objectPart[0].object, Gfx::ENG_RSTATE_PART3,
+        { 0.0f, 0.25f * (GetEnergyLevel() - 1.0f) }, { 1.0f, 1.0f });
```
