### PR TITLE
Fix incorrect file name in CEngine::DeleteAllGroundSpots()

### DIFF
--- a/colobot-base/src/graphics/engine/engine.cpp
+++ b/colobot-base/src/graphics/engine/engine.cpp
@@ -1348,7 +1348,7 @@ void CEngine::DeleteAllGroundSpots()
         shadowImg.Fill(Gfx::IntColor(255, 255, 255, 255));
 
         std::stringstream str;
-        str << "shadow" << std::setfill('0') << std::setw(2) << s << ".png";
+        str << "textures/shadow" << std::setfill('0') << std::setw(2) << s << ".png";
         std::string texName = str.str();
 
         CreateOrUpdateTexture(texName, &shadowImg);


### PR DESCRIPTION
7131abd made LoadTexture require full path with "textures/" directory, but forgot to add textures/ in DeleteAllGroundSpots()

* Fix #1280
* Fix #976