### PR TITLE
Fix Couldn't load texture 'textures/interface/human.png'

### DIFF
--- a/colobot-base/src/ui/controls/window.cpp
+++ b/colobot-base/src/ui/controls/window.cpp
@@ -986,7 +986,7 @@ void CWindow::DrawVertex(const glm::vec2& position, const glm::vec2& dimension, 
         dim.x += 100.0f/640.0f;
         dim.y +=  60.0f/480.0f;
 
-        auto texture = m_engine->LoadTexture("textures/interface/human.png");
+        auto texture = m_engine->LoadTexture("textures/objects/human.png");
         renderer->SetTexture(texture);
         renderer->SetTransparency(Gfx::TransparencyMode::NONE);
         uv1.x = 140.0f/256.0f;


### PR DESCRIPTION
The SatCom interface is drawn on the background taken from the astronaut texture

The texture name used to be correct: "textures/objects/human.png", but then it was changed first to "textures/object/human.png" and then to "textures/interface/human.png". Neither file exists. This was causing errors:

```
[ERROR]: Error opening file with PHYSFS: "textures/interface/human.png"
[ERROR]: Couldn't load texture 'textures/interface/human.png': Unable to open file, blacklisting
```

```diff
commit 465fe59dfbd60ffa22610958420c24a835712d3c
Author: Tomasz Kapuściński <tomaszkax86@gmail.com>
Date:   Wed Jun 16 02:33:15 2021 +0200

    Added Renderers
    Added UI Renderer
    Added OpenGL 3.3 UI Renderer
    Reimplemented most of UI drawing functionality to use UI Renderer
    TODO: fix OpenGL errors

diff --git a/src/ui/controls/window.cpp b/src/ui/controls/window.cpp
--- a/src/ui/controls/window.cpp
+++ b/src/ui/controls/window.cpp
@@ -965,3 +975,3 @@
 
-        m_engine->SetTexture("textures/objects/human.png");
+        m_engine->SetUITexture("textures/object/human.png");
         m_engine->SetState(Gfx::ENG_RSTATE_NORMAL);

commit 1a190b7f6f1e32662d55ea6ed219aed91060c203
Author: Tomasz Kapuściński <tomaszkax86@gmail.com>
Date:   Thu Feb 3 18:40:58 2022 +0100

    Partial refactor of UI rendering to improve performance and fix transparency issues
    Disabled rendering via CDevice

diff --git a/src/ui/controls/window.cpp b/src/ui/controls/window.cpp
--- a/src/ui/controls/window.cpp
+++ b/src/ui/controls/window.cpp
@@ -976,3 +982,3 @@
 
-        m_engine->SetUITexture("textures/object/human.png");
-        m_engine->SetState(Gfx::ENG_RSTATE_NORMAL);
+        auto texture = m_engine->LoadTexture("textures/interface/human.png");
+        renderer->SetTexture(texture);
```