### PR TITLE
Make GetObjectById() take int instaed of unsigned

### DIFF
--- a/colobot-base/src/object/object_manager.cpp
+++ b/colobot-base/src/object/object_manager.cpp
@@ -111,7 +111,7 @@ void CObjectManager::DeleteAllObjects()
     m_nextId = 0;
 }
 
-CObject* CObjectManager::GetObjectById(unsigned int id)
+CObject* CObjectManager::GetObjectById(int id)
 {
     if (m_objects.count(id) == 0) return nullptr;
     return m_objects[id].get();

--- a/colobot-base/src/object/object_manager.h
+++ b/colobot-base/src/object/object_manager.h
@@ -165,7 +165,7 @@ public:
     void      DeleteAllObjects();
 
     //! Finds object by id (CObject::GetID())
-    CObject*  GetObjectById(unsigned int id);
+    CObject*  GetObjectById(int id);
 
     //! Gets object by id in range <0; number of objects - 1>
     CObject*  GetObjectByRank(unsigned int id);


### PR DESCRIPTION
1. In every place, where it is used `GetObjectById()` gets an `int` argument
2. `m_objects` is `std::map<int, std::unique_ptr<CObject>>`
3. `unsigned` (ideally) be used to signal that wrap-around is desired and intended

`unsigned` does not contribute anything useful here.