### PR TITLE
Add self-destruct

### DIFF
--- a/colobot-base/src/common/restext.cpp
+++ b/colobot-base/src/common/restext.cpp
@@ -108,7 +108,7 @@ void InitializeRestext()
 
     stringsText[RT_DIALOG_ABORT]     = TR("Abort\\Abort the current mission");
     stringsText[RT_DIALOG_CONTINUE]  = TR("Continue\\Continue the current mission");
-    stringsText[RT_DIALOG_DELOBJ]    = TR("Do you really want to destroy the selected building?");
+    stringsText[RT_DIALOG_DELOBJ]    = TR("Do you really want to destroy the selected bot or building?");
     stringsText[RT_DIALOG_DELGAME]   = TR("Do you want to delete %s's saved games?");
     stringsText[RT_DIALOG_YES]       = TR("Yes");
     stringsText[RT_DIALOG_NO]        = TR("No");

--- a/colobot-base/src/ui/object_interface.cpp
+++ b/colobot-base/src/ui/object_interface.cpp
@@ -885,6 +885,12 @@ bool CObjectInterface::CreateInterface(bool bSelect)
          type == OBJECT_WORM     ||
          type == OBJECT_CONTROLLER)  // vehicle?
     {
+        pos.x = ox+sx*6.2f;
+        pos.y = oy+sy*0;
+        ddim.x = dim.x*0.6f;
+        ddim.y = dim.y*0.6f;
+        pw->CreateButton(pos, ddim, 12, EVENT_OBJECT_DELETE);
+
         if (m_main->GetMissionType() != MISSION_RETRO)
         {
             ddim.x = dim.x*5.1f;


### PR DESCRIPTION
* Fix #643

Use case: I often use cheats to spawn bots while trying to reproduce various bugs. Sometimes I want to destroy the bots that I no longer need

![image](https://github.com/user-attachments/assets/020f78fc-c89b-4957-9aac-341eaeef7a06)

