### PR TITLE
Fix misc. compiler warnings

### DIFF
--- a/cmake/compilers/Clang.cmake
+++ b/cmake/compilers/Clang.cmake
@@ -10,7 +10,7 @@ endif()
 
 add_compile_options(
     -Wall
-    -Wold-style-cast
+    $<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>
     -pedantic-errors
     -Wmissing-prototypes
     -Wno-error=deprecated-declarations      # updated version of physfs is not available on some platforms so we keep using deprecated functions, see #958

--- a/cmake/compilers/GNU.cmake
+++ b/cmake/compilers/GNU.cmake
@@ -6,7 +6,7 @@ message(STATUS "Detected GCC version 4.7+")
 
 add_compile_options(
     -Wall
-    -Wold-style-cast
+    $<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>
     -pedantic-errors
     -Wmissing-declarations
     -lstdc++fs

--- a/cmake/systems/Darwin.cmake
+++ b/cmake/systems/Darwin.cmake
@@ -6,7 +6,7 @@ set(PLATFORM_FREEBSD 0)
 
 add_compile_options(
     -Wall
-    -Wold-style-cast
+    $<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>
     -Wmissing-prototypes
     -pedantic-errors
     -Wno-error=deprecated-declarations

--- a/colobot-base/src/graphics/engine/lightman.cpp
+++ b/colobot-base/src/graphics/engine/lightman.cpp
@@ -519,7 +519,7 @@ float CLightManager::CLightsComparator::GetLightWeight(const DynamicLight& dynLi
     else if (dynLight.excludeType != ENG_OBJTYPE_NULL)
         enabled = dynLight.excludeType != m_objectType;
 
-    return enabled ? ( glm::length(dynLight.light.position - m_eyePos) * dynLight.priority ) : 10000.0f;
+    return enabled ? ( glm::length(dynLight.light.position - m_eyePos) * static_cast<float>(dynLight.priority) ) : 10000.0f;
 }
 
 bool CLightManager::CLightsComparator::operator()(const DynamicLight& left, const DynamicLight& right)

--- a/colobot-base/src/graphics/model/model_gltf.cpp
+++ b/colobot-base/src/graphics/model/model_gltf.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "graphics/model/model_mod.h"
+#include "graphics/model/model_gltf.h"
 
 #include "common/ioutils.h"
 #include "common/logger.h"

--- a/colobot-base/src/graphics/model/model_mesh.cpp
+++ b/colobot-base/src/graphics/model/model_mesh.cpp
@@ -145,8 +145,6 @@ bool CModelPart::Has(VertexAttribute array) const
 {
     switch (array)
     {
-    case VertexAttribute::POSITION:
-        return true;
     case VertexAttribute::COLOR:
         return m_colors.enabled;
     case VertexAttribute::UV1:

--- a/colobot-base/src/graphics/model/model_mesh.h
+++ b/colobot-base/src/graphics/model/model_mesh.h
@@ -33,7 +33,6 @@ namespace Gfx
  */
 enum class VertexAttribute
 {
-    POSITION,
     COLOR,
     UV1,
     UV2,

--- a/colobot-base/src/graphics/model/model_txt.cpp
+++ b/colobot-base/src/graphics/model/model_txt.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "graphics/model/model_mod.h"
+#include "graphics/model/model_txt.h"
 
 #include "common/ioutils.h"
 #include "common/stringutils.h"


### PR DESCRIPTION
```c++
cc1: warning: command-line option '-Wold-style-cast' is valid for C++/ObjC++ but not for C

/home/cdda/git/colobot/colobot-base/src/graphics/engine/lightman.cpp: In member function 'float Gfx::CLightManager::CLightsComparator::GetLightWeight(const Gfx::DynamicLi
ght&)':
/home/cdda/git/colobot/colobot-base/src/graphics/engine/lightman.cpp:522:72: error: arithmetic between floating-point type 'float' and enumeration type 'const Gfx::LightP
riority' is deprecated [-Werror=deprecated-enum-float-conversion]
  522 |     return enabled ? ( glm::length(dynLight.light.position - m_eyePos) * dynLight.priority ) : 10000.0f;
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/home/cdda/git/colobot/colobot-base/src/graphics/model/model_gltf.cpp:106:25: error: no previous declaration for 'std::unique_ptr<Gfx::CModel> Gfx::ModelIO::ReadGLTFMode
(const std::filesystem::__cxx11::path&)' [-Werror=missing-declarations]
  106 | std::unique_ptr<CModel> ReadGLTFModel(const std::filesystem::path& path)
      |                         ^~~~~~~~~~~~~
```
Note VertexAttribute::POSITION was unused. I removed it.
```c++
/home/cdda/git/colobot/colobot-base/src/graphics/model/model_mesh.cpp: In member function 'void Gfx::CModelPart::Add(Gfx::VertexAttribute)':
/home/cdda/git/colobot/colobot-base/src/graphics/model/model_mesh.cpp:171:12: error: enumeration value 'POSITION' not handled in switch [-Werror=switch]
  171 |     switch (attribute)
      |            ^
/home/cdda/git/colobot/colobot-base/src/graphics/model/model_mesh.cpp: In member function 'void Gfx::CModelPart::Remove(Gfx::VertexAttribute)':
/home/cdda/git/colobot/colobot-base/src/graphics/model/model_mesh.cpp:206:12: error: enumeration value 'POSITION' not handled in switch [-Werror=switch]
  206 |     switch (attribute)
      |            ^
```
```c++
/home/cdda/git/colobot/colobot-base/src/graphics/model/model_txt.cpp:52:25: error: no previous declaration for 'std::unique_ptr<Gfx::CModel> Gfx::ModelIO::ReadTextModel(c
onst std::filesystem::__cxx11::path&)' [-Werror=missing-declarations]
   52 | std::unique_ptr<CModel> ReadTextModel(const std::filesystem::path& path)
```