### PR TITLE
Stable goto

### DIFF
--- a/colobot-base/src/app/app.cpp
+++ b/colobot-base/src/app/app.cpp
@@ -1031,6 +1031,11 @@ void CApplication::UpdateMouse()
     m_input->MouseMove(pos);
 }
 
+void CApplication::SetMsPerFrame(Uint32 ms)
+{
+    m_msPerFrame = ms;
+}
+
 int CApplication::Run()
 {
     m_active = true;
@@ -1045,8 +1050,16 @@ int CApplication::Run()
     TimeStamp currentTimeStamp{};
     TimeStamp interpolatedTimeStamp{};
 
+    Uint32 nextFrameStart = SDL_GetTicks();
     while (true)
     {
+        Sint32 diff = static_cast<Sint32>(nextFrameStart - SDL_GetTicks());
+        if(diff > 0)
+        {
+            SDL_Delay(diff);
+        }
+        nextFrameStart = SDL_GetTicks() + m_msPerFrame;
+
         if (m_active)
         {
             CProfiler::StartPerformanceCounter(PCNT_ALL);

--- a/colobot-base/src/app/app.h
+++ b/colobot-base/src/app/app.h
@@ -288,6 +288,8 @@ public:
     //! Stops a force feedback effect on the joystick
     void        StopForceFeedbackEffect();
 
+    void        SetMsPerFrame(Uint32 ms);
+
 protected:
     //! Creates the window's SDL_Surface
     bool CreateVideoSurface();
@@ -428,4 +430,6 @@ protected:
     inline static std::array<char, 64> m_languageLocale = { '\0' };
 
     std::map<int, bool> m_textInputEnabled;
+
+    Uint32 m_msPerFrame = 0;
 };

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -1535,6 +1535,20 @@ void CRobotMain::ExecuteCmd(const std::string& cmd)
         return;
     }
 
+    int fps;
+    if (sscanf(cmd.c_str(), "fps %d", &fps) > 0)
+    {
+        if (fps > 0)
+        {
+            m_app->SetMsPerFrame(1000 / fps);
+        }
+        else
+        {
+            m_app->SetMsPerFrame(0);  // No limit
+        }
+        return;
+    }
+
     if (m_phase == PHASE_SIMUL)
         m_displayText->DisplayError(ERR_CMD, glm::vec3(0.0f,0.0f,0.0f));
 }

--- a/colobot-base/src/object/task/taskgoto.cpp
+++ b/colobot-base/src/object/task/taskgoto.cpp
@@ -364,12 +364,6 @@ bool CTaskGoto::EventProcess(const Event &event)
         return true;
     }
 
-    if ( m_phase == TGP_LAND )  // landed?
-    {
-        m_physics->SetMotorSpeedY(-0.5f);  // tomb
-        return true;
-    }
-
     if ( m_goalMode == TGG_EXPRESS )
     {
         if ( m_crashMode == TGC_HALT )
@@ -383,6 +377,14 @@ bool CTaskGoto::EventProcess(const Event &event)
         }
 
         pos = m_object->GetPosition();
+
+        float dist = Math::DistanceProjected(m_goal, pos);
+        if ( dist < 10.0f && dist > m_lastDistance )
+        {
+            m_error = ERR_STOP;
+            return true;
+        }
+        m_lastDistance = dist;
 
         if ( m_altitude > 0.0f )
         {
@@ -409,6 +411,12 @@ bool CTaskGoto::EventProcess(const Event &event)
 
         m_physics->SetMotorSpeedZ(cirSpeed);  // turns left / right
         m_physics->SetMotorSpeedX(1.0f);  // advance
+        return true;
+    }
+
+    if ( m_phase == TGP_LAND )  // landed?
+    {
+        m_physics->SetMotorSpeedY(-0.5f);  // tomb
         return true;
     }
 
@@ -924,16 +932,6 @@ Error CTaskGoto::IsEnded()
             m_physics->SetMotorSpeedZ(0.0f);  // stops the rotation
             return ERR_STOP;
         }
-    }
-
-    if ( m_goalMode == TGG_EXPRESS )
-    {
-        dist = Math::DistanceProjected(m_goal, pos);
-        if ( dist < 10.0f && dist > m_lastDistance )
-        {
-            return ERR_STOP;
-        }
-        m_lastDistance = dist;
     }
 
     if ( m_phase == TGP_ADVANCE )  // going towards the goal?

