### PR TITLE
Fix proxyActivate on objects with a power cell

### DIFF
--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -2029,13 +2029,14 @@ CObject* CRobotMain::DetectObject(const glm::vec2& pos)
     for (CObject* obj : m_objMan->GetAllObjects())
     {
         if (!obj->GetDetectable()) continue;
+        if (obj->GetProxyActivate()) continue;
 
         CObject* transporter = nullptr;
         if (obj->Implements(ObjectInterfaceType::Transportable))
             transporter = dynamic_cast<CTransportableObject&>(*obj).GetTransporter();
 
         if (transporter != nullptr && !transporter->GetDetectable()) continue;
-        if (obj->GetProxyActivate()) continue;
+        if (transporter != nullptr && transporter->GetProxyActivate()) continue;
 
         CObject* target = obj;
         // TODO: should this also apply to slots other than power cell slots?


### PR DESCRIPTION
* Fixes #1175

Mousing over and clicking an object taht has a power cell used to bypass proxyActivate=1