### PR TITLE
Make public functions and classes in CBot not shared between teams

### DIFF
--- a/CBot/CMakeLists.txt
+++ b/CBot/CMakeLists.txt
@@ -133,6 +133,8 @@ target_sources(CBot PRIVATE
     src/CBot/CBotInstr/CBotWhile.h
     src/CBot/CBotProgram.cpp
     src/CBot/CBotProgram.h
+    src/CBot/CBotProgramGroup.cpp
+    src/CBot/CBotProgramGroup.h
     src/CBot/CBotStack.cpp
     src/CBot/CBotStack.h
     src/CBot/CBotToken.cpp

--- a/CBot/src/CBot/CBotCStack.cpp
+++ b/CBot/src/CBot/CBotCStack.cpp
@@ -406,7 +406,7 @@ bool CBotCStack::CheckCall(CBotToken* &pToken, CBotDefParam* pParam, const std::
         }
     }
 
-    for (CBotFunction* pp : CBotFunction::m_publicFunctions)
+    for (CBotFunction* pp : GetProgram()->GetPublicFunctions())
     {
         if ( name == pp->GetName() )
         {

--- a/CBot/src/CBot/CBotClass.cpp
+++ b/CBot/src/CBot/CBotClass.cpp
@@ -623,7 +623,6 @@ bool CBotClass::CompileDefItem(CBotToken* &p, CBotCStack* pStack, bool bSecond)
 
                     if ( f != nullptr )
                     {
-                        f->m_pProg = pStack->GetProgram();
                         f->m_bSynchro = bSynchro;
                     }
                     pStack->DeleteNext();

--- a/CBot/src/CBot/CBotInstr/CBotFunction.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotFunction.cpp
@@ -54,19 +54,12 @@ CBotFunction::CBotFunction(CBotProgram& prog):
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-std::set<CBotFunction*> CBotFunction::m_publicFunctions{};
-
-////////////////////////////////////////////////////////////////////////////////
 CBotFunction::~CBotFunction()
 {
     delete m_param;                // empty parameter list
     delete m_block;                // the instruction block
 
-    // remove public list if there is
-    if (m_bPublic)
-    {
-        m_publicFunctions.erase(this);
-    }
+    m_prog.RemovePublic(this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -503,6 +496,7 @@ void CBotFunction::RestoreState(CBotVar** ppVars, CBotStack* &pj, CBotVar* pInst
 ////////////////////////////////////////////////////////////////////////////////
 CBotTypResult CBotFunction::CompileCall(const std::string &name, CBotVar** ppVars, long &nIdent, CBotProgram* program)
 {
+    assert(program);
     CBotTypResult type;
     if (!FindLocalOrPublic(program->GetFunctions(), nIdent, name, ppVars, type, program))
     {
@@ -516,6 +510,7 @@ CBotTypResult CBotFunction::CompileCall(const std::string &name, CBotVar** ppVar
 CBotFunction* CBotFunction::FindLocalOrPublic(const std::list<CBotFunction*>& localFunctionList, long &nIdent, const std::string &name,
                                               CBotVar** ppVars, CBotTypResult &TypeOrError, CBotProgram* baseProg)
 {
+    assert(baseProg);
     TypeOrError.SetType(CBotErrUndefCall);      // no routine of the name
 
     if ( nIdent )
@@ -530,7 +525,7 @@ CBotFunction* CBotFunction::FindLocalOrPublic(const std::list<CBotFunction*>& lo
         }
 
         // search the list of public functions
-        for (CBotFunction* pt : m_publicFunctions)
+        for (CBotFunction* pt : baseProg->GetPublicFunctions())
         {
             if (pt->m_nFuncIdent == nIdent)
             {
@@ -546,14 +541,14 @@ CBotFunction* CBotFunction::FindLocalOrPublic(const std::list<CBotFunction*>& lo
 
     CBotFunction::SearchList(localFunctionList, name, ppVars, TypeOrError, funcMap);
 
-    CBotFunction::SearchPublic(name, ppVars, TypeOrError, funcMap);
+    CBotFunction::SearchPublic(name, ppVars, TypeOrError, funcMap, nullptr, baseProg);
 
-    if (baseProg != nullptr && baseProg->m_thisVar != nullptr)
+    if (baseProg->m_thisVar != nullptr)
     {
         // find object:: functions
         CBotClass* pClass = baseProg->m_thisVar->GetClass();
         CBotFunction::SearchList(localFunctionList, name, ppVars, TypeOrError, funcMap, pClass);
-        CBotFunction::SearchPublic(name, ppVars, TypeOrError, funcMap, pClass);
+        CBotFunction::SearchPublic(name, ppVars, TypeOrError, funcMap, pClass, baseProg);
     }
 
     return CBotFunction::BestFunction(funcMap, nIdent, TypeOrError);
@@ -637,10 +632,11 @@ void CBotFunction::SearchList(const std::list<CBotFunction*>& functionList,
 
 ////////////////////////////////////////////////////////////////////////////////
 void CBotFunction::SearchPublic(const std::string& name, CBotVar** ppVars, CBotTypResult& TypeOrError,
-                                std::map<CBotFunction*, int>& funcMap, CBotClass* pClass)
+                                std::map<CBotFunction*, int>& funcMap, CBotClass* pClass, CBotProgram* program)
 {
+    assert(program);
     {
-        for (CBotFunction* pt : m_publicFunctions)
+        for (CBotFunction* pt : program->GetPublicFunctions())
         {
             if ( pt->m_token.GetString() == name )
             {
@@ -750,6 +746,7 @@ int CBotFunction::DoCall(CBotProgram* program, const std::list<CBotFunction*>& l
     CBotTypResult   type;
     CBotFunction*   pt = nullptr;
     CBotProgram*    baseProg = pStack->GetProgram(true);
+    assert(baseProg);
 
     pt = FindLocalOrPublic(localFunctionList, nIdent, name, ppVars, type, baseProg);
 
@@ -841,6 +838,7 @@ void CBotFunction::RestoreCall(const std::list<CBotFunction*>& localFunctionList
     CBotStack*      pStk1;
     CBotStack*      pStk3;
     CBotProgram*    baseProg = pStack->GetProgram(true);
+    assert(baseProg);
 
     pt = FindLocalOrPublic(localFunctionList, nIdent, name, ppVars, type, baseProg);
 
@@ -973,19 +971,19 @@ CBotFunction* CBotFunction::FindMethod(long& nIdent, const std::string& name,
                     return pt;
                 }
             }
-        }
 
-        // search the list of public functions
-        if (!skipPublic)
-        {
-            for (CBotFunction* pt : m_publicFunctions)
+            // search the list of public functions
+            if (!skipPublic)
             {
-                if (pt->m_nFuncIdent == nIdent)
+                for (CBotFunction* pt : program->GetPublicFunctions())
                 {
-                    // check if the method is inherited, break in case there is an override
-                    if ( pt->GetClassName() != pClass->GetName() ) break;
-                    TypeOrError = pt->m_retTyp;
-                    return pt;
+                    if (pt->m_nFuncIdent == nIdent)
+                    {
+                        // check if the method is inherited, break in case there is an override
+                        if ( pt->GetClassName() != pClass->GetName() ) break;
+                        TypeOrError = pt->m_retTyp;
+                        return pt;
+                    }
                 }
             }
         }
@@ -1000,9 +998,10 @@ CBotFunction* CBotFunction::FindMethod(long& nIdent, const std::string& name,
 
     // search the current program for methods
     if (program != nullptr)
+    {
         CBotFunction::SearchList(program->GetFunctions(), name, ppVars, TypeOrError, funcMap, pClass);
-
-    CBotFunction::SearchPublic(name, ppVars, TypeOrError, funcMap, pClass);
+        CBotFunction::SearchPublic(name, ppVars, TypeOrError, funcMap, pClass, program);
+    }
 
     return CBotFunction::BestFunction(funcMap, nIdent, TypeOrError);
 }
@@ -1211,11 +1210,6 @@ const std::string& CBotFunction::GetClassName() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void CBotFunction::AddPublic(CBotFunction* func)
-{
-    m_publicFunctions.insert(func);
-}
-
 bool CBotFunction::HasReturn()
 {
     if (m_block != nullptr) return m_block->HasReturn();

--- a/CBot/src/CBot/CBotInstr/CBotFunction.h
+++ b/CBot/src/CBot/CBotInstr/CBotFunction.h
@@ -42,7 +42,7 @@ namespace CBot
 class CBotFunction : public CBotInstr
 {
 public:
-    CBotFunction();
+    CBotFunction(CBotProgram& prog);
     ~CBotFunction();
 
     /*!
@@ -350,7 +350,7 @@ private:
     std::string m_MasterClass;
     //! Token of the class we are part of
     CBotToken m_classToken;
-    CBotProgram* m_pProg;
+    CBotProgram& m_prog;
     //! For the position of the word "extern".
     CBotToken m_extern;
     CBotToken m_openpar;

--- a/CBot/src/CBot/CBotInstr/CBotFunction.h
+++ b/CBot/src/CBot/CBotInstr/CBotFunction.h
@@ -146,17 +146,6 @@ public:
                            std::map<CBotFunction*, int>& funcMap, CBotClass* pClass = nullptr);
 
     /*!
-     * \brief Find all public functions that match the name and arguments.
-     * \param name Name of the function to find.
-     * \param ppVars Arguments to compare with parameters.
-     * \param TypeOrError Contains a CBotError when no useable function has been found.
-     * \param funcMap Container for suitable functions and their signature values.
-     * \param pClass Pointer to class when searching for methods.
-     */
-    static void SearchPublic(const std::string& name, CBotVar** ppVars, CBotTypResult& TypeOrError,
-                             std::map<CBotFunction*, int>& funcMap, CBotClass* pClass = nullptr);
-
-    /*!
      * \brief Find the function with the lowest signature value. If there is more
      * than one of the same signature value, TypeOrError is set to CBotErrAmbiguousCall.
      * \param funcMap List of functions and their signature values, can be empty.
@@ -254,12 +243,6 @@ public:
     bool CheckParam(CBotDefParam* pParam);
 
     /*!
-     * \brief AddPublic
-     * \param pfunc
-     */
-    static void AddPublic(CBotFunction* pfunc);
-
-    /*!
      * \brief GetName
      * \return
      */
@@ -325,6 +308,17 @@ protected:
     virtual std::map<std::string, CBotInstr*> GetDebugLinks() override;
 
 private:
+    /*!
+     * \brief Find all public functions that match the name and arguments.
+     * \param name Name of the function to find.
+     * \param ppVars Arguments to compare with parameters.
+     * \param TypeOrError Contains a CBotError when no useable function has been found.
+     * \param funcMap Container for suitable functions and their signature values.
+     * \param pClass Pointer to class when searching for methods.
+     */
+    static void SearchPublic(const std::string& name, CBotVar** ppVars, CBotTypResult& TypeOrError,
+                             std::map<CBotFunction*, int>& funcMap, CBotClass* pClass, CBotProgram* program);
+
     friend class CBotDebug;
     long m_nFuncIdent;
     //! Synchronized method.
@@ -357,9 +351,6 @@ private:
     CBotToken m_closepar;
     CBotToken m_openblk;
     CBotToken m_closeblk;
-
-    //! List of public functions
-    static std::set<CBotFunction*> m_publicFunctions;
 
     friend class CBotProgram;
     friend class CBotClass;

--- a/CBot/src/CBot/CBotProgram.cpp
+++ b/CBot/src/CBot/CBotProgram.cpp
@@ -127,7 +127,6 @@ bool CBotProgram::Compile(const std::string& program, std::vector<std::string>& 
             CBotFunction::Compile(p, pStack.get(), *next);
             if ((*next)->IsExtern()) externFunctions.push_back((*next)->GetName()/* + next->GetParams()*/);
             if ((*next)->IsPublic()) CBotFunction::AddPublic(*next);
-            (*next)->m_pProg = this;                           // keeps pointers to the module
             ++next;
         }
     }

--- a/CBot/src/CBot/CBotProgram.cpp
+++ b/CBot/src/CBot/CBotProgram.cpp
@@ -47,12 +47,11 @@ CBotProgram::CBotProgram(CBotVar* thisVar)
 
 CBotProgram::~CBotProgram()
 {
-//  delete  m_classes;
+    Stop();
+
     for (CBotClass* c : m_classes)
         c->Purge();
     m_classes.clear();
-
-    CBotClass::FreeLock(this);
 
     for (CBotFunction* f : m_functions) delete f;
     m_functions.clear();

--- a/CBot/src/CBot/CBotProgram.cpp
+++ b/CBot/src/CBot/CBotProgram.cpp
@@ -24,6 +24,7 @@
 #include "CBot/CBotCStack.h"
 #include "CBot/CBotClass.h"
 #include "CBot/CBotUtils.h"
+#include "CBot/CBotProgramGroup.h"
 
 #include "CBot/CBotInstr/CBotFunction.h"
 
@@ -36,8 +37,8 @@ namespace CBot
 
 std::unique_ptr<CBotExternalCallList> CBotProgram::m_externalCalls;
 
-CBotProgram::CBotProgram(CBotVar* thisVar)
-: m_thisVar(thisVar)
+CBotProgram::CBotProgram(CBotVar* thisVar, CBotProgramGroup& group)
+: m_thisVar(thisVar), m_group(group)
 {
 }
 
@@ -126,7 +127,7 @@ bool CBotProgram::Compile(const std::string& program, std::vector<std::string>& 
         {
             CBotFunction::Compile(p, pStack.get(), *next);
             if ((*next)->IsExtern()) externFunctions.push_back((*next)->GetName()/* + next->GetParams()*/);
-            if ((*next)->IsPublic()) CBotFunction::AddPublic(*next);
+            if ((*next)->IsPublic()) m_group.AddPublic(*next);
             ++next;
         }
     }
@@ -415,6 +416,17 @@ void CBotProgram::Free()
 const std::unique_ptr<CBotExternalCallList>& CBotProgram::GetExternalCalls()
 {
     return m_externalCalls;
+}
+
+
+const std::set<CBotFunction*>& CBotProgram::GetPublicFunctions() const
+{
+    return m_group.GetPublicFunctions();
+}
+
+void CBotProgram::RemovePublic(CBotFunction* func)
+{
+    m_group.RemovePublic(func);
 }
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotProgram.cpp
+++ b/CBot/src/CBot/CBotProgram.cpp
@@ -36,10 +36,6 @@ namespace CBot
 
 std::unique_ptr<CBotExternalCallList> CBotProgram::m_externalCalls;
 
-CBotProgram::CBotProgram()
-{
-}
-
 CBotProgram::CBotProgram(CBotVar* thisVar)
 : m_thisVar(thisVar)
 {

--- a/CBot/src/CBot/CBotProgram.h
+++ b/CBot/src/CBot/CBotProgram.h
@@ -86,16 +86,6 @@ class CBotExternalCallList;
 class CBotProgram
 {
 public:
-    /**
-     * \brief Constructor
-     */
-    CBotProgram();
-
-    /**
-     * \brief Constructor
-     * \param thisVar Variable to pass to the program as "this"
-     */
-    CBotProgram(CBotVar* thisVar);
 
     /**
      * \brief Destructor
@@ -332,6 +322,13 @@ public:
     static const std::unique_ptr<CBotExternalCallList>& GetExternalCalls();
 
 private:
+    /**
+     * \brief Constructor
+     * \param thisVar Variable to pass to the program as "this"
+     */
+    CBotProgram(CBotVar* thisVar);
+private:
+
     //! All external calls
     static std::unique_ptr<CBotExternalCallList> m_externalCalls;
     //! All user-defined functions
@@ -346,6 +343,7 @@ private:
     CBotVar* m_thisVar = nullptr;
     friend class CBotFunction;
     friend class CBotDebug;
+    friend class CBotProgramGroup;
 
     CBotError m_error = CBotNoErr;
     int m_errorStart = 0;

--- a/CBot/src/CBot/CBotProgram.h
+++ b/CBot/src/CBot/CBotProgram.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <set>
 
 namespace CBot
 {
@@ -35,6 +36,7 @@ class CBotStack;
 class CBotTypResult;
 class CBotVar;
 class CBotExternalCallList;
+class CBotProgramGroup;
 
 /**
  * \brief Class that manages a CBot program. This is the main entry point into the CBot engine.
@@ -326,8 +328,14 @@ private:
      * \brief Constructor
      * \param thisVar Variable to pass to the program as "this"
      */
-    CBotProgram(CBotVar* thisVar);
-private:
+    CBotProgram(CBotVar* thisVar, CBotProgramGroup& group);
+
+    /**
+     * \brief Returns all public functions in the program group that contains this program
+     */
+    const std::set<CBotFunction*>& GetPublicFunctions() const;
+
+    void RemovePublic(CBotFunction* func);
 
     //! All external calls
     static std::unique_ptr<CBotExternalCallList> m_externalCalls;
@@ -344,10 +352,12 @@ private:
     friend class CBotFunction;
     friend class CBotDebug;
     friend class CBotProgramGroup;
+    friend class CBotCStack;
 
     CBotError m_error = CBotNoErr;
     int m_errorStart = 0;
     int m_errorEnd = 0;
+    CBotProgramGroup& m_group;
 };
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotProgramGroup.cpp
+++ b/CBot/src/CBot/CBotProgramGroup.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Colobot: Gold Edition source code
- * Copyright (C) 2001-2023, Daniel Roux, EPSITEC SA & TerranovaTeam
- * http://epsitec.ch; http://colobot.info; http://github.com/colobot
+ * Copyright (C) 2024 TerranovaTeam
+ * http://colobot.info; http://github.com/colobot
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,19 +17,16 @@
  * along with this program. If not, see http://gnu.org/licenses
  */
 
-/*!
- * \file CBot.h
- * \brief Public interface of CBot language interpreter. CBot.h is the only file
- * that should be included by any Colobot files outside of the CBot module.
- */
-
-#include "CBot/CBotFileUtils.h"
-#include "CBot/CBotClass.h"
-#include "CBot/CBotToken.h"
-#include "CBot/CBotProgram.h"
 #include "CBot/CBotProgramGroup.h"
-#include "CBot/CBotTypResult.h"
+#include "CBot/CBotProgram.h"
 
-#include "CBot/CBotVar/CBotVar.h"
+namespace CBot
+{
 
-#include "CBot/stdlib/stdlib_public.h"
+std::unique_ptr<CBotProgram> CBotProgramGroup::AddProgram(CBotVar* thisVar)
+{
+    return std::unique_ptr<CBotProgram>(new CBotProgram(thisVar));
+}
+
+} // namespace CBot
+

--- a/CBot/src/CBot/CBotProgramGroup.cpp
+++ b/CBot/src/CBot/CBotProgramGroup.cpp
@@ -25,7 +25,22 @@ namespace CBot
 
 std::unique_ptr<CBotProgram> CBotProgramGroup::AddProgram(CBotVar* thisVar)
 {
-    return std::unique_ptr<CBotProgram>(new CBotProgram(thisVar));
+    return std::unique_ptr<CBotProgram>(new CBotProgram(thisVar, *this));
+}
+
+const std::set<CBotFunction*>& CBotProgramGroup::GetPublicFunctions() const
+{
+    return m_publicFunctions;
+}
+
+void CBotProgramGroup::AddPublic(CBotFunction* func)
+{
+    m_publicFunctions.insert(func);
+}
+
+void CBotProgramGroup::RemovePublic(CBotFunction* func)
+{
+    m_publicFunctions.erase(func);
 }
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotProgramGroup.h
+++ b/CBot/src/CBot/CBotProgramGroup.h
@@ -21,17 +21,27 @@
 
 #include <memory>
 #include <string>
+#include <set>
 
 namespace CBot
 {
 
 class CBotProgram;
 class CBotVar;
+class CBotFunction;
 
 class CBotProgramGroup
 {
 public:
     std::unique_ptr<CBotProgram> AddProgram(CBotVar* thisVar);
+
+private:
+    const std::set<CBotFunction*>& GetPublicFunctions() const;
+    void AddPublic(CBotFunction* func);
+    void RemovePublic(CBotFunction* func);
+    friend class CBotProgram;
+
+    std::set<CBotFunction*> m_publicFunctions;
 };
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotProgramGroup.h
+++ b/CBot/src/CBot/CBotProgramGroup.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Colobot: Gold Edition source code
- * Copyright (C) 2001-2023, Daniel Roux, EPSITEC SA & TerranovaTeam
- * http://epsitec.ch; http://colobot.info; http://github.com/colobot
+ * Copyright (C) 2024 TerranovaTeam
+ * http://colobot.info; http://github.com/colobot
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,19 +17,21 @@
  * along with this program. If not, see http://gnu.org/licenses
  */
 
-/*!
- * \file CBot.h
- * \brief Public interface of CBot language interpreter. CBot.h is the only file
- * that should be included by any Colobot files outside of the CBot module.
- */
+#pragma once
 
-#include "CBot/CBotFileUtils.h"
-#include "CBot/CBotClass.h"
-#include "CBot/CBotToken.h"
-#include "CBot/CBotProgram.h"
-#include "CBot/CBotProgramGroup.h"
-#include "CBot/CBotTypResult.h"
+#include <memory>
+#include <string>
 
-#include "CBot/CBotVar/CBotVar.h"
+namespace CBot
+{
 
-#include "CBot/stdlib/stdlib_public.h"
+class CBotProgram;
+class CBotVar;
+
+class CBotProgramGroup
+{
+public:
+    std::unique_ptr<CBotProgram> AddProgram(CBotVar* thisVar);
+};
+
+} // namespace CBot

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -6353,3 +6353,13 @@ std::set<int> CRobotMain::GetAllActiveTeams()
     }
     return teams;
 }
+
+CBot::CBotProgramGroup& CRobotMain::GetRefereeGroup()
+{
+    return m_refereeGroup;
+}
+
+CBot::CBotProgramGroup& CRobotMain::GetTeamGroup(int team)
+{
+    return m_progGroups[team];
+}

--- a/colobot-base/src/level/robotmain.h
+++ b/colobot-base/src/level/robotmain.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include "CBot/CBot.h"
+
 #include "app/pausemanager.h"
 
 #include "common/error.h"
@@ -515,6 +517,9 @@ public:
     //! Returns a set of all team IDs in the current level that are still active
     std::set<int> GetAllActiveTeams();
 
+    CBot::CBotProgramGroup& GetRefereeGroup();
+    CBot::CBotProgramGroup& GetTeamGroup(int team);
+
 protected:
     bool        EventFrame(const Event &event);
     bool        EventObject(const Event &event);
@@ -767,4 +772,7 @@ protected:
 
     //! Vector of available viewpoints
     std::vector<Viewpoint> m_viewpoints;
+
+    CBot::CBotProgramGroup m_refereeGroup;
+    std::map<int, CBot::CBotProgramGroup>  m_progGroups;
 };

--- a/colobot-base/src/level/robotmain.h
+++ b/colobot-base/src/level/robotmain.h
@@ -595,6 +595,8 @@ protected:
     Gfx::CLightManager* m_lightMan = nullptr;
     CSoundInterface*    m_sound = nullptr;
     CInput*             m_input = nullptr;
+    CBot::CBotProgramGroup m_refereeGroup;  // CBotProgramGroup must outlive CObjectManager
+    std::map<int, CBot::CBotProgramGroup>  m_progGroups;  // CBotProgramGroup must outlive CObjectManager
     std::unique_ptr<CObjectManager> m_objMan;
     std::unique_ptr<CMainMovie> m_movie;
     std::unique_ptr<CPauseManager> m_pause;
@@ -772,7 +774,4 @@ protected:
 
     //! Vector of available viewpoints
     std::vector<Viewpoint> m_viewpoints;
-
-    CBot::CBotProgramGroup m_refereeGroup;
-    std::map<int, CBot::CBotProgramGroup>  m_progGroups;
 };

--- a/colobot-base/src/object/old_object.cpp
+++ b/colobot-base/src/object/old_object.cpp
@@ -3479,7 +3479,8 @@ bool COldObject::IsSelectableByDefault(ObjectType type)
          type == OBJECT_ANT      ||
          type == OBJECT_SPIDER   ||
          type == OBJECT_BEE      ||
-         type == OBJECT_WORM     )
+         type == OBJECT_WORM     ||
+         type == OBJECT_CONTROLLER )
     {
         return false;
     }

--- a/colobot-base/src/script/script.cpp
+++ b/colobot-base/src/script/script.cpp
@@ -233,7 +233,14 @@ bool CScript::Compile()
 
     if (m_botProg == nullptr)
     {
-        m_botProg = std::make_unique<CBot::CBotProgram>(m_object->GetBotVar());
+        if (m_object->GetSelectable())
+        {
+            m_botProg = m_main->GetTeamGroup(m_object->GetTeam()).AddProgram(m_object->GetBotVar());
+        }
+        else
+        {
+            m_botProg = m_main->GetRefereeGroup().AddProgram(m_object->GetBotVar());
+        }
     }
 
     if ( m_botProg->Compile(m_script, functionList, this) )

--- a/test/src/CBot/CBot_test.cpp
+++ b/test/src/CBot/CBot_test.cpp
@@ -224,7 +224,7 @@ protected:
         CBotError expectedCompileError = expectedError < 6000 ? expectedError : CBotNoErr;
         CBotError expectedRuntimeError = expectedError >= 6000 ? expectedError : CBotNoErr;
 
-        auto program = std::unique_ptr<CBotProgram>(new CBotProgram());
+        auto program = m_progGroup.AddProgram(nullptr);
         std::vector<std::string> tests;
         program->Compile(code, tests);
 
@@ -318,6 +318,9 @@ protected:
         }
         return program; // Take it if you want, destroy on exit otherwise
     }
+
+private:
+    CBotProgramGroup m_progGroup;
 };
 
 TEST_F(CBotUT, EmptyTest)

--- a/tools/cbot-console/src/console.cpp
+++ b/tools/cbot-console/src/console.cpp
@@ -69,10 +69,11 @@ int main(int argc, char* argv[])
     // Error message strings are stored on Colobot side (meh!) so let's initialize that
     InitializeRestext();
 
+    CBotProgramGroup progGroup;
 
     // Compile the program
     std::vector<std::string> externFunctions;
-    std::unique_ptr<CBotProgram> program{new CBotProgram(nullptr)};
+    std::unique_ptr<CBotProgram> program = progGroup.AddProgram(nullptr);
     if (!program->Compile(code.c_str(), externFunctions, nullptr))
     {
         CBotError error;

--- a/tools/cbot-graph/src/compile_graph.cpp
+++ b/tools/cbot-graph/src/compile_graph.cpp
@@ -55,9 +55,11 @@ int main(int argc, char* argv[])
     // Initialize the CBot engine
     CBotProgram::Init();
 
+    CBotProgramGroup progGroup;
+
     // Compile the program
     std::vector<std::string> externFunctions;
-    std::unique_ptr<CBotProgram> program{new CBotProgram(nullptr)};
+    std::unique_ptr<CBotProgram> program = progGroup.AddProgram(nullptr);
     if (!program->Compile(code.c_str(), externFunctions, nullptr))
     {
         CBotError error;


### PR DESCRIPTION
* Fixes #526

All public functions and classes used to live in one shared namespace. This caused many issues including:
* Two teams in a codebattle could not define a public function with the same name.
* A public function defined in an alien could be called by a robot

Solution:
* In a codebattle each team should  have its own namespace
* Every bot or alien that the player can't control should be in a namespace separate from the player-controlled teams

- [x] Make public functions not shared
- [ ] Make public classes not shared