### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/1-feature_request.yaml
@@ -5,7 +5,7 @@ labels: enhancement,needs-triage
 body:
 - type: markdown
   attributes:
-    value: Please **do not use** external websites (such as drop box or google drive) to upload screenshots, save files etc. External links have a tendency to become dead. Upload the files to github insted by using one of the below fields.
+    value: Please **do not use** external websites (such as Dropbox or Google Drive) to upload screenshots, save files etc. External links have a tendency to become dead. Upload the files to GitHub insted by using one of the below fields.
 - type: textarea
   attributes:
     label: Describe the feature

--- a/.github/ISSUE_TEMPLATE/1-feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/1-feature_request.yaml
@@ -1,0 +1,13 @@
+name: Feature request
+description: Suggest an idea for this project
+labels: enhancement,needs-triage
+
+body:
+- type: markdown
+  attributes:
+    value: Please **do not use** external websites (such as drop box or google drive) to upload screenshots, save files etc. External links have a tendency to become dead. Upload the files to github insted by using one of the below fields.
+- type: textarea
+  attributes:
+    label: Describe the feature
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/2-crash-report.yaml
+++ b/.github/ISSUE_TEMPLATE/2-crash-report.yaml
@@ -1,0 +1,69 @@
+name: Report a crash or hang
+description: The game has crashed or hanged
+labels: bug,crash,needs-triage
+
+body:
+- type: markdown
+  attributes:
+    value: Please **do not use** external websites (such as drop box or google drive) to upload screenshots, save files etc. External links have a tendency to become dead. Upload the files to github insted by using one of the below fields.
+- type: textarea
+  attributes:
+    label: Error message
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: log.txt
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    value: |
+      Uploading a save file makes it more likely we would be able to troubleshoot the issue
+      1. Find the save dirrectory
+      2. Make a zip archive from it
+      3. Upload it to github by using the field below
+- type: textarea
+  attributes:
+    label: Save file
+- type: markdown
+  attributes:
+    value: |
+      Uploading a colobot.ini or colobot.json file makes it more likely we would be able to troubleshoot the issue
+- type: textarea
+  attributes:
+    label: colobot.ini or colobot.json
+- type: input
+  attributes:
+    label: Game version (e.g. 0.2.1-alpha)
+    description: You can find this information in the bottom right corner of the main menu
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Operating system (e.g. Windows 11)
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Steps to reproduce the crash
+    placeholder: |
+      1. Start the "Alien Queen" mission from the "On Terranova" chapter
+      2. Fly the astronaut tovards the vault and smash into it
+      3. The game crashes
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Are you able to reproduce the crsah?
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Please, post a stack trace if you know how
+- type: textarea
+  attributes:
+    label: Installed mods (if any)
+- type: textarea
+  attributes:
+    label: Additional information

--- a/.github/ISSUE_TEMPLATE/2-crash-report.yaml
+++ b/.github/ISSUE_TEMPLATE/2-crash-report.yaml
@@ -5,7 +5,7 @@ labels: bug,crash,needs-triage
 body:
 - type: markdown
   attributes:
-    value: Please **do not use** external websites (such as drop box or google drive) to upload screenshots, save files etc. External links have a tendency to become dead. Upload the files to github insted by using one of the below fields.
+    value: Please **do not use** external websites (such as Dropbox or Google Drive) to upload screenshots, save files etc. External links have a tendency to become dead. Upload the files to GitHub insted by using one of the below fields.
 - type: textarea
   attributes:
     label: Error message
@@ -22,7 +22,7 @@ body:
       Uploading a save file makes it more likely we would be able to troubleshoot the issue
       1. Find the save dirrectory
       2. Make a zip archive from it
-      3. Upload it to github by using the field below
+      3. Upload it to Github by using the field below
 - type: textarea
   attributes:
     label: Save file

--- a/.github/ISSUE_TEMPLATE/2-crash-report.yaml
+++ b/.github/ISSUE_TEMPLATE/2-crash-report.yaml
@@ -44,6 +44,12 @@ body:
     label: Operating system (e.g. Windows 11)
   validations:
     required: true
+- type: markdown
+  attributes:
+    value: Posting information about your video card makes it more likely we would be able to troubleshoot the issue
+- type: textarea
+  attributes:
+    label: Video card
 - type: textarea
   attributes:
     label: Steps to reproduce the crash

