### PR TITLE
Fix power=0

### DIFF
--- a/colobot-base/src/object/motion/motionvehicle.cpp
+++ b/colobot-base/src/object/motion/motionvehicle.cpp
@@ -1057,7 +1057,7 @@ void CMotionVehicle::Create(glm::vec3 pos, float angle, ObjectType type,
     CreatePhysics(type);
     m_object->SetFloorHeight(0.0f);
 
-    if (power > 0.0f            &&
+    if (power >= 0.0f           &&
         type != OBJECT_MOBILEdr &&
         type != OBJECT_APOLLO2)
     {


### PR DESCRIPTION
* Fixes #1070
* See also #1725

[The documentation says that power=0 is supposed to result in an empty power cell](https://colobot.info/files/old/original/colobotusere.pdf), but the game was spawning no power cell instead 

![image](https://github.com/user-attachments/assets/2315d307-8df7-49ae-9cfc-b1b9464b0dd0)

Now power=0 causes a bot to spawn with an empty power cell