--- a/colobot-base/src/object/task/taskgoto.cpp
+++ b/colobot-base/src/object/task/taskgoto.cpp
@@ -409,8 +409,9 @@ bool CTaskGoto::EventProcess(const Event &event)
         if ( cirSpeed >  1.0f )  cirSpeed =  1.0f;
         if ( cirSpeed < -1.0f )  cirSpeed = -1.0f;
 
+        float linSpeed = 1.0f-(1.0f-0.3f)*fabs(cirSpeed);
         m_physics->SetMotorSpeedZ(cirSpeed);  // turns left / right
-        m_physics->SetMotorSpeedX(1.0f);  // advance
+        m_physics->SetMotorSpeedX(linSpeed);  // advance
         return true;
     }
 

--- a/colobot-base/src/object/task/taskgoto.cpp
+++ b/colobot-base/src/object/task/taskgoto.cpp
@@ -378,8 +378,10 @@ bool CTaskGoto::EventProcess(const Event &event)
 
         pos = m_object->GetPosition();
 
+        float margin = 10.0f;
+        if ( m_object->Implements(ObjectInterfaceType::Flying) ) margin = 20.0f;
         float dist = Math::DistanceProjected(m_goal, pos);
-        if ( dist < 10.0f && dist > m_lastDistance )
+        if ( dist < margin && dist > m_lastDistance )
         {
             m_error = ERR_STOP;
             return true;

--- a/colobot-base/src/object/task/taskgoto.cpp
+++ b/colobot-base/src/object/task/taskgoto.cpp
@@ -816,7 +816,7 @@ Error CTaskGoto::IsEnded()
 {
     glm::vec3    pos;
     float       limit, angle = 0.0f, h, level;
-    volatile float dist; //fix for issue #844
+    float dist;
 
     if ( m_engine->GetPause() )  return ERR_CONTINUE;
     if ( m_error != ERR_OK )  return m_error;
@@ -929,9 +929,7 @@ Error CTaskGoto::IsEnded()
     if ( m_goalMode == TGG_EXPRESS )
     {
         dist = Math::DistanceProjected(m_goal, pos);
-        float margin = 10.0f;
-        if ( m_object->Implements(ObjectInterfaceType::Flying) ) margin = 20.0f;
-        if ( dist < margin && dist > m_lastDistance )
+        if ( dist < 10.0f && dist > m_lastDistance )
         {
             return ERR_STOP;
         }


### PR DESCRIPTION
* fixes #844

## Make goto numerically stable on 32 bit targets

* [Gcc handling of `float` on 32 bit platforms has some quirks](https://gcc.gnu.org/wiki/FloatingPointMath#Note_on_x86_and_m68080_floating-point_math)
* Edit: this caused a bug (see this comment: https://github.com/colobot/colobot/issues/844#issuecomment-2274193955)
* Edit: We hid the bug by using `volatile`, but did not know why `volatile` appeared to fix this - the mysterious use of `volatile` is what caused me to investigate
* I think `CTask::IsEnded()` should not be modifying instance variables because we rely on `CTask::IsEnded()` to not change its return value if called twice in a row. This is a small step in that direction - fixing one cause where modifying an instance variable caused a different value to be returned on a subsequent call.

### Test case

Completed mission 4-3 (System Failure) on a 32 bit platform with CMAKE_BUILD_TYPE=RelWithDebInfo

## Fix goto orbiting

`goto(position, altitude, 1, 1)` used to instruct the bot to apply full forward thrust even if it is facing more than 90 degrees away from the destination. This resulted in the bots sometimes endlessly orbiting the destination.

Fix: apply the same forward speed reduction that several other parts of CTaskGoto use.

### Test case 1

```c++
extern void object::New()
{
    point pos = this.position;

    goto(pos, pos.z, 1, 1);
}
```

### Test case 2

```c++
extern void object::WingedBot()
{
	point pos = position;
	pos.x += 10;
	turn(direction(pos));
	pos = position;
	pos.x -= 6;
	message("goto(");
	goto(pos, pos.z, 1, 1);
	message(")");
}
```

## Add a cheat to simulate low frames per second

* Added a new cheat code `fps <number>` to enable testing how the game handles low frames per second
* `fps 10` caps the frames per second at 10
* `fps 0` uncaps the fps

## Restore 5 meter margin for flying bots

When fps is low a bot may overshoot the destination and double back. This no longer gets the bot stuck in an infinite loop because I fixed the orbiting, but this makes the bot in the mission 4-3 (System Failure) run out of battery before completing the program if the game is running at 4 frames per second.

Fix: re-introduce the 5 meter margin for flying bots

### Test case

Completed mission 4-3 (System Failure) with 4 fps