### PR TITLE
Revert "Clamp energy level to standard values for OrgaShooters"

### DIFF
--- a/colobot-base/src/object/motion/motionvehicle.cpp
+++ b/colobot-base/src/object/motion/motionvehicle.cpp
@@ -1945,7 +1945,6 @@ bool CMotionVehicle::EventFrameCanoni(const Event &event)
 
     float energy = GetObjectEnergyLevel(m_object);
     if (energy == 0.0f)  return true;
-    if (energy > 1.0f) energy = 1.0f; //fix issue with cheated cells, see issue #1009
 
     factor = 0.5f+energy*0.5f;
     if ( bOnBoard )  factor *= 0.8f;


### PR DESCRIPTION
* Fix #1039

Spawning regular power cells via the debug menu used to produce power cells with m_energyLevel=100 even though the value is supposed to be capped at 1. This was fixed by https://github.com/colobot/colobot/commit/c4385961c4d73e8548b23def377ae53c98f32f1f - the debug menu no longer makes overcharged power cells

This pull request reverts dab223e because I think it is no longer necessary.