### PR TITLE
Fix unused variables 4

### DIFF
--- a/colobot-base/src/object/task/taskbuild.cpp
+++ b/colobot-base/src/object/task/taskbuild.cpp
@@ -665,8 +665,7 @@ bool CTaskBuild::Abort()
 Error CTaskBuild::FlatFloor()
 {
     ObjectType  type;
-    glm::vec3    center, pos, bPos;
-    glm::vec2       c, p;
+    glm::vec3    center, bPos;
     float       radius, max, bRadius = 0.0f, angle, dist;
     bool        bLittleFlat, bBase;
 

--- a/colobot-base/src/object/task/taskfire.cpp
+++ b/colobot-base/src/object/task/taskfire.cpp
@@ -274,7 +274,7 @@ bool CTaskFire::EventProcess(const Event &event)
 
 Error CTaskFire::Start(float delay)
 {
-    glm::vec3    pos, goal, speed;
+    glm::vec3   speed;
     float       energy, fire;
     ObjectType  type;
 

--- a/colobot-base/src/object/task/taskfireant.cpp
+++ b/colobot-base/src/object/task/taskfireant.cpp
@@ -54,7 +54,6 @@ CTaskFireAnt::~CTaskFireAnt()
 
 bool CTaskFireAnt::EventProcess(const Event &event)
 {
-    glm::vec3    dir, vib;
     float       a, g, cirSpeed;
 
     if ( m_engine->GetPause() )  return true;

--- a/colobot-base/src/object/task/taskmanip.cpp
+++ b/colobot-base/src/object/task/taskmanip.cpp
@@ -517,7 +517,6 @@ Error CTaskManip::Start(TaskManipOrder order, TaskManipArm arm)
 Error CTaskManip::IsEnded()
 {
     CObject*    cargo;
-    glm::vec3    pos;
     float       angle, dist;
     int         i;
 

--- a/colobot-base/src/object/task/taskrecover.cpp
+++ b/colobot-base/src/object/task/taskrecover.cpp
@@ -226,8 +226,7 @@ Error CTaskRecover::Start()
 
 Error CTaskRecover::IsEnded()
 {
-    glm::vec3    pos, speed, goal;
-    glm::vec2       dim;
+    glm::vec3    pos, goal;
     float       angle, dist, time;
     int         i;
 


### PR DESCRIPTION
```c++
/home/cdda/git/colobot/colobot-base/src/object/task/taskbuild.cpp: In member function ‘Error CTaskBuild::FlatFloor()’:
/home/cdda/git/colobot/colobot-base/src/object/task/taskbuild.cpp:668:26: error: unused variable ‘pos’ [-Werror=unused-variable]
  668 |     glm::vec3    center, pos, bPos;
      |                          ^~~
/home/cdda/git/colobot/colobot-base/src/object/task/taskbuild.cpp:669:21: error: unused variable ‘c’ [-Werror=unused-variable]
  669 |     glm::vec2       c, p;
      |                     ^
/home/cdda/git/colobot/colobot-base/src/object/task/taskbuild.cpp:669:24: error: unused variable ‘p’ [-Werror=unused-variable]
  669 |     glm::vec2       c, p;
      |                        ^
/home/cdda/git/colobot/colobot-base/src/object/task/taskfire.cpp: In member function ‘Error CTaskFire::Start(float)’:
/home/cdda/git/colobot/colobot-base/src/object/task/taskfire.cpp:277:18: error: unused variable ‘pos’ [-Werror=unused-variable]
  277 |     glm::vec3    pos, goal, speed;
      |                  ^~~
/home/cdda/git/colobot/colobot-base/src/object/task/taskfire.cpp:277:23: error: unused variable ‘goal’ [-Werror=unused-variable]
  277 |     glm::vec3    pos, goal, speed;
      |                       ^~~~
/home/cdda/git/colobot/colobot-base/src/object/task/taskfireant.cpp: In member function ‘virtual bool CTaskFireAnt::EventProcess(const Event&)’:
/home/cdda/git/colobot/colobot-base/src/object/task/taskfireant.cpp:57:18: error: unused variable ‘dir’ [-Werror=unused-variable]
   57 |     glm::vec3    dir, vib;
      |                  ^~~
/home/cdda/git/colobot/colobot-base/src/object/task/taskfireant.cpp:57:23: error: unused variable ‘vib’ [-Werror=unused-variable]
   57 |     glm::vec3    dir, vib;
      |                       ^~~
/home/cdda/git/colobot/colobot-base/src/object/task/taskmanip.cpp: In member function ‘virtual Error CTaskManip::IsEnded()’:
/home/cdda/git/colobot/colobot-base/src/object/task/taskmanip.cpp:520:18: error: unused variable ‘pos’ [-Werror=unused-variable]
  520 |     glm::vec3    pos;
      |                  ^~~
/home/cdda/git/colobot/colobot-base/src/object/task/taskrecover.cpp: In member function ‘virtual Error CTaskRecover::IsEnded()’:
/home/cdda/git/colobot/colobot-base/src/object/task/taskrecover.cpp:229:23: error: unused variable ‘speed’ [-Werror=unused-variable]
  229 |     glm::vec3    pos, speed, goal;
      |                       ^~~~~
/home/cdda/git/colobot/colobot-base/src/object/task/taskrecover.cpp:230:21: error: unused variable ‘dim’ [-Werror=unused-variable]
  230 |     glm::vec2       dim;
      |                     ^~~
```

Unused since the initial commit

https://github.com/colobot/colobot/blob/a4c804b49ec872b71bd5a0167c3ad45704a3cc30/src/taskbuild.cpp#L564-L565
https://github.com/colobot/colobot/blob/a4c804b49ec872b71bd5a0167c3ad45704a3cc30/src/taskfire.cpp#L269
https://github.com/colobot/colobot/blob/a4c804b49ec872b71bd5a0167c3ad45704a3cc30/src/taskfireant.cpp#L50
https://github.com/colobot/colobot/blob/a4c804b49ec872b71bd5a0167c3ad45704a3cc30/src/taskmanip.cpp#L538
https://github.com/colobot/colobot/blob/a4c804b49ec872b71bd5a0167c3ad45704a3cc30/src/taskrecover.cpp#L223-L224
