### PR TITLE
Fix unused variables 5

### DIFF
--- a/colobot-base/src/physics/physics.cpp
+++ b/colobot-base/src/physics/physics.cpp
@@ -1439,7 +1439,7 @@ void CPhysics::UpdateMotionStruct(float rTime, Motion &motion)
 bool CPhysics::EventFrame(const Event &event)
 {
     ObjectType  type;
-    glm::mat4    objRotate, matRotate;
+    glm::mat4   matRotate;
     glm::vec3    iPos{ 0, 0, 0 }, iAngle{ 0, 0, 0 }, tAngle{ 0, 0, 0 }, pos{ 0, 0, 0 }, newpos{ 0, 0, 0 }, angle{ 0, 0, 0 }, newangle{ 0, 0, 0 }, n{ 0, 0, 0 };
     float       h, w;
     int         i;
@@ -3055,7 +3055,7 @@ void CPhysics::MotorParticle(float aTime, float rTime)
     glm::vec3    pos{ 0, 0, 0 }, speed{ 0, 0, 0 };
     glm::vec2       dim;
     ObjectType  type;
-    glm::vec2   c, p;
+    glm::vec2   p;
     float       h, a, delay, level;
     int         r, i, nb;
 

--- a/colobot-base/src/script/script.cpp
+++ b/colobot-base/src/script/script.cpp
@@ -839,7 +839,7 @@ void CScript::GetError(std::string& error)
 
 void CScript::New(Ui::CEdit* edit, const std::string& name)
 {
-    int     cursor1, cursor2, len, i;
+    int     cursor1, cursor2, i;
 
     std::string resStr;
     GetResource(RES_TEXT, RT_SCRIPT_NEW, resStr);

--- a/colobot-base/src/ui/controls/gauge.cpp
+++ b/colobot-base/src/ui/controls/gauge.cpp
@@ -76,7 +76,7 @@ bool CGauge::EventProcess(const Event &event)
 
 void CGauge::Draw()
 {
-    glm::vec2   pos, dim, ddim, uv1, uv2, corner;
+    glm::vec2   pos, dim, uv1, uv2, corner;
     float       dp;
 
     if ( (m_state & STATE_VISIBLE) == 0 )  return;

--- a/colobot-base/src/ui/controls/map.cpp
+++ b/colobot-base/src/ui/controls/map.cpp
@@ -829,7 +829,7 @@ void CMap::DrawObject(const glm::vec2& position, float dir, ObjectType type, Map
 void CMap::DrawObjectIcon(const glm::vec2& pos, const glm::vec2& dim, MapColor color,
                           ObjectType type, bool bHilite)
 {
-    glm::vec2 ppos, ddim, uv1, uv2;
+    glm::vec2 uv1, uv2;
     float   dp;
     int     icon;
 

--- a/colobot-base/src/ui/controls/window.cpp
+++ b/colobot-base/src/ui/controls/window.cpp
@@ -846,8 +846,6 @@ void CWindow::Draw()
         glm::vec2 pos, dim;
         // Draws the shadow under the title bar.
         {
-            glm::vec2 sPos, sDim;
-
             pos.x = m_pos.x+0.01f;
             dim.x = m_dim.x-0.02f;
             pos.y = m_pos.y+m_dim.y-0.01f-h*1.2f;
@@ -908,7 +906,7 @@ void CWindow::Draw()
 
 void CWindow::DrawVertex(const glm::vec2& position, const glm::vec2& dimension, int icon)
 {
-    glm::vec2   p1, p2, uv1, uv2, corner;
+    glm::vec2   uv1, uv2, corner;
     float       dp;
     int         i;
 

--- a/colobot-base/src/ui/maindialog.cpp
+++ b/colobot-base/src/ui/maindialog.cpp
@@ -352,7 +352,7 @@ void CMainDialog::StartInformation(const std::string& title, const std::string& 
 void CMainDialog::StartDialog(const glm::vec2& dim, bool fireParticles)
 {
     CWindow*    pw;
-    glm::vec2   pos, ddim;
+    glm::vec2   pos;
 
     m_main->StartSuspend();
 

--- a/colobot-base/src/ui/object_interface.cpp
+++ b/colobot-base/src/ui/object_interface.cpp
@@ -1546,7 +1546,6 @@ void CObjectInterface::UpdateInterface(float rTime)
     CButton*    pb;
     CGroup*     pgr;
     CTarget*    ptg;
-    glm::vec3    pos, hPos;
     glm::vec2     ppos;
     float       range;
     int         icon;


### PR DESCRIPTION
## Error 1

```c++
/home/cdda/git/colobot/colobot-base/src/physics/physics.cpp: In member function ‘bool CPhysics::EventFrame(const Event&)’:
/home/cdda/git/colobot/colobot-base/src/physics/physics.cpp:1442:18: error: unused variable ‘objRotate’ [-Werror=unused-variable]
 1442 |     glm::mat4    objRotate, matRotate;
      |                  ^~~~~~~~~
/home/cdda/git/colobot/colobot-base/src/physics/physics.cpp: In member function ‘void CPhysics::MotorParticle(float, float)’:
/home/cdda/git/colobot/colobot-base/src/physics/physics.cpp:3058:17: error: unused variable ‘c’ [-Werror=unused-variable]
 3058 |     glm::vec2   c, p;
      |                 ^
```

### Explanation

Unused since the initial commit

https://github.com/colobot/colobot/blob/a4c804b49ec872b71bd5a0167c3ad45704a3cc30/src/physics.cpp#L1458
https://github.com/colobot/colobot/blob/a4c804b49ec872b71bd5a0167c3ad45704a3cc30/src/physics.cpp#L3133

## Error 2

```c++
/home/cdda/git/colobot/colobot-base/src/script/script.cpp: In member function ‘void CScript::New(Ui::CEdit*, const string&)’:
/home/cdda/git/colobot/colobot-base/src/script/script.cpp:842:31: error: unused variable ‘len’ [-Werror=unused-variable]
  842 |     int     cursor1, cursor2, len, i;
      |                               ^~~
```

### Explanation

commit 1058d48c8bdff2b452440a46f53713cef0b273b0
```diff
-            len = stream.size();
+            std::size_t len = stream.size();
```

## Error 3

```c++
/home/cdda/git/colobot/colobot-base/src/ui/maindialog.cpp: In member function ‘void Ui::CMainDialog::StartDialog(const vec2&, bool)’:
/home/cdda/git/colobot/colobot-base/src/ui/maindialog.cpp:355:22: error: unused variable ‘ddim’ [-Werror=unused-variable]
  355 |     glm::vec2   pos, ddim;
      |                      ^~~~
```

### Explanation

commit 711643b454d925b9405538c6848e597199192552
```diff
-    if ( bOK )
-    {
-        pos.x  = 0.50f-0.15f-0.02f;
-        pos.y  = 0.50f-dim.y/2.0f+0.03f;
-        ddim.x = 0.15f;
-        ddim.y = 0.06f;
-        pb = pw->CreateButton(pos, ddim, -1, EVENT_DIALOG_OK);
-        pb->SetState(STATE_SHADOW);
-        GetResource(RES_EVENT, EVENT_DIALOG_OK, name);
-        pb->SetName(name);
-    }
-
-    if ( bCancel )
-    {
-        pos.x  = 0.50f+0.02f;
-        pos.y  = 0.50f-dim.y/2.0f+0.03f;
-        ddim.x = 0.15f;
-        ddim.y = 0.06f;
-        pb = pw->CreateButton(pos, ddim, -1, EVENT_DIALOG_CANCEL);
-        pb->SetState(STATE_SHADOW);
-        GetResource(RES_EVENT, EVENT_DIALOG_CANCEL, name);
-        pb->SetName(name);
-    }
```

## Error 4

```c++
/home/cdda/git/colobot/colobot-base/src/ui/object_interface.cpp: In member function ‘void Ui::CObjectInterface::UpdateInterface(float)’:
/home/cdda/git/colobot/colobot-base/src/ui/object_interface.cpp:1549:18: error: unused variable ‘pos’ [-Werror=unused-variable]
 1549 |     glm::vec3    pos, hPos;
      |                  ^~~
/home/cdda/git/colobot/colobot-base/src/ui/object_interface.cpp:1549:23: error: unused variable ‘hPos’ [-Werror=unused-variable]
 1549 |     glm::vec3    pos, hPos;
      |                       ^~~~
/home/cdda/git/colobot/colobot-base/src/ui/controls/gauge.cpp: In member function ‘virtual void Ui::CGauge::Draw()’:
/home/cdda/git/colobot/colobot-base/src/ui/controls/gauge.cpp:79:27: error: unused variable ‘ddim’ [-Werror=unused-variable]
   79 |     glm::vec2   pos, dim, ddim, uv1, uv2, corner;
      |                           ^~~~
/home/cdda/git/colobot/colobot-base/src/ui/controls/map.cpp: In member function ‘void Ui::CMap::DrawObjectIcon(const vec2&, const vec2&, Ui::MapColor, ObjectType, bool)’:
/home/cdda/git/colobot/colobot-base/src/ui/controls/map.cpp:832:15: error: unused variable ‘ppos’ [-Werror=unused-variable]
  832 |     glm::vec2 ppos, ddim, uv1, uv2;
      |               ^~~~
/home/cdda/git/colobot/colobot-base/src/ui/controls/map.cpp:832:21: error: unused variable ‘ddim’ [-Werror=unused-variable]
  832 |     glm::vec2 ppos, ddim, uv1, uv2;
      |                     ^~~~
/home/cdda/git/colobot/colobot-base/src/ui/controls/window.cpp: In member function ‘virtual void Ui::CWindow::Draw()’:
/home/cdda/git/colobot/colobot-base/src/ui/controls/window.cpp:849:23: error: unused variable ‘sPos’ [-Werror=unused-variable]
  849 |             glm::vec2 sPos, sDim;
      |                       ^~~~
/home/cdda/git/colobot/colobot-base/src/ui/controls/window.cpp:849:29: error: unused variable ‘sDim’ [-Werror=unused-variable]
  849 |             glm::vec2 sPos, sDim;
      |                             ^~~~
/home/cdda/git/colobot/colobot-base/src/ui/controls/window.cpp: In member function ‘void Ui::CWindow::DrawVertex(const vec2&, const vec2&, int)’:
/home/cdda/git/colobot/colobot-base/src/ui/controls/window.cpp:911:17: error: unused variable ‘p1’ [-Werror=unused-variable]
  911 |     glm::vec2   p1, p2, uv1, uv2, corner;
      |                 ^~
/home/cdda/git/colobot/colobot-base/src/ui/controls/window.cpp:911:21: error: unused variable ‘p2’ [-Werror=unused-variable]
  911 |     glm::vec2   p1, p2, uv1, uv2, corner;
      |                     ^~
```

### Explanation

Unused since the initial commit

https://github.com/colobot/colobot/blob/a4c804b49ec872b71bd5a0167c3ad45704a3cc30/src/brain.cpp#L1924
https://github.com/colobot/colobot/blob/a4c804b49ec872b71bd5a0167c3ad45704a3cc30/src/gauge.cpp#L74C20-L74C24
https://github.com/colobot/colobot/blob/a4c804b49ec872b71bd5a0167c3ad45704a3cc30/src/map.cpp#L778
https://github.com/colobot/colobot/blob/a4c804b49ec872b71bd5a0167c3ad45704a3cc30/src/window.cpp#L1134
https://github.com/colobot/colobot/blob/a4c804b49ec872b71bd5a0167c3ad45704a3cc30/src/window.cpp#L1199
