### PR TITLE
Add recolor threshold as a material parameter and to glTF importer

### DIFF
--- a/colobot-base/src/graphics/core/material.h
+++ b/colobot-base/src/graphics/core/material.h
@@ -78,6 +78,8 @@ struct Material
     std::string recolor = "";
     // Recolor reference color
     Color recolorReference = { 0.0f, 0.0f, 0.0f, 0.0f };
+    // Recolor threshold
+    float recolorThreshold = 0.1f;
 
     // Legacy functionality
     //! Variable detail texture

--- a/colobot-base/src/graphics/engine/engine.cpp
+++ b/colobot-base/src/graphics/engine/engine.cpp
@@ -3054,6 +3054,19 @@ void CEngine::Draw3DScene()
 
             for (auto& data : p1.next)
             {
+                if (data.material.recolor.empty())
+                {
+                    objectRenderer->SetRecolor(false);
+                }
+                else
+                {
+                    Color recolorFrom = data.material.recolorReference;
+                    Color recolorTo = GetObjectColor(objRank, data.material.recolor);
+                    float recolorThreshold = data.material.recolorThreshold;
+
+                    objectRenderer->SetRecolor(true, recolorFrom, recolorTo, recolorThreshold);
+                }
+
                 objectRenderer->SetAlbedoColor(tColor);
                 objectRenderer->SetAlbedoTexture(data.albedoTexture);
                 objectRenderer->SetDetailTexture(data.detailTexture);

--- a/colobot-base/src/graphics/engine/engine.cpp
+++ b/colobot-base/src/graphics/engine/engine.cpp
@@ -2985,7 +2985,7 @@ void CEngine::Draw3DScene()
             {
                 Color recolorFrom = data.material.recolorReference;
                 Color recolorTo = GetObjectColor(objRank, data.material.recolor);
-                float recolorThreshold = 0.1;
+                float recolorThreshold = data.material.recolorThreshold;
 
                 objectRenderer->SetRecolor(true, recolorFrom, recolorTo, recolorThreshold);
             }

--- a/colobot-base/src/graphics/model/model_gltf.cpp
+++ b/colobot-base/src/graphics/model/model_gltf.cpp
@@ -221,7 +221,11 @@ void GLTFLoader::ReadMaterials()
                 float b = color[2];
 
                 mat.recolorReference = Color(r, g, b);
+            }
 
+            if (extras.contains("recolor_threshold"))
+            {
+                mat.recolorThreshold = extras["recolor_threshold"].get<float>();
             }
         }
 

--- a/colobot-base/src/graphics/opengl33/CMakeLists.txt
+++ b/colobot-base/src/graphics/opengl33/CMakeLists.txt
@@ -18,9 +18,32 @@ target_sources(Colobot-Base PRIVATE
 )
 
 if(COLOBOT_DEVELOPMENT_MODE)
-    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/shaders/gl33
-        DESTINATION ${PROJECT_BINARY_DIR}/data/shaders
+    set(SHADERS
+        lighting.glsl
+        object_fs.glsl
+        object_vs.glsl
+        particle_fs.glsl
+        particle_vs.glsl
+        preamble.glsl
+        shadow_fs.glsl
+        shadow_vs.glsl
+        shadow.glsl
+        terrain_fs.glsl
+        terrain_vs.glsl
+        ui_fs.glsl
+        ui_vs.glsl
     )
+
+    add_custom_target(UpdateShaders ALL)
+
+    foreach(shader ${SHADERS})
+        add_custom_command(
+            TARGET UpdateShaders POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${CMAKE_CURRENT_SOURCE_DIR}/shaders/gl33/${shader}"
+                "${PROJECT_BINARY_DIR}/data/shaders/gl33/${shader}"
+        )
+    endforeach()
 endif()
 
 install(DIRECTORY shaders/gl33 DESTINATION ${COLOBOT_INSTALL_DATA_DIR}/shaders)

--- a/colobot-base/src/graphics/opengl33/shaders/gl33/object_fs.glsl
+++ b/colobot-base/src/graphics/opengl33/shaders/gl33/object_fs.glsl
@@ -101,10 +101,13 @@ void main()
 
         if (abs(hsv.x - uni_RecolorFrom.x) < uni_RecolorThreshold)
         {
-            hsv += (uni_RecolorTo - uni_RecolorFrom);
+            hsv.x += (uni_RecolorTo.x - uni_RecolorFrom.x);
+            hsv.y += (uni_RecolorTo.y - uni_RecolorFrom.y);
 
             if (hsv.x < 0.0) hsv.x += 1.0;
             if (hsv.x > 1.0) hsv.x -= 1.0;
+
+            hsv.y = clamp(hsv.y, 0.0, 1.0);
         }
 
         texColor.rgb = hsv2rgb(hsv);


### PR DESCRIPTION
Currently recolor threshold is hardcoded to value 0.1. This pull request adds threshold to material properties and allows loading them from custom glTF material property "recolor_threshold". The value defaults to 0.1 if not specified.