### PR TITLE
Fix -Wmaybe-uninitialized

### DIFF
--- a/colobot-base/src/graphics/engine/particle.cpp
+++ b/colobot-base/src/graphics/engine/particle.cpp
@@ -794,11 +794,11 @@ void CParticle::FrameParticle(float rTime)
     glm::vec3 wind = m_terrain->GetWind();
     glm::vec3 eye = m_engine->GetEyePt();
 
-    glm::vec2 ts, ti;
     glm::vec3 pos = { 0, 0, 0 };
 
     for (int i = 0; i < MAXPARTICULE*MAXPARTITYPE; i++)
     {
+        glm::vec2 ts(0), ti(0);
         if (!m_particle[i].used) continue;
         if (!m_frameUpdate[m_particle[i].sheet]) continue;
 
@@ -2876,32 +2876,25 @@ void CParticle::DrawParticleFog(int i)
     if (m_particle[i].intensity == 0.0f) return;
 
     glm::vec3 pos = m_particle[i].pos;
-
-    glm::vec2 dim;
-    dim.x = m_particle[i].dim.x;
-    dim.y = m_particle[i].dim.y;
-
-    glm::vec2 zoom;
+    glm::vec2 dim = m_particle[i].dim;
 
     if ( m_particle[i].type == PARTIFOG0 ||
          m_particle[i].type == PARTIFOG2 ||
          m_particle[i].type == PARTIFOG4 ||
          m_particle[i].type == PARTIFOG6 )
     {
-        zoom.x = 1.0f+sinf(m_particle[i].zoom*2.0f)/6.0f;
-        zoom.y = 1.0f+cosf(m_particle[i].zoom*2.7f)/6.0f;
+        dim.x *= 1.0f+sinf(m_particle[i].zoom*2.0f)/6.0f;
+        dim.y *= 1.0f+cosf(m_particle[i].zoom*2.7f)/6.0f;
     }
     if ( m_particle[i].type == PARTIFOG1 ||
          m_particle[i].type == PARTIFOG3 ||
          m_particle[i].type == PARTIFOG5 ||
          m_particle[i].type == PARTIFOG7 )
     {
-        zoom.x = 1.0f+sinf(m_particle[i].zoom*3.0f)/6.0f;
-        zoom.y = 1.0f+cosf(m_particle[i].zoom*3.7f)/6.0f;
+        dim.x *= 1.0f+sinf(m_particle[i].zoom*3.0f)/6.0f;
+        dim.y *= 1.0f+cosf(m_particle[i].zoom*3.7f)/6.0f;
     }
 
-    dim.x *= zoom.x;
-    dim.y *= zoom.y;
 
     CObject* object = m_particle[i].objLink;
     if (object != nullptr)


### PR DESCRIPTION
```c++
/home/cdda/git/colobot/colobot-base/src/graphics/engine/particle.cpp: In member function 'void Gfx::CParticle::DrawParticleFog(int)':
/home/cdda/git/colobot/colobot-base/src/graphics/engine/particle.cpp:2903:19: error: 'zoom.glm::vec<2, float, glm::packed_highp>::<anonymous>.glm::vec<2, float, glm::packed_highp>::<unnamed union>::x' may be used uninitialized [-Werror=ma
ybe-uninitialized]
 2903 |     dim.x *= zoom.x;
      |              ~~~~~^
/home/cdda/git/colobot/colobot-base/src/graphics/engine/particle.cpp:2884:15: note: 'zoom.glm::vec<2, float, glm::packed_highp>::<anonymous>.glm::vec<2, float, glm::packed_highp>::<unnamed union>::x' was declared here
 2884 |     glm::vec2 zoom;
      |               ^~~~
/home/cdda/git/colobot/colobot-base/src/graphics/engine/particle.cpp:2904:19: error: 'zoom.glm::vec<2, float, glm::packed_highp>::<anonymous>.glm::vec<2, float, glm::packed_highp>::<unnamed union>::y' may be used uninitialized [-Werror=ma
ybe-uninitialized]
 2904 |     dim.y *= zoom.y;
      |              ~~~~~^
/home/cdda/git/colobot/colobot-base/src/graphics/engine/particle.cpp:2884:15: note: 'zoom.glm::vec<2, float, glm::packed_highp>::<anonymous>.glm::vec<2, float, glm::packed_highp>::<unnamed union>::y' was declared here
 2884 |     glm::vec2 zoom;
      |               ^~~~
/home/cdda/git/colobot/colobot-base/src/graphics/engine/particle.cpp: In member function 'void Gfx::CParticle::FrameParticle(float)':
/home/cdda/git/colobot/colobot-base/src/graphics/engine/particle.cpp:2449:37: error: 'ts.glm::vec<2, float, glm::packed_highp>::<anonymous>.glm::vec<2, float, glm::packed_highp>::<unnamed union>::y' may be used uninitialized [-Werror=mayb
e-uninitialized]
 2449 |         m_particle[i].texSup.y = ts.y+dp;
      |                                  ~~~^
/home/cdda/git/colobot/colobot-base/src/graphics/engine/particle.cpp:797:15: note: 'ts.glm::vec<2, float, glm::packed_highp>::<anonymous>.glm::vec<2, float, glm::packed_highp>::<unnamed union>::y' was declared here
  797 |     glm::vec2 ts, ti;
      |               ^~
/home/cdda/git/colobot/colobot-base/src/graphics/engine/particle.cpp:2450:37: error: 'ti.glm::vec<2, float, glm::packed_highp>::<anonymous>.glm::vec<2, float, glm::packed_highp>::<unnamed union>::x' may be used uninitialized [-Werror=mayb
e-uninitialized]
 2450 |         m_particle[i].texInf.x = ti.x-dp;
      |                                  ~~~^
/home/cdda/git/colobot/colobot-base/src/graphics/engine/particle.cpp:797:19: note: 'ti.glm::vec<2, float, glm::packed_highp>::<anonymous>.glm::vec<2, float, glm::packed_highp>::<unnamed union>::x' was declared here
  797 |     glm::vec2 ts, ti;
      |                   ^~
/home/cdda/git/colobot/colobot-base/src/graphics/engine/particle.cpp:2448:37: error: 'ts.glm::vec<2, float, glm::packed_highp>::<anonymous>.glm::vec<2, float, glm::packed_highp>::<unnamed union>::x' may be used uninitialized [-Werror=mayb
e-uninitialized]
 2448 |         m_particle[i].texSup.x = ts.x+dp;
      |                                  ~~~^
/home/cdda/git/colobot/colobot-base/src/graphics/engine/particle.cpp:797:15: note: 'ts.glm::vec<2, float, glm::packed_highp>::<anonymous>.glm::vec<2, float, glm::packed_highp>::<unnamed union>::x' was declared here
  797 |     glm::vec2 ts, ti;
      |               ^~
/home/cdda/git/colobot/colobot-base/src/graphics/engine/particle.cpp:2451:37: error: 'ti.glm::vec<2, float, glm::packed_highp>::<anonymous>.glm::vec<2, float, glm::packed_highp>::<unnamed union>::y' may be used uninitialized [-Werror=mayb
e-uninitialized]
 2451 |         m_particle[i].texInf.y = ti.y-dp;
      |                                  ~~~^
/home/cdda/git/colobot/colobot-base/src/graphics/engine/particle.cpp:797:19: note: 'ti.glm::vec<2, float, glm::packed_highp>::<anonymous>.glm::vec<2, float, glm::packed_highp>::<unnamed union>::y' was declared here
  797 |     glm::vec2 ts, ti;
      |                   ^~
```