### PR TITLE
Fix error message

### DIFF
--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -2922,10 +2922,17 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
                             if (rank >= 0)
                             {
                                 // TODO: Fix default levels and add a future removal warning
-                                GetLogger()->Warn("This level is using deprecated way of defining %% scene. Please change the %%= parameter in EndingFile from %% to \"levels/other/%1$s%2$03d.txt\".\n", type, type, rank);
                                 std::stringstream ss;
                                 ss << std::setfill('0') << std::setw(3) << rank << ".txt";
-                                return "levels/other" / StrUtils::ToPath(type) / StrUtils::ToPath(ss.str());
+                                auto result = "levels/other" / StrUtils::ToPath(type) / StrUtils::ToPath(ss.str());
+                                GetLogger()->Warn(
+                                        "This level is using deprecated way of defining %% scene. Please change the %%= parameter in EndingFile from %% to \"%%\".\n",
+                                        type,
+                                        type,
+                                        rank,
+                                        StrUtils::ToString(result)
+                                        );
+                                return result;
                             }
                             else
                             {


### PR DESCRIPTION
* Fix #1722

Now it prints the expected error message:

```c++
[WARN]: This level is using deprecated way of defining win scene. Please change the win= parameter in EndingFile from 101 to "levels/other/win/101.txt".
[WARN]: This level is using deprecated way of defining lost scene. Please change the lost= parameter in EndingFile from 0 to "levels/other/lost/000.txt".
```