### PR TITLE
Fix use-after-free when loading a save

### DIFF
--- a/CBot/src/CBot/CBotVar/CBotVarClass.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarClass.cpp
@@ -77,7 +77,7 @@ CBotVarClass::~CBotVarClass( )
         assert(0);
 
     // removes the class list
-    if (m_ItemIdent != 0) m_instances.erase(this);
+    m_instances.erase(this);
 
     delete    m_pVar;
 }


### PR DESCRIPTION
* Fix #1758

Always remove the pointer from the map regardless of m_ItemIdent. If the pointer is not in the map std::map::erase() is a no-op