### PR TITLE
Make AlienNest destroyable by shooters

### DIFF
--- a/colobot-base/src/object/old_object.cpp
+++ b/colobot-base/src/object/old_object.cpp
@@ -871,6 +871,7 @@ void COldObject::SetType(ObjectType type)
          m_type == OBJECT_LABO     ||
          m_type == OBJECT_NUCLEAR  ||
          m_type == OBJECT_PARA     ||
+         m_type == OBJECT_NEST     ||
          m_type == OBJECT_MOTHER    )
     {
         m_implementedInterfaces[static_cast<int>(ObjectInterfaceType::Damageable)] = true;


### PR DESCRIPTION
* Fix #588
* Fix #1343

Make it possible to destroy an AlienNest by shooting at it. Previously you could only destroy a nest by activating a thumper directly on top of it. Alien nests now have the same amount of hit points as a bot or a building (the default amount of HP that everything in the game except for the astronaut has). This makes them quite tough. In my testing a regular shooter drains somewhere between two and three regular batteries before the nest is destroyed.

## Notes for map makers
1. You can make a nest invulnerable by using `magnifyDamage=0` (same as any other object):
    ```
    CreateObject type=AlienNest magnifyDamage=0 ...
    ```
    Note that Thumper currently bypasses the invulnerability, but this may change. See #1741
2. You can make a nest easier to destroy (magnifyDamage is a damage multiplier)
    ```
    // Example: takes somewhere between 2 and 3 shots from a regular shooter (2 seconds per shot)
    CreateObject type=AlienNest magnifyDamage=5 ...
    // Dies very quickly
    CreateObject type=AlienNest magnifyDamage=100 ...
    ```
3. If you keep the default damage multiplier of 1, you should probably include a feedback mechanism - some way for the player to know that they are doing damage. For example you could add the following script as a LevelController:
    ```c++
    extern void DisplayNestHp()
    {
    	object nest = radar(AlienNest); // Assumes there is only one nest
    	float prevShieldLevel = nest.shieldLevel;
    	while(nest != null and not nest.dead)
    	{
    		if(prevShieldLevel > nest.shieldLevel)
    		{
    			message("AlienNest HP: " + nest.shieldLevel);
    		}
    		prevShieldLevel = nest.shieldLevel;
    		wait(1);
    	}
    	message("AlienNest destroyed");
    }
    ```