### PR TITLE
Print byte as a number

### DIFF
--- a/CBot/src/CBot/CBotVar/CBotVarValue.h
+++ b/CBot/src/CBot/CBotVar/CBotVarValue.h
@@ -290,6 +290,13 @@ public:
     {
         this->m_val = ~(this->m_val);
     }
+
+    std::string GetValString() const override
+    {
+        std::ostringstream s;
+        s << +this->m_val;
+        return s.str();
+    }
 };
 
 } // namespace CBot

--- a/test/src/CBot/CBot_test.cpp
+++ b/test/src/CBot/CBot_test.cpp
@@ -3542,3 +3542,12 @@ TEST_F(CBotUT, TestFinally) {
         CBotErrBadType2
     );
 }
+
+TEST_F(CBotUT, TestByteToString) {
+    ExecuteTest(
+        "extern void TestByteToString() {\n"
+        "    byte c = 90;\n"
+        "    ASSERT(c + \"\" == \"90\");\n"
+        "}\n"
+    );
+}


### PR DESCRIPTION
Fix #1446

In CBot the type `byte` behaves like `int`, but with a smaller range of values. The `message()` function used to incorrectly interpret it as utf-8 encoded text. Now printing it should correctly display it as a number.

```c++
extern void New()
{
	byte b = 88;
	message (b);
}
```

![image](https://github.com/user-attachments/assets/57d7f522-4696-4d4b-99a8-ef59057e4e32)