### PR TITLE
Do not notify the player of discovered dying objects

### DIFF
--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -2421,7 +2421,8 @@ bool CRobotMain::EventFrame(const Event &event)
             {
                 glm::vec3 eye = m_engine->GetLookatPt();
                 float dist = glm::distance(eye, obj->GetPosition());
-                if ( dist < obj->GetProxyDistance() )
+                bool isDying = obj->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject&>(*obj).IsDying();
+                if ( dist < obj->GetProxyDistance() && !isDying )
                 {
                     obj->SetProxyActivate(false);
                     CreateShortcuts();


### PR DESCRIPTION
* Fix #1091

An object is only completely removed after its death animation finishes playing. It used to be possible to get a "You found a usable object" notification about an object that is dying.