### PR TITLE
Fix buffer overflow in CBotTwoOpExpr::Compile

### DIFF
--- a/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp
@@ -139,15 +139,14 @@ CBotInstr* CBotTwoOpExpr::Compile(CBotToken* &p, CBotCStack* pStack, int* pOpera
     int typeMask;
 
     if ( pOperations == nullptr ) pOperations = ListOp;
+    if ( *pOperations == 0 ) return CBotParExpr::Compile(p, pStack, bConstExpr);
     int* pOp = pOperations;
     while ( *pOp++ != 0 );              // follows the table
 
     CBotCStack* pStk = pStack->TokenStack();                    // one end of stack please
 
     // search the intructions that may be suitable to the left of the operation
-    CBotInstr*  left = (*pOp == 0) ?
-                        CBotParExpr::Compile(p, pStk, bConstExpr) :       // expression (...) left
-                        CBotTwoOpExpr::Compile(p, pStk, pOp, bConstExpr); // expression A * B left
+    CBotInstr*  left = CBotTwoOpExpr::Compile(p, pStk, pOp, bConstExpr);
 
     if (left == nullptr) return pStack->Return(nullptr, pStk);        // if error,  transmit
 


### PR DESCRIPTION
This pull request fixes a buffer overflow in CBotTwoOpExpr::Compile

## To reproduce the bug

1. Compile colobot  with AddressSanitizer
2. Compile the following CBot code:
    ```c++
    extern void BasicMath()
    {
    	6**3;
    }
    ```

## Expected

No errors

## Got

```c++
=================================================================
==91736==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7ffff7403f2c at pc 0x7ffff73175a5 bp 0x7fffffff8930 sp 0x7fffffff8920
READ of size 4 at 0x7ffff7403f2c thread T0
    #0 0x7ffff73175a4 in CBot::CBotTwoOpExpr::Compile(CBot::CBotToken*&, CBot::CBotCStack*, int*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp:148
    #1 0x7ffff7317f41 in CBot::CBotTwoOpExpr::Compile(CBot::CBotToken*&, CBot::CBotCStack*, int*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp:210
    #2 0x7ffff73175f7 in CBot::CBotTwoOpExpr::Compile(CBot::CBotToken*&, CBot::CBotCStack*, int*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp:150
    #3 0x7ffff73175f7 in CBot::CBotTwoOpExpr::Compile(CBot::CBotToken*&, CBot::CBotCStack*, int*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp:150
    #4 0x7ffff73175f7 in CBot::CBotTwoOpExpr::Compile(CBot::CBotToken*&, CBot::CBotCStack*, int*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp:150
    #5 0x7ffff73175f7 in CBot::CBotTwoOpExpr::Compile(CBot::CBotToken*&, CBot::CBotCStack*, int*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp:150
    #6 0x7ffff73175f7 in CBot::CBotTwoOpExpr::Compile(CBot::CBotToken*&, CBot::CBotCStack*, int*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp:150
    #7 0x7ffff73175f7 in CBot::CBotTwoOpExpr::Compile(CBot::CBotToken*&, CBot::CBotCStack*, int*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp:150
    #8 0x7ffff73175f7 in CBot::CBotTwoOpExpr::Compile(CBot::CBotToken*&, CBot::CBotCStack*, int*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp:150
    #9 0x7ffff73175f7 in CBot::CBotTwoOpExpr::Compile(CBot::CBotToken*&, CBot::CBotCStack*, int*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp:150
    #10 0x7ffff73175f7 in CBot::CBotTwoOpExpr::Compile(CBot::CBotToken*&, CBot::CBotCStack*, int*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp:150
    #11 0x7ffff73175f7 in CBot::CBotTwoOpExpr::Compile(CBot::CBotToken*&, CBot::CBotCStack*, int*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp:150
    #12 0x7ffff73175f7 in CBot::CBotTwoOpExpr::Compile(CBot::CBotToken*&, CBot::CBotCStack*, int*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp:150
    #13 0x7ffff72da3b6 in CBot::CBotExpression::Compile(CBot::CBotToken*&, CBot::CBotCStack*) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotExpression.cpp:155
    #14 0x7ffff72f62e2 in CBot::CBotInstr::Compile(CBot::CBotToken*&, CBot::CBotCStack*) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotInstr.cpp:271
    #15 0x7ffff72ade19 in CBot::CBotBlock::CompileBlkOrInst(CBot::CBotToken*&, CBot::CBotCStack*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotBlock.cpp:64
    #16 0x7ffff7306b67 in CBot::CBotListInstr::Compile(CBot::CBotToken*&, CBot::CBotCStack*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotListInstr.cpp:62
    #17 0x7ffff72adc3a in CBot::CBotBlock::Compile(CBot::CBotToken*&, CBot::CBotCStack*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotBlock.cpp:37
    #18 0x7ffff72e2a23 in CBot::CBotFunction::Compile(CBot::CBotToken*&, CBot::CBotCStack*, CBot::CBotFunction*, bool) /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotFunction.cpp:233
    #19 0x7ffff7320360 in CBot::CBotProgram::Compile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<char, std
::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, void*) /home/cdda/git/colobot/CBot/src/CBot
/CBotProgram.cpp:132
    #20 0x55555604ca67 in CScript::Compile() /home/cdda/git/colobot/colobot-base/src/script/script.cpp:239
    #21 0x55555604b68e in CScript::GetScript(Ui::CEdit*) /home/cdda/git/colobot/colobot-base/src/script/script.cpp:120
    #22 0x555555ca9df6 in Ui::CStudio::StopEditScript(bool) /home/cdda/git/colobot/colobot-base/src/ui/studio.cpp:915
    #23 0x555555c8b37d in Ui::CObjectInterface::StopEditScript(bool) /home/cdda/git/colobot/colobot-base/src/ui/object_interface.cpp:751
    #24 0x555555c85780 in Ui::CObjectInterface::EventProcess(Event const&) /home/cdda/git/colobot/colobot-base/src/ui/object_interface.cpp:270
    #25 0x555555b65538 in COldObject::EventProcess(Event const&) /home/cdda/git/colobot/colobot-base/src/object/old_object.cpp:2306
    #26 0x555555a344f6 in CRobotMain::EventObject(Event const&) /home/cdda/git/colobot/colobot-base/src/level/robotmain.cpp:2693
    #27 0x555555a24fc7 in CRobotMain::ProcessEvent(Event&) /home/cdda/git/colobot/colobot-base/src/level/robotmain.cpp:1160
    #28 0x55555573a10d in CController::ProcessEvent(Event&) /home/cdda/git/colobot/colobot-base/src/app/controller.cpp:53
    #29 0x5555556ee657 in CApplication::Run() /home/cdda/git/colobot/colobot-base/src/app/app.cpp:1169
    #30 0x5555556d5187 in main /home/cdda/git/colobot/colobot-app/src/main.cpp:173
    #31 0x7ffff699bd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #32 0x7ffff699be3f in __libc_start_main_impl ../csu/libc-start.c:392
    #33 0x5555556d4124 in _start (/home/cdda/git/colobot/build-asan/colobot+0x180124)

0x7ffff7403f2c is located 0 bytes to the right of global variable 'ListOp' defined in '/home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp:66:13' (0x7ffff7403e40) of size 236
SUMMARY: AddressSanitizer: global-buffer-overflow /home/cdda/git/colobot/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp:148 in CBot::CBotTwoOpExpr::Compile(CBot::CBotToken*&, CBot::CBotCStack*, 
int*, bool)
Shadow bytes around the buggy address:
  0x10007ee78790: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x10007ee787a0: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x10007ee787b0: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x10007ee787c0: f9 f9 f9 f9 f9 f9 f9 f9 00 00 00 00 00 00 00 00
  0x10007ee787d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x10007ee787e0: 00 00 00 00 00[04]f9 f9 f9 f9 f9 f9 00 00 00 00
  0x10007ee787f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10007ee78800: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x10007ee78810: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x10007ee78820: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x10007ee78830: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==91736==ABORTING
```

## Proposed solution

Recursion base case: if the parent expression was the highest precedence expression, parse CBotParExpr

## Alternative solution

```diff
diff --git a/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp b/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp
index ebbdefc1..03e51847 100644
--- a/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp
@@ -206,8 +206,11 @@ CBotInstr* CBotTwoOpExpr::Compile(CBotToken* &p, CBotCStack* pStack, int* pOpera
         p = p->GetNext();                                           // skip the token of the operation
 
         // looking statements that may be suitable for right
+        inst->m_rightop = (*pOp == 0) ?
+                        CBotParExpr::Compile(p, pStk, bConstExpr) :       // expression (...) left
+                        CBotTwoOpExpr::Compile(p, pStk, pOp, bConstExpr); // expression A * B left
 
-        if ( nullptr != (inst->m_rightop = CBotTwoOpExpr::Compile(p, pStk, pOp, bConstExpr)) )
+        if ( nullptr != inst->m_rightop )
                                                                 // expression (...) right
         {
             // there is an second operand acceptable
@@ -264,7 +267,9 @@ CBotInstr* CBotTwoOpExpr::Compile(CBotToken* &p, CBotCStack* pStack, int* pOpera
                     type1 = TypeRes;
 
                     p = p->GetNext();                                       // advance after
-                    i->m_rightop = CBotTwoOpExpr::Compile(p, pStk, pOp, bConstExpr);
+                    i->m_rightop = (*pOp == 0) ?
+                        CBotParExpr::Compile(p, pStk, bConstExpr) :       // expression (...) left
+                        CBotTwoOpExpr::Compile(p, pStk, pOp, bConstExpr); // expression A * B left
                     type2 = pStk->GetTypResult();
 
                     if ( !TypeCompatible (type1, type2, typeOp) )       // the results are compatible
```