### PR TITLE
Make build() and recycle() more robust

### DIFF
--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -4483,7 +4483,7 @@ static bool IsSkip( const CObject* obj )
 {
     return obj->GetType() == OBJECT_TOTO
         || IsObjectBeingTransported(obj)
-        || obj->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<const CDestroyableObject&>(*obj).IsDying();
+        || (obj->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<const CDestroyableObject&>(*obj).IsDying());
 }
 
 //! Saves the current game

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -4479,6 +4479,13 @@ void CRobotMain::IOWriteObject(CLevelParserLine* line, CObject* obj,
     }
 }
 
+static bool IsSkip( const CObject* obj )
+{
+    return obj->GetType() == OBJECT_TOTO
+        || IsObjectBeingTransported(obj)
+        || obj->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<const CDestroyableObject&>(*obj).IsDying();
+}
+
 //! Saves the current game
 bool CRobotMain::IOWriteScene(const std::filesystem::path& filename,
         const std::filesystem::path& filecbot,
@@ -4546,9 +4553,7 @@ bool CRobotMain::IOWriteScene(const std::filesystem::path& filename,
     int objRank = 0;
     for (CObject* obj : m_objMan->GetAllObjects())
     {
-        if (obj->GetType() == OBJECT_TOTO) continue;
-        if (IsObjectBeingTransported(obj)) continue;
-        if (obj->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject&>(*obj).IsDying()) continue;
+        if (IsSkip(obj)) continue;
 
         if (obj->Implements(ObjectInterfaceType::Slotted))
         {
@@ -4597,9 +4602,7 @@ bool CRobotMain::IOWriteScene(const std::filesystem::path& filename,
 
     for (CObject* obj : m_objMan->GetAllObjects())
     {
-        if (obj->GetType() == OBJECT_TOTO) continue;
-        if (IsObjectBeingTransported(obj)) continue;
-        if (obj->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject&>(*obj).IsDying()) continue;
+        if (IsSkip(obj)) continue;
 
         if (!SaveFileStack(obj, ostr))
         {

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -4431,7 +4431,7 @@ void CRobotMain::IOWriteObject(CLevelParserLine* line, CObject* obj,
     line->AddParam("id", std::make_unique<CLevelParserParam>(obj->GetID()));
     line->AddParam("pos", std::make_unique<CLevelParserParam>(obj->GetPosition()/g_unit));
     line->AddParam("angle", std::make_unique<CLevelParserParam>(obj->GetRotation() * Math::RAD_TO_DEG));
-    line->AddParam("zoom", std::make_unique<CLevelParserParam>(obj->GetScale()));
+    line->AddParam("zoom", std::make_unique<CLevelParserParam>(obj->GetScaleForSave()));
 
     if (obj->Implements(ObjectInterfaceType::Old))
     {
@@ -4482,6 +4482,7 @@ void CRobotMain::IOWriteObject(CLevelParserLine* line, CObject* obj,
 static bool IsSkip( const CObject* obj )
 {
     return obj->GetType() == OBJECT_TOTO
+        || !obj->GetPersistent()
         || IsObjectBeingTransported(obj)
         || (obj->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<const CDestroyableObject&>(*obj).IsDying());
 }

--- a/colobot-base/src/object/auto/autofactory.cpp
+++ b/colobot-base/src/object/auto/autofactory.cpp
@@ -72,7 +72,7 @@ CAutoFactory::~CAutoFactory()
 
 void CAutoFactory::DeleteObject(bool all)
 {
-    if ( !all )
+    if ( !all && m_phase != AFP_WAIT )
     {
         CObject* cargo = SearchCargo();  // transform metal?
         if ( cargo != nullptr )

--- a/colobot-base/src/object/interface/destroyable_object.h
+++ b/colobot-base/src/object/interface/destroyable_object.h
@@ -77,5 +77,5 @@ public:
     //! Return object death type
     virtual DeathType   GetDying() = 0;
     //! Is object currently dying?
-    virtual bool        IsDying() = 0;
+    virtual bool        IsDying() const = 0;
 };

--- a/colobot-base/src/object/interface/transportable_object.h
+++ b/colobot-base/src/object/interface/transportable_object.h
@@ -39,20 +39,20 @@ public:
     //! Set transporter object that transports this object
     virtual void SetTransporter(CObject* transporter) = 0;
     //! Return transported object
-    virtual CObject* GetTransporter() = 0;
+    virtual CObject* GetTransporter() const = 0;
 
     // TODO: This will have to be refactored while implementing new model format
     virtual void SetTransporterPart(int part) = 0;
 
     //! Return true if the object is currently transported
-    inline bool IsBeingTransported()
+    inline bool IsBeingTransported() const
     {
         return GetTransporter() != nullptr;
     }
 };
 
-inline bool IsObjectBeingTransported(CObject* obj)
+inline bool IsObjectBeingTransported(const CObject* obj)
 {
     return obj->Implements(ObjectInterfaceType::Transportable) &&
-           dynamic_cast<CTransportableObject&>(*obj).IsBeingTransported();
+           dynamic_cast<const CTransportableObject&>(*obj).IsBeingTransported();
 }

--- a/colobot-base/src/object/object.cpp
+++ b/colobot-base/src/object/object.cpp
@@ -49,6 +49,7 @@ CObject::CObject(int id, ObjectType type)
     , m_proxyActivate(false)
     , m_proxyDistance(60.0f)
     , m_lock(false)
+    , m_persistent(true)
 {
     m_implementedInterfaces.fill(false);
     m_botVar = CScriptFunctions::CreateObjectVar(this);
@@ -217,6 +218,16 @@ void CObject::SetScale(float scale)
     SetScale(glm::vec3(scale, scale, scale));
 }
 
+void CObject::SetScaleOverride(std::optional<glm::vec3> scale)
+{
+    m_scaleOverride = scale;
+}
+
+glm::vec3 CObject::GetScaleForSave() const
+{
+    return m_scaleOverride.value_or(GetScale());
+}
+
 void CObject::SetScaleX(float angle)
 {
     glm::vec3 scale = GetScale();
@@ -350,7 +361,27 @@ void CObject::SetLock(bool lock)
     m_lock = lock;
 }
 
-bool CObject::GetLock()
+bool CObject::GetLock() const
 {
     return m_lock;
+}
+
+void CObject::SetLockOverride(std::optional<bool> lock)
+{
+    m_lockOverride = lock;
+}
+
+bool CObject::GetLockForSave() const
+{
+    return m_lockOverride.value_or(GetLock());
+}
+
+void CObject::SetPersistent(bool persistent)
+{
+    m_persistent = persistent;
+}
+
+bool CObject::GetPersistent() const
+{
+    return m_persistent;
 }

--- a/colobot-base/src/object/object.h
+++ b/colobot-base/src/object/object.h
@@ -30,6 +30,7 @@
 #include "object/old_object_interface.h"
 
 #include <vector>
+#include <optional>
 
 namespace Gfx
 {
@@ -128,6 +129,11 @@ public:
     //! Sets objects's scale (uniform value)
     void SetScale(float scale);
 
+    //! Overrides objects's scale that is saved when saving the game
+    void SetScaleOverride(std::optional<glm::vec3> scale);
+    //! Return objects's scale that should be written to a save file
+    glm::vec3 GetScaleForSave() const;
+
     //!@{
     //! Shortcuts for scale components
     void SetScaleX(float angle);
@@ -199,7 +205,11 @@ public:
     //! Set "lock" mode of an object (for example, a robot while it's being factored, or a building while it's built)
     void SetLock(bool lock);
     //! Return "lock" mode of an object
-    bool GetLock();
+    bool GetLock() const;
+    //! Overrides the "lock" mode of an object that is saved when saving the game
+    void SetLockOverride(std::optional<bool> lock);
+    //! Return "lock" mode of an object that should be written to a save file
+    bool GetLockForSave() const;
 
     //! Is this object active (not dead)?
     virtual bool GetActive() { return true; }
@@ -210,6 +220,10 @@ public:
     //! This is useful to make Barriers protect from bullets
     //! \todo It will work like this for now but later I'd like to refactor this to something more manageable ~krzys_h
     virtual bool IsBulletWall() { return false; }
+
+    //! Set whether the object is saved when creating a save file
+    void SetPersistent(bool);
+    bool GetPersistent() const;
 
 protected:
     //! Transform crash sphere by object's world matrix
@@ -224,6 +238,7 @@ protected:
     glm::vec3 m_position;
     glm::vec3 m_rotation;
     glm::vec3 m_scale;
+    std::optional<glm::vec3> m_scaleOverride;
     std::vector<CrashSphere> m_crashSpheres; //!< crash spheres
     Math::Sphere m_cameraCollisionSphere;
     bool m_animateOnReset;
@@ -233,4 +248,6 @@ protected:
     float m_proxyDistance;
     CBot::CBotVar* m_botVar;
     bool m_lock;
+    std::optional<bool> m_lockOverride;
+    bool m_persistent;
 };

--- a/colobot-base/src/object/object.h
+++ b/colobot-base/src/object/object.h
@@ -221,9 +221,9 @@ protected:
     const int m_id; //!< unique identifier
     ObjectType m_type; //!< object type
     ObjectInterfaceTypes m_implementedInterfaces; //!< interfaces that the object implements
-    glm::vec3 m_position{ 0, 0, 0 };
-    glm::vec3 m_rotation{ 0, 0, 0 };
-    glm::vec3 m_scale{ 0, 0, 0 };
+    glm::vec3 m_position;
+    glm::vec3 m_rotation;
+    glm::vec3 m_scale;
     std::vector<CrashSphere> m_crashSpheres; //!< crash spheres
     Math::Sphere m_cameraCollisionSphere;
     bool m_animateOnReset;

--- a/colobot-base/src/object/old_object.cpp
+++ b/colobot-base/src/object/old_object.cpp
@@ -1094,8 +1094,8 @@ void COldObject::Write(CLevelParserLine* line)
     if ( !GetCollisions() )
         line->AddParam("clip", std::make_unique<CLevelParserParam>(GetCollisions()));
 
-    if ( GetLock() )
-        line->AddParam("lock", std::make_unique<CLevelParserParam>(GetLock()));
+    if ( GetLockForSave() )
+        line->AddParam("lock", std::make_unique<CLevelParserParam>(true));
 
     if ( !GetActivity() )
         line->AddParam("activity", std::make_unique<CLevelParserParam>(GetActivity()));

--- a/colobot-base/src/object/old_object.cpp
+++ b/colobot-base/src/object/old_object.cpp
@@ -314,6 +314,9 @@ void COldObject::Simplify()
     }
     m_main->SaveOneScript(this);
 
+    StopForegroundTask();
+    StopBackgroundTask();
+
     m_implementedInterfaces[static_cast<int>(ObjectInterfaceType::ProgramStorage)] = false;
     m_implementedInterfaces[static_cast<int>(ObjectInterfaceType::Programmable)] = false;
 

--- a/colobot-base/src/object/old_object.cpp
+++ b/colobot-base/src/object/old_object.cpp
@@ -1824,7 +1824,7 @@ void COldObject::SetTransporter(CObject* transporter)
     m_engine->SetObjectShadowSpotHide(m_objectPart[0].object, (m_transporter != nullptr));
 }
 
-CObject* COldObject::GetTransporter()
+CObject* COldObject::GetTransporter() const
 {
     return m_transporter;
 }
@@ -2879,7 +2879,7 @@ DeathType COldObject::GetDying()
     return m_dying;
 }
 
-bool COldObject::IsDying()
+bool COldObject::IsDying() const
 {
     return m_dying != DeathType::Alive;
 }

--- a/colobot-base/src/object/old_object.h
+++ b/colobot-base/src/object/old_object.h
@@ -179,7 +179,7 @@ public:
     void        SetMasterParticle(int part, int parti) override;
 
     void        SetTransporter(CObject* transporter) override;
-    CObject*    GetTransporter() override;
+    CObject*    GetTransporter() const override;
     void        SetTransporterPart(int part) override;
 
     glm::mat4   GetRotateMatrix(int part);
@@ -240,7 +240,7 @@ public:
 
     void        SetDying(DeathType deathType) override;
     DeathType   GetDying() override;
-    bool        IsDying() override;
+    bool        IsDying() const override;
 
     bool        GetActive() override;
     bool        GetDetectable() override;

--- a/colobot-base/src/object/task/taskbuild.cpp
+++ b/colobot-base/src/object/task/taskbuild.cpp
@@ -430,7 +430,7 @@ Error CTaskBuild::Start(ObjectType type)
     if (IsObjectCarryingCargo(m_object))  return ERR_MANIP_BUSY;
 
     CObject* metal = SearchMetalObject(oAngle, 2.0f, 100.0f, Math::PI*0.25f, err);
-    m_metal_id = metal->GetID();
+    if ( metal ) m_metal_id = metal->GetID();
     if ( err == ERR_BUILD_METALNEAR && metal != nullptr )
     {
         err = FlatFloor();

--- a/colobot-base/src/object/task/taskbuild.cpp
+++ b/colobot-base/src/object/task/taskbuild.cpp
@@ -968,8 +968,8 @@ void CTaskBuild::DeleteMark(glm::vec3 pos, float radius)
 
 CObject* CTaskBuild::GetMetal()
 {
-    if ( !m_metal_id.has_value() ) return nullptr;
-    CObject* metal = CObjectManager::GetInstancePointer()->GetObjectById(m_metal_id.value());
+    assert(m_metal_id != -1);
+    CObject* metal = CObjectManager::GetInstancePointer()->GetObjectById(m_metal_id);
     if ( metal && metal->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject&>(*metal).IsDying() ) return nullptr;
     return metal;
 }

--- a/colobot-base/src/object/task/taskbuild.cpp
+++ b/colobot-base/src/object/task/taskbuild.cpp
@@ -479,7 +479,7 @@ Error CTaskBuild::IsEnded()
     if ( m_phase == TBP_TURN )  // preliminary rotation?
     {
         CObject* metal = GetMetal();
-        if ( !metal ) return ERR_STOP;
+        if ( !metal ) return ERR_BUILD_METALINEX;
 
         angle = m_object->GetRotationY();
         angle = Math::NormAngle(angle);  // 0..2*Math::PI
@@ -508,7 +508,7 @@ Error CTaskBuild::IsEnded()
     if ( m_phase == TBP_MOVE )  // preliminary forward/backward?
     {
         CObject* metal = GetMetal();
-        if ( !metal ) return ERR_STOP;
+        if ( !metal ) return ERR_BUILD_METALINEX;
 
         dist = glm::distance(m_object->GetPosition(), metal->GetPosition());
 
@@ -550,7 +550,7 @@ Error CTaskBuild::IsEnded()
     if ( m_phase == TBP_TAKE )  // takes gun
     {
         CObject* metal = GetMetal();
-        if ( !metal ) return ERR_STOP;
+        if ( !metal ) return ERR_BUILD_METALINEX;
 
         if ( m_progress < 1.0f )  return ERR_CONTINUE;
 
@@ -583,7 +583,7 @@ Error CTaskBuild::IsEnded()
     if ( m_phase == TBP_PREP )  // prepares?
     {
         CObject* metal = GetMetal();
-        if ( !metal ) return ERR_STOP;
+        if ( !metal ) return ERR_BUILD_METALINEX;
 
         if ( m_progress < 1.0f )  return ERR_CONTINUE;
 
@@ -602,10 +602,10 @@ Error CTaskBuild::IsEnded()
     if ( m_phase == TBP_BUILD )  // construction?
     {
         CObject* metal = GetMetal();
-        if ( !metal ) return ERR_STOP;
+        if ( !metal ) return ERR_BUILD_METALINEX;
         if ( m_progress < 1.0f )  return ERR_CONTINUE;
         CObject* building = GetBuilding();
-        if ( ! building ) return ERR_STOP;
+        if ( ! building ) return ERR_BUILD_METALINEX;
 
         DeleteMark(metal->GetPosition(), 20.0f);
 

--- a/colobot-base/src/object/task/taskbuild.cpp
+++ b/colobot-base/src/object/task/taskbuild.cpp
@@ -282,6 +282,8 @@ bool CTaskBuild::EventProcess(const Event &event)
         return true;
     }
 
+    assert(m_phase == TBP_BUILD);
+
     if ( !m_bBuild )  // building to build?
     {
         m_bBuild = true;
@@ -646,6 +648,18 @@ Error CTaskBuild::IsEnded()
 
 bool CTaskBuild::Abort()
 {
+    // If the metal still exists, then we did not finish the building
+    if ( m_metal )
+    {
+        m_metal->SetScale(1.0f);
+        m_metal->SetLock(false);
+        if (m_building)
+        {
+            CObjectManager::GetInstancePointer()->DeleteObject(m_building);
+            m_building = nullptr;
+        }
+    }
+
     if ( m_soundChannel != -1 )
     {
         m_sound->FlushEnvelope(m_soundChannel);

--- a/colobot-base/src/object/task/taskbuild.cpp
+++ b/colobot-base/src/object/task/taskbuild.cpp
@@ -95,8 +95,9 @@ void CTaskBuild::CreateBuilding(glm::vec3 pos, float angle, bool trainer)
     params.power = 0.0f;
     params.team = m_object->GetTeam();
     params.trainer = trainer;
-    m_building = CObjectManager::GetInstancePointer()->CreateObject(params);
-    m_building->SetLock(true);  // not yet usable
+    CObject* building = CObjectManager::GetInstancePointer()->CreateObject(params);
+    m_building_id = building->GetID();
+    building->SetLock(true);  // not yet usable
 
     if ( m_type == OBJECT_DERRICK  )  m_buildingHeight = 35.0f;
     if ( m_type == OBJECT_FACTORY  )  m_buildingHeight = 28.0f;
@@ -116,9 +117,9 @@ void CTaskBuild::CreateBuilding(glm::vec3 pos, float angle, bool trainer)
     if ( m_type == OBJECT_HUSTON   )  m_buildingHeight = 45.0f;
     m_buildingHeight *= 0.25f;
 
-    m_buildingPos = m_building->GetPosition();
+    m_buildingPos = building->GetPosition();
     m_buildingPos.y -= m_buildingHeight;
-    m_building->SetPosition(m_buildingPos);
+    building->SetPosition(m_buildingPos);
 }
 
 // Creates lights for the effects.
@@ -133,7 +134,9 @@ void CTaskBuild::CreateLight()
 
     if ( !m_engine->GetLightMode() )  return;
 
-    center = m_metal->GetPosition();
+    CObject* metal = GetMetal();
+    if (!metal) return;
+    center = metal->GetPosition();
 
     angle = 0;
     for ( i=0 ; i<TBMAXLIGHT ; i++ )
@@ -245,7 +248,10 @@ bool CTaskBuild::EventProcess(const Event &event)
 
     if ( m_phase == TBP_MOVE )  // preliminary forward/backward?
     {
-        dist = glm::distance(m_object->GetPosition(), m_metal->GetPosition());
+        CObject* metal = GetMetal();
+        if ( !metal ) return false;
+
+        dist = glm::distance(m_object->GetPosition(), metal->GetPosition());
         linSpeed = 0.0f;
         if ( m_physics->GetLand() )
         {
@@ -284,29 +290,48 @@ bool CTaskBuild::EventProcess(const Event &event)
 
     assert(m_phase == TBP_BUILD);
 
+    CObject* metal = GetMetal();
+    if ( !metal )
+    {
+        // Metal was destroyed before the building was finished
+        if (CObject* building = GetBuilding())
+        {
+            CObjectManager::GetInstancePointer()->DeleteObject(building);
+        }
+        return false;
+    }
+
     if ( !m_bBuild )  // building to build?
     {
         m_bBuild = true;
 
-        pos = m_metal->GetPosition();
+        pos = metal->GetPosition();
         a   = m_object->GetRotationY();
         CreateBuilding(pos, a+Math::PI, m_object->GetTrainer());
         CreateLight();
     }
 
+    CObject* building = GetBuilding();
+    if ( !building )
+    {
+        // A partially built building was destroyed
+        CObjectManager::GetInstancePointer()->DeleteObject(metal);
+        return false;
+    }
+
     pos = m_buildingPos;
     pos.y += m_buildingHeight*m_progress;
-    m_building->SetPosition(pos);  // the building rises
+    building->SetPosition(pos);  // the building rises
 
-    m_building->SetScale(m_progress*0.75f+0.25f);
-    m_metal->SetScale(1.0f-m_progress);
+    metal->SetScale(1.0f-m_progress);
+    building->SetScale(m_progress*0.75f+0.25f);
 
     a = (2.0f-2.0f*m_progress);
     if ( a > 1.0f )  a = 1.0f;
     dir.x = (Math::Rand()-0.5f)*a*0.1f;
     dir.z = (Math::Rand()-0.5f)*a*0.1f;
     dir.y = (Math::Rand()-0.5f)*a*0.1f;
-    m_building->SetCirVibration(dir);
+    building->SetCirVibration(dir);
 
     if ( !m_bBlack && m_progress >= 0.25f )
     {
@@ -317,7 +342,7 @@ bool CTaskBuild::EventProcess(const Event &event)
     {
         m_lastParticle = m_time;
 
-        pos = m_metal->GetPosition();
+        pos = metal->GetPosition();
         speed.x = (Math::Rand()-0.5f)*20.0f;
         speed.z = (Math::Rand()-0.5f)*20.0f;
         speed.y = Math::Rand()*10.0f;
@@ -347,7 +372,7 @@ bool CTaskBuild::EventProcess(const Event &event)
                 break;
         }
         pos = Math::Transform(mat, pos);
-        speed = m_metal->GetPosition();
+        speed = metal->GetPosition();
         speed.x += (Math::Rand()-0.5f)*5.0f;
         speed.z += (Math::Rand()-0.5f)*5.0f;
         speed -= pos;
@@ -364,7 +389,7 @@ bool CTaskBuild::EventProcess(const Event &event)
     if(m_object->GetType() == OBJECT_MOBILEfb && m_object->GetReactorRange()<0.2f && m_phase != TBP_MOVE)
     {
         pv = m_object->GetPosition();
-        pm = m_metal->GetPosition();
+        pm = metal->GetPosition();
         dist = glm::distance(pv, pm);
         diff = pm.y - 8.0f - pv.y;
         tilt = m_object->GetRotation();
@@ -404,8 +429,9 @@ Error CTaskBuild::Start(ObjectType type)
 
     if (IsObjectCarryingCargo(m_object))  return ERR_MANIP_BUSY;
 
-    m_metal = SearchMetalObject(oAngle, 2.0f, 100.0f, Math::PI*0.25f, err);
-    if ( err == ERR_BUILD_METALNEAR && m_metal != nullptr )
+    CObject* metal = SearchMetalObject(oAngle, 2.0f, 100.0f, Math::PI*0.25f, err);
+    m_metal_id = metal->GetID();
+    if ( err == ERR_BUILD_METALNEAR && metal != nullptr )
     {
         err = FlatFloor();
         if ( err != ERR_OK )  return err;
@@ -417,10 +443,10 @@ Error CTaskBuild::Start(ObjectType type)
     if ( err != ERR_OK )  return err;
 
     pv = m_object->GetPosition();
-    pm = m_metal->GetPosition();
+    pm = metal->GetPosition();
     if(!m_physics->GetLand() && fabs(pm.y-pv.y)>8.0f) return ERR_BUILD_METALAWAY;
 
-    m_metal->SetLock(true);  // not usable
+    metal->SetLock(true);  // not usable
     m_camera->StartCentering(m_object, Math::PI*0.15f, 99.9f, 0.0f, 1.0f);
 
     m_phase = TBP_TURN;  // rotation necessary preliminary
@@ -440,7 +466,6 @@ Error CTaskBuild::Start(ObjectType type)
 
 Error CTaskBuild::IsEnded()
 {
-    CAuto*      automat;
     float       angle, dist, time, diff;
     glm::vec3       pv,   pm,   tilt;
 
@@ -449,6 +474,9 @@ Error CTaskBuild::IsEnded()
 
     if ( m_phase == TBP_TURN )  // preliminary rotation?
     {
+        CObject* metal = GetMetal();
+        if ( !metal ) return ERR_STOP;
+
         angle = m_object->GetRotationY();
         angle = Math::NormAngle(angle);  // 0..2*Math::PI
 
@@ -456,7 +484,7 @@ Error CTaskBuild::IsEnded()
         {
             m_physics->SetMotorSpeedZ(0.0f);
 
-            dist = glm::distance(m_object->GetPosition(), m_metal->GetPosition());
+            dist = glm::distance(m_object->GetPosition(), metal->GetPosition());
             if ( dist > 30.0f )
             {
                 time = m_physics->GetLinTimeLength(dist-30.0f, 1.0f);
@@ -475,7 +503,10 @@ Error CTaskBuild::IsEnded()
 
     if ( m_phase == TBP_MOVE )  // preliminary forward/backward?
     {
-        dist = glm::distance(m_object->GetPosition(), m_metal->GetPosition());
+        CObject* metal = GetMetal();
+        if ( !metal ) return ERR_STOP;
+
+        dist = glm::distance(m_object->GetPosition(), metal->GetPosition());
 
         if ( !m_physics->GetLand())
         {
@@ -502,7 +533,7 @@ Error CTaskBuild::IsEnded()
         {
             if ( m_progress > 1.0f )  // timeout?
             {
-                m_metal->SetLock(false);  // usable again
+                metal->SetLock(false);  // usable again
                 if ( dist < 30.0f )  return ERR_BUILD_METALNEAR;
                 else                 return ERR_BUILD_METALAWAY;
             }
@@ -512,6 +543,9 @@ Error CTaskBuild::IsEnded()
 
     if ( m_phase == TBP_TAKE )  // takes gun
     {
+        CObject* metal = GetMetal();
+        if ( !metal ) return ERR_STOP;
+
         if ( m_progress < 1.0f )  return ERR_CONTINUE;
 
         m_motion->SetAction(MHS_FIRE);  // shooting position
@@ -528,7 +562,7 @@ Error CTaskBuild::IsEnded()
         {
             m_object->SetObjectParent(1, 0);
             pv = m_object->GetPosition();
-            pm = m_metal->GetPosition();
+            pm = metal->GetPosition();
             dist = glm::distance(pv, pm);
             diff = pm.y - 8.0f - pv.y;
             tilt = m_object->GetRotation();
@@ -542,6 +576,9 @@ Error CTaskBuild::IsEnded()
 
     if ( m_phase == TBP_PREP )  // prepares?
     {
+        CObject* metal = GetMetal();
+        if ( !metal ) return ERR_STOP;
+
         if ( m_progress < 1.0f )  return ERR_CONTINUE;
 
         m_soundChannel = m_sound->Play(SOUND_TREMBLE, m_object->GetPosition(), 0.0f, 1.0f, true);
@@ -549,7 +586,7 @@ Error CTaskBuild::IsEnded()
         m_sound->AddEnvelope(m_soundChannel, 0.7f, 1.5f, 7.0f, SOPER_CONTINUE);
         m_sound->AddEnvelope(m_soundChannel, 0.0f, 1.5f, 2.0f, SOPER_STOP);
 
-        m_camera->StartEffect(Gfx::CAM_EFFECT_VIBRATION, m_metal->GetPosition(), 1.0f);
+        m_camera->StartEffect(Gfx::CAM_EFFECT_VIBRATION, metal->GetPosition(), 1.0f);
 
         m_phase = TBP_BUILD;
         m_speed = 1.0f/10.f;  // duration of 10s
@@ -558,24 +595,23 @@ Error CTaskBuild::IsEnded()
 
     if ( m_phase == TBP_BUILD )  // construction?
     {
+        CObject* metal = GetMetal();
+        if ( !metal ) return ERR_STOP;
         if ( m_progress < 1.0f )  return ERR_CONTINUE;
+        CObject* building = GetBuilding();
+        if ( ! building ) return ERR_STOP;
 
-        DeleteMark(m_metal->GetPosition(), 20.0f);
+        DeleteMark(metal->GetPosition(), 20.0f);
 
-        CObjectManager::GetInstancePointer()->DeleteObject(m_metal);
-        m_metal = nullptr;
+        CObjectManager::GetInstancePointer()->DeleteObject(metal);
 
-        m_building->SetScale(1.0f);
-        m_building->SetCirVibration(glm::vec3(0.0f, 0.0f, 0.0f));
-        m_building->SetLock(false);  // building usable
+        building->SetScale(1.0f);
+        building->SetCirVibration(glm::vec3(0.0f, 0.0f, 0.0f));
+        building->SetLock(false);  // building usable
         m_main->CreateShortcuts();
         m_main->DisplayError(INFO_BUILD, m_buildingPos, 10.0f, 50.0f);
 
-        automat = m_building->GetAuto();
-        if ( automat != nullptr )
-        {
-            automat->Init();
-        }
+        if (CAuto* automat = building->GetAuto()) automat->Init();
 
         m_motion->SetAction(MHS_GUN);  // hands gun
         m_phase = TBP_TERM;
@@ -637,7 +673,7 @@ Error CTaskBuild::IsEnded()
         m_physics->SetMotorSpeedX(0.0f);
         m_physics->SetMotorSpeedZ(0.0f);
 
-        m_metal->SetLock(false); // make titanium usable
+        if ( CObject* metal = GetMetal() ) metal->SetLock(false); // make titanium usable
     }
 
     Abort();
@@ -649,14 +685,13 @@ Error CTaskBuild::IsEnded()
 bool CTaskBuild::Abort()
 {
     // If the metal still exists, then we did not finish the building
-    if ( m_metal )
+    if ( CObject* metal = GetMetal() )
     {
-        m_metal->SetScale(1.0f);
-        m_metal->SetLock(false);
-        if (m_building)
+        metal->SetScale(1.0f);
+        metal->SetLock(false);
+        if (CObject* building = GetBuilding())
         {
-            CObjectManager::GetInstancePointer()->DeleteObject(m_building);
-            m_building = nullptr;
+            CObjectManager::GetInstancePointer()->DeleteObject(building);
         }
     }
 
@@ -683,6 +718,9 @@ Error CTaskBuild::FlatFloor()
     float       radius, max, bRadius = 0.0f, angle, dist;
     bool        bLittleFlat, bBase;
 
+    CObject* metal = GetMetal();
+    if (!metal) return ERR_BUILD_METALINEX;
+
     radius = 0.0f;
     if ( m_type == OBJECT_DERRICK  )  radius =  5.0f;
     if ( m_type == OBJECT_FACTORY  )  radius = 15.0f;
@@ -701,7 +739,7 @@ Error CTaskBuild::FlatFloor()
     if ( m_type == OBJECT_DESTROYER)  radius = 20.0f;
     //if ( radius == 0.0f )  return ERR_UNKNOWN;
 
-    center = m_metal->GetPosition();
+    center = metal->GetPosition();
     angle = m_terrain->GetFineSlope(center);
     bLittleFlat = ( angle < Gfx::TERRAIN_FLATLIMIT);
 
@@ -710,7 +748,7 @@ Error CTaskBuild::FlatFloor()
     {
         if ( bLittleFlat )
         {
-            m_main->SetShowLimit(1, Gfx::PARTILIMIT3, m_metal, center, max, 10.0f);
+            m_main->SetShowLimit(1, Gfx::PARTILIMIT3, metal, center, max, 10.0f);
         }
         return bLittleFlat?ERR_BUILD_FLATLIT:ERR_BUILD_FLAT;
     }
@@ -721,7 +759,7 @@ Error CTaskBuild::FlatFloor()
     {
         if ( !pObj->GetActive() )  continue;  // inactive?
         if (IsObjectBeingTransported(pObj))  continue;
-        if ( pObj == m_metal )  continue;
+        if ( pObj == metal )  continue;
         if ( pObj == m_object )  continue;
 
         type = pObj->GetType();
@@ -757,9 +795,9 @@ Error CTaskBuild::FlatFloor()
     }
     if ( max < radius )
     {
-        m_main->SetShowLimit(1, Gfx::PARTILIMIT2, m_metal, center, max, 10.0f);
+        m_main->SetShowLimit(1, Gfx::PARTILIMIT2, metal, center, max, 10.0f);
         if ( bRadius < 2.0f )  bRadius = 2.0f;
-        m_main->SetShowLimit(2, Gfx::PARTILIMIT3, m_metal, bPos, bRadius, 10.0f);
+        m_main->SetShowLimit(2, Gfx::PARTILIMIT3, metal, bPos, bRadius, 10.0f);
         return bBase?ERR_BUILD_BASE:ERR_BUILD_BUSY;
     }
 
@@ -768,7 +806,7 @@ Error CTaskBuild::FlatFloor()
     {
         if ( !pObj->GetActive() )  continue;  // inactive?
         if (IsObjectBeingTransported(pObj))  continue;
-        if ( pObj == m_metal )  continue;
+        if ( pObj == metal )  continue;
         if ( pObj == m_object )  continue;
 
         type = pObj->GetType();
@@ -808,8 +846,8 @@ Error CTaskBuild::FlatFloor()
     }
     if ( max-BUILDMARGIN < radius )
     {
-        m_main->SetShowLimit(1, Gfx::PARTILIMIT2, m_metal, center, max-BUILDMARGIN, 10.0f);
-        m_main->SetShowLimit(2, Gfx::PARTILIMIT3, m_metal, bPos, bRadius+BUILDMARGIN, 10.0f);
+        m_main->SetShowLimit(1, Gfx::PARTILIMIT2, metal, center, max-BUILDMARGIN, 10.0f);
+        m_main->SetShowLimit(2, Gfx::PARTILIMIT3, metal, bPos, bRadius+BUILDMARGIN, 10.0f);
         return bBase?ERR_BUILD_BASE:ERR_BUILD_NARROW;
     }
 
@@ -911,4 +949,21 @@ void CTaskBuild::DeleteMark(glm::vec3 pos, float radius)
     {
         CObjectManager::GetInstancePointer()->DeleteObject(obj);
     }
+}
+
+
+CObject* CTaskBuild::GetMetal()
+{
+    if ( !m_metal_id.has_value() ) return nullptr;
+    CObject* metal = CObjectManager::GetInstancePointer()->GetObjectById(m_metal_id.value());
+    if ( metal && metal->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject&>(*metal).IsDying() ) return nullptr;
+    return metal;
+}
+
+CObject* CTaskBuild::GetBuilding()
+{
+    if ( !m_building_id.has_value() ) return nullptr;
+    CObject* building = CObjectManager::GetInstancePointer()->GetObjectById(m_building_id.value());
+    if ( building && building->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject&>(*building).IsDying() ) return nullptr;
+    return building;
 }

--- a/colobot-base/src/object/task/taskbuild.h
+++ b/colobot-base/src/object/task/taskbuild.h
@@ -24,6 +24,8 @@
 
 #include "object/object_type.h"
 
+#include <optional>
+
 #include <glm/glm.hpp>
 
 
@@ -66,11 +68,13 @@ protected:
     void        BlackLight();
     CObject*    SearchMetalObject(float &angle, float dMin, float dMax, float aLimit, Error &err);
     void        DeleteMark(glm::vec3 pos, float radius);
+    CObject*    GetMetal();
+    CObject*    GetBuilding();
 
 protected:
     ObjectType      m_type = OBJECT_NULL;                  // type of construction
-    CObject*        m_metal = nullptr;                 // transforms metal object
-    CObject*        m_building = nullptr;              // building built
+    std::optional<unsigned int> m_metal_id;  // transforms metal object
+    std::optional<unsigned int> m_building_id;  // building built
     TaskBuildPhase  m_phase = TBP_STOP;                 // phase of the operation
     bool            m_bError = false;                // true -> operation impossible
     bool            m_bBuild = false;                // true -> building built

--- a/colobot-base/src/object/task/taskbuild.h
+++ b/colobot-base/src/object/task/taskbuild.h
@@ -73,8 +73,8 @@ protected:
 
 protected:
     ObjectType      m_type = OBJECT_NULL;                  // type of construction
-    std::optional<unsigned int> m_metal_id;  // transforms metal object
-    std::optional<unsigned int> m_building_id;  // building built
+    int             m_metal_id = -1;  // transforms metal object
+    std::optional<int> m_building_id;  // building built
     TaskBuildPhase  m_phase = TBP_STOP;                 // phase of the operation
     bool            m_bError = false;                // true -> operation impossible
     bool            m_bBuild = false;                // true -> building built

--- a/colobot-base/src/object/task/taskbuild.h
+++ b/colobot-base/src/object/task/taskbuild.h
@@ -70,7 +70,6 @@ protected:
 protected:
     ObjectType      m_type = OBJECT_NULL;                  // type of construction
     CObject*        m_metal = nullptr;                 // transforms metal object
-    CObject*        m_power = nullptr;                 // the vehicle battery
     CObject*        m_building = nullptr;              // building built
     TaskBuildPhase  m_phase = TBP_STOP;                 // phase of the operation
     bool            m_bError = false;                // true -> operation impossible

--- a/colobot-base/src/object/task/taskbuild.h
+++ b/colobot-base/src/object/task/taskbuild.h
@@ -73,7 +73,7 @@ protected:
 
 protected:
     ObjectType      m_type = OBJECT_NULL;                  // type of construction
-    int             m_metal_id = -1;  // transforms metal object
+    std::optional<int> m_metal_id;  // transforms metal object
     std::optional<int> m_building_id;  // building built
     TaskBuildPhase  m_phase = TBP_STOP;                 // phase of the operation
     bool            m_bError = false;                // true -> operation impossible

--- a/colobot-base/src/object/task/taskrecover.cpp
+++ b/colobot-base/src/object/task/taskrecover.cpp
@@ -234,7 +234,11 @@ Error CTaskRecover::IsEnded()
         case TRP_TURN:  // preliminary rotation?
         {
             CObject* ruin = GetRuin();
-            if ( !ruin ) return ERR_RECOVER_NULL;
+            if ( !ruin )
+            {
+                Abort();
+                return ERR_RECOVER_NULL;
+            }
 
             angle = m_object->GetRotationY();
             angle = Math::NormAngle(angle);  // 0..2*Math::PI
@@ -263,7 +267,11 @@ Error CTaskRecover::IsEnded()
         case TRP_MOVE:  // preliminary advance?
         {
             CObject* ruin = GetRuin();
-            if ( !ruin ) return ERR_RECOVER_NULL;
+            if ( !ruin )
+            {
+                Abort();
+                return ERR_RECOVER_NULL;
+            }
 
             dist = glm::distance(m_object->GetPosition(), ruin->GetPosition());
 
@@ -291,8 +299,7 @@ Error CTaskRecover::IsEnded()
             {
                 if ( m_progress > 1.0f )  // timeout?
                 {
-                    ruin->SetLock(false);  // usable again
-                    m_camera->StopCentering(m_object, 2.0f);
+                    Abort();
                     return ERR_RECOVER_NULL;
                 }
             }
@@ -439,8 +446,8 @@ CObject* CTaskRecover::SearchRuin()
 
 CObject* CTaskRecover::GetRuin()
 {
-    assert(m_ruin_id != -1);
-    CObject* ruin = CObjectManager::GetInstancePointer()->GetObjectById(m_ruin_id);
+    if ( !m_ruin_id.has_value() ) return nullptr;
+    CObject* ruin = CObjectManager::GetInstancePointer()->GetObjectById(m_ruin_id.value());
     if ( ruin && ruin->Implements(ObjectInterfaceType::Destroyable) && dynamic_cast<CDestroyableObject&>(*ruin).IsDying() ) return nullptr;
     return ruin;
 }

--- a/colobot-base/src/object/task/taskrecover.cpp
+++ b/colobot-base/src/object/task/taskrecover.cpp
@@ -189,11 +189,7 @@ Error CTaskRecover::Start()
     ObjectType type = m_object->GetType();
     if ( type != OBJECT_MOBILErr )  return ERR_WRONG_BOT;
 
-    CPowerContainerObject *power = GetObjectPowerCell(m_object);
-    if (power == nullptr)  return ERR_RECOVER_ENERGY;
-
-    float energy = power->GetEnergy();
-    if ( energy < ENERGY_RECOVER+0.05f )  return ERR_RECOVER_ENERGY;
+    if ( GetObjectEnergy(m_object) < ENERGY_RECOVER+0.05f )  return ERR_RECOVER_ENERGY;
 
     glm::mat4 mat = m_object->GetWorldMatrix(0);
     glm::vec3 pos = glm::vec3(RECOVER_DIST, 3.3f, 0.0f);

--- a/colobot-base/src/object/task/taskrecover.cpp
+++ b/colobot-base/src/object/task/taskrecover.cpp
@@ -345,6 +345,11 @@ Error CTaskRecover::IsEnded()
                 Abort();
                 return ERR_RECOVER_NULL;
             }
+            if ( GetObjectEnergy(m_object) == 0.0f )
+            {
+                Abort();
+                return ERR_RECOVER_ENERGY;
+            }
 
             if ( m_progress < 1.0f )  return ERR_CONTINUE;
 

--- a/colobot-base/src/object/task/taskrecover.cpp
+++ b/colobot-base/src/object/task/taskrecover.cpp
@@ -320,7 +320,7 @@ Error CTaskRecover::IsEnded()
             pos = Math::Transform(mat, pos);
             goal = glm::vec3(RECOVER_DIST, 3.1f, -3.9f);
             goal = Math::Transform(mat, goal);
-            m_particle->CreateRay(pos, goal, Gfx::PARTIRAY2,
+            m_rayChannel = m_particle->CreateRay(pos, goal, Gfx::PARTIRAY2,
                                   { 2.0f, 2.0f }, 8.0f);
 
             m_soundChannel = m_sound->Play(SOUND_RECOVER, ruin->GetPosition(), 0.0f, 1.0f, true);
@@ -405,6 +405,8 @@ bool CTaskRecover::Abort()
             metal->SetScale(1.0f);
         }
     }
+
+    if ( m_rayChannel.has_value() ) m_particle->DeleteParticle(m_rayChannel.value());
 
     m_object->SetPartRotationZ(2,  126.0f*Math::PI/180.0f);
     m_object->SetPartRotationZ(4,  126.0f*Math::PI/180.0f);

--- a/colobot-base/src/object/task/taskrecover.cpp
+++ b/colobot-base/src/object/task/taskrecover.cpp
@@ -302,7 +302,11 @@ Error CTaskRecover::IsEnded()
         case TRP_DOWN:
         {
             CObject* ruin = GetRuin();
-            if ( !ruin ) return ERR_RECOVER_NULL;
+            if ( !ruin )
+            {
+                Abort();
+                return ERR_RECOVER_NULL;
+            }
 
             if ( m_progress < 1.0f )  return ERR_CONTINUE;
 
@@ -338,6 +342,7 @@ Error CTaskRecover::IsEnded()
             {
                 if ( metal ) CObjectManager::GetInstancePointer()->DeleteObject(metal);
                 if ( ruin ) CObjectManager::GetInstancePointer()->DeleteObject(ruin);
+                Abort();
                 return ERR_RECOVER_NULL;
             }
 
@@ -363,7 +368,11 @@ Error CTaskRecover::IsEnded()
         case TRP_UP:
         {
             CObject* metal = GetMetal();
-            if ( !metal ) return ERR_RECOVER_NULL;
+            if ( !metal )
+            {
+                Abort();
+                return ERR_RECOVER_NULL;
+            }
 
             if ( m_progress < 1.0f )  return ERR_CONTINUE;
 
@@ -381,6 +390,22 @@ Error CTaskRecover::IsEnded()
 
 bool CTaskRecover::Abort()
 {
+    if ( CObject* ruin = GetRuin() )
+    {
+        ruin->SetLock(false);
+        ruin->SetCirVibration(glm::vec3(0.0f));
+        ruin->SetScale(1.0f);
+        if (CObject* metal = GetMetal()) CObjectManager::GetInstancePointer()->DeleteObject(metal);
+    }
+    else
+    {
+        if (CObject* metal = GetMetal())
+        {
+            metal->SetLock(false);
+            metal->SetScale(1.0f);
+        }
+    }
+
     m_object->SetPartRotationZ(2,  126.0f*Math::PI/180.0f);
     m_object->SetPartRotationZ(4,  126.0f*Math::PI/180.0f);
     m_object->SetPartRotationZ(3, -144.0f*Math::PI/180.0f);

--- a/colobot-base/src/object/task/taskrecover.cpp
+++ b/colobot-base/src/object/task/taskrecover.cpp
@@ -201,6 +201,8 @@ Error CTaskRecover::Start()
     if ( ruin == nullptr )  return ERR_RECOVER_NULL;
     m_ruin_id = ruin->GetID();
     ruin->SetLock(true);  // ruin no longer usable
+    ruin->SetLockOverride(false);
+    ruin->SetScaleOverride(glm::vec3(1.0f));
 
     glm::vec3 iPos = m_object->GetPosition();
     glm::vec3 oPos = ruin->GetPosition();
@@ -321,6 +323,7 @@ Error CTaskRecover::IsEnded()
             m_metal_id = metal->GetID();
             metal->SetLock(true);  // metal not yet usable
             metal->SetScale(0.0f);
+            metal->SetPersistent(false);
 
             glm::mat4 mat = m_object->GetWorldMatrix(0);
             pos = glm::vec3(RECOVER_DIST, 3.1f, 3.9f);
@@ -361,6 +364,8 @@ Error CTaskRecover::IsEnded()
             if ( m_progress < 1.0f )  return ERR_CONTINUE;
 
             metal->SetScale(1.0f);
+            metal->SetPersistent(true);
+            metal->SetLockOverride(false);
 
             CObjectManager::GetInstancePointer()->DeleteObject(ruin);
 
@@ -389,6 +394,7 @@ Error CTaskRecover::IsEnded()
             if ( m_progress < 1.0f )  return ERR_CONTINUE;
 
             metal->SetLock(false);  // metal usable
+            metal->SetLockOverride({});
 
             Abort();
             return ERR_STOP;
@@ -404,17 +410,21 @@ bool CTaskRecover::Abort()
 {
     if ( CObject* ruin = GetRuin() )
     {
-        ruin->SetLock(false);
         ruin->SetCirVibration(glm::vec3(0.0f));
+        ruin->SetLock(false);
         ruin->SetScale(1.0f);
+        ruin->SetLockOverride({});
+        ruin->SetScaleOverride({});
         if (CObject* metal = GetMetal()) CObjectManager::GetInstancePointer()->DeleteObject(metal);
     }
     else
     {
         if (CObject* metal = GetMetal())
         {
-            metal->SetLock(false);
             metal->SetScale(1.0f);
+            metal->SetPersistent(true);
+            metal->SetLock(false);
+            metal->SetLockOverride({});
         }
     }
 

--- a/colobot-base/src/object/task/taskrecover.h
+++ b/colobot-base/src/object/task/taskrecover.h
@@ -63,7 +63,7 @@ protected:
     float           m_angle = 0.0f;
     float           m_lastParticle = 0.0f;
     bool            m_bError = false;
-    int             m_ruin_id = -1;
+    std::optional<int> m_ruin_id;
     std::optional<int> m_metal_id;
     glm::vec3       m_recoverPos = { 0, 0, 0 };
     int             m_soundChannel = -1;

--- a/colobot-base/src/object/task/taskrecover.h
+++ b/colobot-base/src/object/task/taskrecover.h
@@ -67,4 +67,5 @@ protected:
     std::optional<int> m_metal_id;
     glm::vec3       m_recoverPos = { 0, 0, 0 };
     int             m_soundChannel = -1;
+    std::optional<int> m_rayChannel;
 };

--- a/colobot-base/src/object/task/taskrecover.h
+++ b/colobot-base/src/object/task/taskrecover.h
@@ -22,6 +22,8 @@
 
 #include "object/task/task.h"
 
+#include <optional>
+
 #include <glm/glm.hpp>
 
 class CObject;
@@ -41,7 +43,6 @@ class CTaskRecover : public CForegroundTask
 {
 public:
     CTaskRecover(COldObject* object);
-    ~CTaskRecover();
 
     bool        EventProcess(const Event &event) override;
 
@@ -51,6 +52,8 @@ public:
 
 protected:
     CObject*    SearchRuin();
+    CObject*    GetRuin();
+    CObject*    GetMetal();
 
 protected:
     TaskRecoverPhase m_phase = TRP_TURN;
@@ -60,8 +63,8 @@ protected:
     float           m_angle = 0.0f;
     float           m_lastParticle = 0.0f;
     bool            m_bError = false;
-    CObject*        m_ruin = nullptr;
-    CObject*        m_metal = nullptr;
+    int             m_ruin_id = -1;
+    std::optional<int> m_metal_id;
     glm::vec3       m_recoverPos = { 0, 0, 0 };
-    int             m_soundChannel = 0;
+    int             m_soundChannel = -1;
 };


### PR DESCRIPTION
Main idea:
* Cancelling a partially complete build() should result in a usable titanium cube
* Cancelling a partially complete recycle() should result in a usable wreck

Full change description:

* Fix #1756
* Fix #1757
* Fix #1413
* Fix #1428
* Fix #1025
* Adds a partial workaround for #1755 - prevents buildings, titanium cube and wrecks from getting stuck in an unusable state if the game is saved while a build() or recycle() task is in progress
* Some code cleanup/refactor