--- a/.github/ISSUE_TEMPLATE/3-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/3-bug-report.yaml
@@ -41,6 +41,9 @@ body:
     required: true
 - type: textarea
   attributes:
+    label: Video card (if the bug is graphics-related)
+- type: textarea
+  attributes:
     label: Steps to reproduce the bug
     placeholder: |
       1. Make a recycler

--- a/.github/ISSUE_TEMPLATE/3-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/3-bug-report.yaml
@@ -5,7 +5,7 @@ labels: bug,needs-triage
 body:
 - type: markdown
   attributes:
-    value: Please **do not use** external websites (such as drop box or google drive) to upload screenshots, save files etc. External links have a tendency to become dead. Upload the files to github insted by using one of the below fields.
+    value: Please **do not use** external websites (such as Dropbox or Google Drive) to upload screenshots, save files etc. External links have a tendency to become dead. Upload the files to GitHub insted by using one of the below fields.
 - type: textarea
   attributes:
     label: log.txt
@@ -17,7 +17,7 @@ body:
       Uploading a save file makes it more likely we would be able to troubleshoot the issue
       1. Find the save dirrectory
       2. Make a zip archive from it
-      3. Upload it to github by using the field below
+      3. Upload it to Github by using the field below
 - type: textarea
   attributes:
     label: Save file

--- a/.github/ISSUE_TEMPLATE/3-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/3-bug-report.yaml
@@ -1,0 +1,71 @@
+name: Report a bug
+description: Something went wrong
+labels: bug,needs-triage
+
+body:
+- type: markdown
+  attributes:
+    value: Please **do not use** external websites (such as drop box or google drive) to upload screenshots, save files etc. External links have a tendency to become dead. Upload the files to github insted by using one of the below fields.
+- type: textarea
+  attributes:
+    label: log.txt
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    value: |
+      Uploading a save file makes it more likely we would be able to troubleshoot the issue
+      1. Find the save dirrectory
+      2. Make a zip archive from it
+      3. Upload it to github by using the field below
+- type: textarea
+  attributes:
+    label: Save file
+- type: markdown
+  attributes:
+    value: |
+      Uploading a colobot.ini or colobot.json file makes it more likely we would be able to troubleshoot the issue
+- type: textarea
+  attributes:
+    label: colobot.ini or colobot.json
+- type: input
+  attributes:
+    label: Game version (e.g. 0.2.1-alpha)
+    description: You can find this information in the bottom right corner of the main menu
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Operating system (e.g. Windows 11)
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Steps to reproduce the bug
+    placeholder: |
+      1. Make a recycler
+      2. Push the recycle button near a Wreck
+      3. Quickly remove PowerCell from Recycler's energyCell slot using a grabber
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: What was supposed to happen
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: What actually happened
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Are you able to reproduce the bug
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Installed mods (if any)
+- type: textarea
+  attributes:
+    label: Additional information

--- a/.github/ISSUE_TEMPLATE/9-other.yaml
+++ b/.github/ISSUE_TEMPLATE/9-other.yaml
@@ -5,7 +5,7 @@ labels: needs-triage
 body:
 - type: markdown
   attributes:
-    value: Please **do not use** external websites (such as drop box or google drive) to upload screenshots, save files etc. External links have a tendency to become dead. Upload the files to github insted by using one of the below fields.
+    value: Please **do not use** external websites (such as Dropbox or Google Drive) to upload screenshots, save files etc. External links have a tendency to become dead. Upload the files to GitHub insted by using one of the below fields.
 - type: textarea
   attributes:
     label: Describe the issue

--- a/.github/ISSUE_TEMPLATE/9-other.yaml
+++ b/.github/ISSUE_TEMPLATE/9-other.yaml
@@ -1,0 +1,13 @@
+name: Other
+description: Other
+labels: needs-triage
+
+body:
+- type: markdown
+  attributes:
+    value: Please **do not use** external websites (such as drop box or google drive) to upload screenshots, save files etc. External links have a tendency to become dead. Upload the files to github insted by using one of the below fields.
+- type: textarea
+  attributes:
+    label: Describe the issue
+  validations:
+    required: true


### PR DESCRIPTION
Most of our bug reports are very sparse on information. This makes troubleshooting difficult. I have created issue templates to, hopefully, improve that. You can try them out here: https://github.com/hexagonrecursion/colobot/issues/new/choose

Note: can someone create a "needs-triage" label? I, apparently, do not have permissions to do it