### PR TITLE
Convert even more paths to std::filesystem::path

### DIFF
--- a/CBot/src/CBot/stdlib/FileFunctions.cpp
+++ b/CBot/src/CBot/stdlib/FileFunctions.cpp
@@ -43,7 +43,16 @@ bool FileClassOpenFile(CBotVar* pThis, CBotVar* pVar, CBotVar* pResult, int& Exc
     // must be a character string
     if ( pVar->GetType() != CBotTypString ) { Exception = CBotErrBadString; return false; }
 
-    std::string  filename = pVar->GetValString();
+    std::filesystem::path  filename;
+    try
+    {
+        filename = StrUtils::ToPath(pVar->GetValString());
+    }
+    catch(...)
+    {
+        Exception = CBotErrFileOpen;
+        return false;
+    }
 
     // there may be a second parameter
     pVar = pVar->GetNext();
@@ -62,7 +71,7 @@ bool FileClassOpenFile(CBotVar* pThis, CBotVar* pVar, CBotVar* pResult, int& Exc
 
     // saves the file name
     pVar = pThis->GetItem("filename");
-    pVar->SetValString(filename);
+    pVar->SetValString(StrUtils::ToString(filename));
 
     // retrieve the item "handle"
     pVar = pThis->GetItem("handle");

--- a/CBot/src/CBot/stdlib/FileFunctions.cpp
+++ b/CBot/src/CBot/stdlib/FileFunctions.cpp
@@ -19,6 +19,8 @@
 
 #include "CBot/stdlib/stdlib.h"
 
+#include "common/stringutils.h"
+
 #include "CBot/CBot.h"
 
 #include <memory>
@@ -351,7 +353,16 @@ CBotTypResult cfeof (CBotVar* pThis, CBotVar* &pVar)
 
 bool rDeleteFile(CBotVar* var, CBotVar* result, int& exception, void* user)
 {
-    std::string filename = var->GetValString();
+    std::filesystem::path filename;
+    try
+    {
+        filename = StrUtils::ToPath(var->GetValString());
+    }
+    catch(...)
+    {
+        exception = CBotErrFileOpen;
+        return false;
+    }
     assert(g_fileHandler != nullptr);
     return g_fileHandler->DeleteFile(filename);
 }

--- a/CBot/src/CBot/stdlib/stdlib_public.h
+++ b/CBot/src/CBot/stdlib/stdlib_public.h
@@ -22,6 +22,7 @@
 #include "CBot/stdlib/Compilation.h"
 
 #include <memory>
+#include <filesystem>
 
 namespace CBot
 {
@@ -46,7 +47,7 @@ public:
 
     enum class OpenMode : char { Read = 'r', Write = 'w', Append = 'a' };
     virtual std::unique_ptr<CBotFile> OpenFile(const std::string& filename, OpenMode mode) = 0;
-    virtual bool DeleteFile(const std::string& filename) = 0;
+    virtual bool DeleteFile(const std::filesystem::path& filename) = 0;
 };
 
 void SetFileAccessHandler(std::unique_ptr<CBotFileAccessHandler> fileHandler);

--- a/CBot/src/CBot/stdlib/stdlib_public.h
+++ b/CBot/src/CBot/stdlib/stdlib_public.h
@@ -46,7 +46,7 @@ public:
     virtual ~CBotFileAccessHandler() {}
 
     enum class OpenMode : char { Read = 'r', Write = 'w', Append = 'a' };
-    virtual std::unique_ptr<CBotFile> OpenFile(const std::string& filename, OpenMode mode) = 0;
+    virtual std::unique_ptr<CBotFile> OpenFile(const std::filesystem::path& filename, OpenMode mode) = 0;
     virtual bool DeleteFile(const std::filesystem::path& filename) = 0;
 };
 

--- a/colobot-base/src/app/app.cpp
+++ b/colobot-base/src/app/app.cpp
@@ -346,7 +346,7 @@ ParseArgsStatus CApplication::ParseArguments(const std::vector<std::string>& arg
                 if (pos != std::string::npos && pos > 0 && pos+1 < playerAndPath.length()) // Split player name from path
                 {
                     m_loadSavePlayerName = playerAndPath.substr(0, pos);
-                    m_loadSaveDirName = playerAndPath.substr(pos+1, playerAndPath.length()-pos-1);
+                    m_loadSaveDirName = StrUtils::ToPath(playerAndPath.substr(pos+1, playerAndPath.length()-pos-1));
                 }
                 else
                 {
@@ -690,7 +690,7 @@ bool CApplication::Create()
     if (!m_loadSaveDirName.empty())
     {
         m_controller->GetRobotMain()->SelectPlayer(m_loadSavePlayerName);
-        m_controller->GetRobotMain()->LoadSaveFromDirName(TempToPath(m_loadSaveDirName));
+        m_controller->GetRobotMain()->LoadSaveFromDirName(m_loadSaveDirName);
     }
     else if (m_runSceneCategory == LevelCategory::Max)
     {

--- a/colobot-base/src/app/app.cpp
+++ b/colobot-base/src/app/app.cpp
@@ -690,7 +690,7 @@ bool CApplication::Create()
     if (!m_loadSaveDirName.empty())
     {
         m_controller->GetRobotMain()->SelectPlayer(m_loadSavePlayerName);
-        m_controller->GetRobotMain()->LoadSaveFromDirName(m_loadSaveDirName);
+        m_controller->GetRobotMain()->LoadSaveFromDirName(TempToPath(m_loadSaveDirName));
     }
     else if (m_runSceneCategory == LevelCategory::Max)
     {

--- a/colobot-base/src/app/app.cpp
+++ b/colobot-base/src/app/app.cpp
@@ -1817,6 +1817,11 @@ char CApplication::GetLanguageChar() const
     return langChar;
 }
 
+std::filesystem::path CApplication::GetLanguageDir() const
+{
+    return StrUtils::ToPath(std::string(1, GetLanguageChar()));
+}
+
 void CApplication::SetLanguage(Language language)
 {
     m_language = language;

--- a/colobot-base/src/app/app.h
+++ b/colobot-base/src/app/app.h
@@ -37,6 +37,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <filesystem>
 
 
 class CEventQueue;
@@ -272,6 +273,7 @@ public:
     //@{
     Language    GetLanguage() const;
     char        GetLanguageChar() const;
+    std::filesystem::path GetLanguageDir() const;
     void        SetLanguage(Language language);
     //@}
 

--- a/colobot-base/src/app/app.h
+++ b/colobot-base/src/app/app.h
@@ -412,7 +412,7 @@ protected:
 
     //! Game to load on startup
     std::string     m_loadSavePlayerName;
-    std::string     m_loadSaveDirName;
+    std::filesystem::path m_loadSaveDirName;
 
     //! Scene test mode
     bool            m_sceneTest = false;

--- a/colobot-base/src/app/modman.cpp
+++ b/colobot-base/src/app/modman.cpp
@@ -72,7 +72,7 @@ void CModManager::FindMods()
     std::map<std::string, std::string> modPaths;
     for (const auto& path : rawPaths)
     {
-        auto modName = std::filesystem::path(path).stem().string();
+        auto modName = StrUtils::ToString(std::filesystem::path(path).stem());
         modPaths.insert(std::make_pair(modName, StrUtils::ToString(path)));
     }
 
@@ -84,7 +84,7 @@ void CModManager::FindMods()
         const auto pathsIt = modPaths.find(mod.name);
         if (pathsIt != modPaths.end())
         {
-            mod.path = (*pathsIt).second;
+            mod.path = TempToPath((*pathsIt).second);
             modPaths.erase(pathsIt);
             ++it;
         }
@@ -100,7 +100,7 @@ void CModManager::FindMods()
     {
         Mod mod{};
         mod.name = newMod.first;
-        mod.path = newMod.second;
+        mod.path = TempToPath(newMod.second);
         m_mods.push_back(mod);
     }
 

--- a/colobot-base/src/app/modman.cpp
+++ b/colobot-base/src/app/modman.cpp
@@ -69,11 +69,11 @@ void CModManager::FindMods()
 
     // Search the folders for mods
     auto rawPaths = m_pathManager->FindMods();
-    std::map<std::string, std::string> modPaths;
+    std::map<std::string, std::filesystem::path> modPaths;
     for (const auto& path : rawPaths)
     {
         auto modName = StrUtils::ToString(std::filesystem::path(path).stem());
-        modPaths.insert(std::make_pair(modName, StrUtils::ToString(path)));
+        modPaths.insert(std::make_pair(modName, path));
     }
 
     // Find paths for already saved mods
@@ -84,7 +84,7 @@ void CModManager::FindMods()
         const auto pathsIt = modPaths.find(mod.name);
         if (pathsIt != modPaths.end())
         {
-            mod.path = TempToPath((*pathsIt).second);
+            mod.path = (*pathsIt).second;
             modPaths.erase(pathsIt);
             ++it;
         }
@@ -100,7 +100,7 @@ void CModManager::FindMods()
     {
         Mod mod{};
         mod.name = newMod.first;
-        mod.path = TempToPath(newMod.second);
+        mod.path = newMod.second;
         m_mods.push_back(mod);
     }
 

--- a/colobot-base/src/common/font_loader.cpp
+++ b/colobot-base/src/common/font_loader.cpp
@@ -60,7 +60,7 @@ bool CFontLoader::Init()
             {
                 auto parts = StrUtils::Split(line, " =");
 
-                m_fonts[parts[0]] = parts[1];
+                m_fonts[parts[0]] = StrUtils::ToPath(parts[1]);
             }
 
             GetLogger()->Debug("Fonts config file loaded correctly.");
@@ -85,5 +85,5 @@ std::optional<std::filesystem::path> CFontLoader::GetFont(Gfx::FontType type) co
     if (iterator == m_fonts.end())
         return std::nullopt;
     else
-        return "fonts" / TempToPath(iterator->second);
+        return "fonts" / iterator->second;
 }

--- a/colobot-base/src/common/font_loader.h
+++ b/colobot-base/src/common/font_loader.h
@@ -57,5 +57,5 @@ public:
     std::optional<std::filesystem::path> GetFont(Gfx::FontType type) const;
 
 private:
-    std::unordered_map<std::string, std::string> m_fonts;
+    std::unordered_map<std::string, std::filesystem::path> m_fonts;
 };

--- a/colobot-base/src/graphics/core/material.h
+++ b/colobot-base/src/graphics/core/material.h
@@ -64,7 +64,7 @@ struct Material
     //! Emissive color
     Color emissiveColor = Color{ 0.0f, 0.0f, 0.0f, 0.0f };
     //! Emissive texture
-    std::string emissiveTexture = "";
+    std::filesystem::path emissiveTexture = "";
     //! Normal map
     std::string normalTexture = "";
     //! Alpha mode

--- a/colobot-base/src/graphics/core/material.h
+++ b/colobot-base/src/graphics/core/material.h
@@ -60,7 +60,7 @@ struct Material
     //! AO strength
     float aoStrength = 0.0;
     //! AO-roughness-metalness texture
-    std::string materialTexture = "";
+    std::filesystem::path materialTexture = "";
     //! Emissive color
     Color emissiveColor = Color{ 0.0f, 0.0f, 0.0f, 0.0f };
     //! Emissive texture

--- a/colobot-base/src/graphics/core/material.h
+++ b/colobot-base/src/graphics/core/material.h
@@ -52,7 +52,7 @@ struct Material
     //! Albedo color
     Color albedoColor = Color{ 1.0f, 1.0f, 1.0f, 1.0f };
     //! Albedo texture
-    std::string albedoTexture = "";
+    std::filesystem::path albedoTexture = "";
     //! Roughness
     float roughness = 1.0;
     //! Metalness

--- a/colobot-base/src/graphics/engine/engine.cpp
+++ b/colobot-base/src/graphics/engine/engine.cpp
@@ -1983,9 +1983,9 @@ bool CEngine::LoadAllTextures()
             if (!data.material.albedoTexture.empty())
             {
                 if (terrain)
-                    data.albedoTexture = LoadTexture(TempToPath("textures/" + data.material.albedoTexture), m_terrainTexParams);
+                    data.albedoTexture = LoadTexture("textures" / data.material.albedoTexture, m_terrainTexParams);
                 else
-                    data.albedoTexture = LoadTexture(TempToPath("textures/" + data.material.albedoTexture));
+                    data.albedoTexture = LoadTexture("textures" / data.material.albedoTexture);
 
                 if (!data.albedoTexture.Valid())
                     ok = false;
@@ -4736,7 +4736,7 @@ void CEngine::AddBaseObjTriangles(int baseObjRank, const std::vector<Gfx::ModelT
         Material material = triangle.material;
 
         if (!material.albedoTexture.empty())
-            material.albedoTexture = "objects/" + material.albedoTexture;
+            material.albedoTexture = "objects" / material.albedoTexture;
 
         if (!material.materialTexture.empty())
             material.materialTexture = "objects/" + material.materialTexture;

--- a/colobot-base/src/graphics/engine/engine.cpp
+++ b/colobot-base/src/graphics/engine/engine.cpp
@@ -1350,9 +1350,8 @@ void CEngine::DeleteAllGroundSpots()
 
         std::stringstream str;
         str << "textures/shadow" << std::setfill('0') << std::setw(2) << s << ".png";
-        std::string texName = str.str();
 
-        CreateOrUpdateTexture(texName, &shadowImg);
+        CreateOrUpdateTexture(StrUtils::ToPath(str.str()), &shadowImg);
     }
 }
 
@@ -2060,12 +2059,12 @@ void CEngine::DeleteTexture(const Texture& tex)
     m_texNameMap.erase(it);
 }
 
-void CEngine::CreateOrUpdateTexture(const std::string& texName, CImage* img)
+void CEngine::CreateOrUpdateTexture(const std::filesystem::path& texName, CImage* img)
 {
-    auto it = m_texNameMap.find(TempToPath(texName));
+    auto it = m_texNameMap.find(texName);
     if (it == m_texNameMap.end())
     {
-        LoadTexture(TempToPath(texName), img);
+        LoadTexture(texName, img);
     }
     else
     {
@@ -4045,7 +4044,7 @@ void CEngine::UpdateGroundSpotTextures()
             str << "textures/shadow" << std::setfill('0') << std::setw(2) << s << ".png";
             std::string texName = str.str();
 
-            CreateOrUpdateTexture(texName, &shadowImg);
+            CreateOrUpdateTexture(StrUtils::ToPath(str.str()), &shadowImg);
         }
     }
 

--- a/colobot-base/src/graphics/engine/engine.cpp
+++ b/colobot-base/src/graphics/engine/engine.cpp
@@ -2005,9 +2005,9 @@ bool CEngine::LoadAllTextures()
             if (!data.material.materialTexture.empty())
             {
                 if (terrain)
-                    data.materialTexture = LoadTexture(TempToPath("textures/" + data.material.materialTexture), m_terrainTexParams);
+                    data.materialTexture = LoadTexture("textures" / data.material.materialTexture, m_terrainTexParams);
                 else
-                    data.materialTexture = LoadTexture(TempToPath("textures/" + data.material.materialTexture));
+                    data.materialTexture = LoadTexture("textures" / data.material.materialTexture);
 
                 if (!data.materialTexture.Valid())
                     ok = false;
@@ -4739,7 +4739,7 @@ void CEngine::AddBaseObjTriangles(int baseObjRank, const std::vector<Gfx::ModelT
             material.albedoTexture = "objects" / material.albedoTexture;
 
         if (!material.materialTexture.empty())
-            material.materialTexture = "objects/" + material.materialTexture;
+            material.materialTexture = "objects" / material.materialTexture;
 
         if (!material.emissiveTexture.empty())
             material.emissiveTexture = "objects/" + material.emissiveTexture;

--- a/colobot-base/src/graphics/engine/engine.cpp
+++ b/colobot-base/src/graphics/engine/engine.cpp
@@ -2016,9 +2016,9 @@ bool CEngine::LoadAllTextures()
             if (!data.material.emissiveTexture.empty())
             {
                 if (terrain)
-                    data.emissiveTexture = LoadTexture(TempToPath("textures/" + data.material.emissiveTexture), m_terrainTexParams);
+                    data.emissiveTexture = LoadTexture("textures" / data.material.emissiveTexture, m_terrainTexParams);
                 else
-                    data.emissiveTexture = LoadTexture(TempToPath("textures/" + data.material.emissiveTexture));
+                    data.emissiveTexture = LoadTexture("textures" / data.material.emissiveTexture);
 
                 if (!data.emissiveTexture.Valid())
                     ok = false;
@@ -4742,7 +4742,7 @@ void CEngine::AddBaseObjTriangles(int baseObjRank, const std::vector<Gfx::ModelT
             material.materialTexture = "objects" / material.materialTexture;
 
         if (!material.emissiveTexture.empty())
-            material.emissiveTexture = "objects/" + material.emissiveTexture;
+            material.emissiveTexture = "objects" / material.emissiveTexture;
 
         if (material.variableDetail)
             material.detailTexture = GetSecondTexture();

--- a/colobot-base/src/graphics/engine/engine.cpp
+++ b/colobot-base/src/graphics/engine/engine.cpp
@@ -1093,7 +1093,7 @@ int CEngine::GetPartialTriangles(int objRank, float percent, int maxCount,
     return actualCount;
 }
 
-void CEngine::ChangeSecondTexture(int objRank, const std::string& tex2Name)
+void CEngine::ChangeSecondTexture(int objRank, const std::filesystem::path& tex2Name)
 {
     assert(objRank >= 0 && objRank < static_cast<int>( m_objects.size() ));
 
@@ -1105,7 +1105,7 @@ void CEngine::ChangeSecondTexture(int objRank, const std::string& tex2Name)
 
     EngineBaseObject& p1 = m_baseObjects[baseObjRank];
 
-    std::filesystem::path tex2Path = "textures" / TempToPath(tex2Name);
+    std::filesystem::path tex2Path = "textures" / tex2Name;
     for (auto& data : p1.next)
     {
         if (data.material.detailTexture == tex2Path)

--- a/colobot-base/src/graphics/engine/engine.h
+++ b/colobot-base/src/graphics/engine/engine.h
@@ -617,7 +617,7 @@ public:
                                         std::vector<EngineTriangle>& triangles);
 
     //! Changes the 2nd texure for given object
-    void            ChangeSecondTexture(int objRank, const std::string& tex2Name);
+    void            ChangeSecondTexture(int objRank, const std::filesystem::path& tex2Name);
 
     void            SetUVTransform(int objRank, const std::string& tag, const glm::vec2& offset, const glm::vec2& scale);
 

--- a/colobot-base/src/graphics/engine/engine.h
+++ b/colobot-base/src/graphics/engine/engine.h
@@ -697,7 +697,7 @@ public:
     void            DeleteTexture(const Texture& tex);
 
     //! Creates or updates the given texture with given image data
-    void            CreateOrUpdateTexture(const std::string& texName, CImage* img);
+    void            CreateOrUpdateTexture(const std::filesystem::path& texName, CImage* img);
 
     //! Empties the texture cache
     void            FlushTextureCache();

--- a/colobot-base/src/graphics/engine/oldmodelmanager.cpp
+++ b/colobot-base/src/graphics/engine/oldmodelmanager.cpp
@@ -51,7 +51,7 @@ bool COldModelManager::LoadModel(const std::string& name, bool mirrored, int tea
     std::unique_ptr<CModel> model;
     try
     {
-        auto extension = TempToPath(name).extension().string();
+        auto extension = TempToPath(name).extension();
 
         if (!extension.empty())
         {

--- a/colobot-base/src/graphics/engine/oldmodelmanager.cpp
+++ b/colobot-base/src/graphics/engine/oldmodelmanager.cpp
@@ -46,18 +46,18 @@ COldModelManager::~COldModelManager()
 {
 }
 
-bool COldModelManager::LoadModel(const std::string& name, bool mirrored, int team)
+bool COldModelManager::LoadModel(const std::filesystem::path& name, bool mirrored, int team)
 {
     std::unique_ptr<CModel> model;
     try
     {
-        auto extension = TempToPath(name).extension();
+        auto extension = name.extension();
 
         if (!extension.empty())
         {
             GetLogger()->Debug("Loading model '%%'", name);
 
-            model = ModelInput::Read(TempToPath("models/" + name));
+            model = ModelInput::Read("models" / name);
 
             if (model->GetMeshCount() == 0)
                 return false;
@@ -65,25 +65,27 @@ bool COldModelManager::LoadModel(const std::string& name, bool mirrored, int tea
             goto skip;
         }
 
-        auto gltf_path = "models/" + name + ".gltf";
+        auto gltf_path = "models" / name;
+        gltf_path.replace_extension("gltf");
 
-        if (CResourceManager::Exists(TempToPath(gltf_path)))
+        if (CResourceManager::Exists(gltf_path))
         {
-            GetLogger()->Debug("Loading model '%%'", (name + ".gltf"));
+            GetLogger()->Debug("Loading model '%%'", gltf_path);
 
-            model = ModelInput::Read(TempToPath(gltf_path));
+            model = ModelInput::Read(gltf_path);
 
             if (model->GetMeshCount() > 0)
                 goto skip;
         }
 
-        auto mod_path = "models/" + name + ".mod";
+        auto mod_path = "models" / name;
+        mod_path.replace_extension("mod");
 
-        if (CResourceManager::Exists(TempToPath(mod_path)))
+        if (CResourceManager::Exists(mod_path))
         {
-            GetLogger()->Debug("Loading model '%%'", (name + ".mod"));
+            GetLogger()->Debug("Loading model '%%'", mod_path);
 
-            model = ModelInput::Read(TempToPath(mod_path));
+            model = ModelInput::Read(mod_path);
 
             if (model->GetMeshCount() > 0)
                 goto skip;
@@ -108,7 +110,7 @@ skip:
     if (mirrored)
         Mirror(modelInfo.triangles);
 
-    FileInfo fileInfo(name, mirrored, team);
+    FileInfo fileInfo(StrUtils::ToString(name), mirrored, team);
     m_models[fileInfo] = modelInfo;
 
     m_engine->AddBaseObjTriangles(modelInfo.baseObjRank, modelInfo.triangles);
@@ -121,7 +123,7 @@ bool COldModelManager::AddModelReference(const std::string& fileName, bool mirro
     auto it = m_models.find(FileInfo(fileName, mirrored, team));
     if (it == m_models.end())
     {
-        if (!LoadModel(fileName, mirrored, team))
+        if (!LoadModel(StrUtils::ToPath(fileName), mirrored, team))
             return false;
 
         it = m_models.find(FileInfo(fileName, mirrored, team));
@@ -138,7 +140,7 @@ bool COldModelManager::AddModelCopy(const std::string& fileName, bool mirrored, 
     auto it = m_models.find(FileInfo(fileName, mirrored, team));
     if (it == m_models.end())
     {
-        if (!LoadModel(fileName, mirrored, team))
+        if (!LoadModel(StrUtils::ToPath(fileName), mirrored, team))
             return false;
 
         it = m_models.find(FileInfo(fileName, mirrored, team));

--- a/colobot-base/src/graphics/engine/oldmodelmanager.h
+++ b/colobot-base/src/graphics/engine/oldmodelmanager.h
@@ -58,7 +58,7 @@ public:
     ~COldModelManager();
 
     //! Loads a model from given file
-    bool LoadModel(const std::string& fileName, bool mirrored, int team = 0);
+    bool LoadModel(const std::filesystem::path& fileName, bool mirrored, int team = 0);
 
     //! Adds an instance of model to the given object rank as a reference to base object
     bool AddModelReference(const std::string& fileName, bool mirrored, int objRank, int team = 0);

--- a/colobot-base/src/graphics/engine/particle.cpp
+++ b/colobot-base/src/graphics/engine/particle.cpp
@@ -3407,7 +3407,7 @@ void CParticle::DrawParticle(int sheet)
             if (m_particle[i].type == PARTIPART)  continue;
 
             auto texture = m_engine->LoadTexture(!m_triangle[i].material.albedoTexture.empty()
-                ? TempToPath("textures/" + m_triangle[i].material.albedoTexture)
+                ? "textures" / m_triangle[i].material.albedoTexture
                 : "");
 
             m_renderer->SetTexture(texture);

--- a/colobot-base/src/graphics/engine/particle.cpp
+++ b/colobot-base/src/graphics/engine/particle.cpp
@@ -143,13 +143,16 @@ void CParticle::FlushParticle(int sheet)
 
 
 //! Returns file name of the effect effectNN.png, with NN = number
-static void NameParticle(std::string &name, int num)
+std::filesystem::path NameParticle(int num)
 {
-         if (num == 1)  name = "effect00.png";
-    else if (num == 2)  name = "effect01.png";
-    else if (num == 3)  name = "effect02.png";
-    else if (num == 4)  name = "effect03.png";
-    else                name = "";
+    switch(num)
+    {
+        case 1: return "effect00.png";
+        case 2: return "effect01.png";
+        case 3: return "effect02.png";
+        case 4: return "effect03.png";
+        default: return "";
+    }
 }
 
 //! Returns random letter for use as virus particle
@@ -3452,9 +3455,7 @@ void CParticle::DrawParticle(int sheet)
 
             if (!loadTexture && t != 5)
             {
-                std::string name;
-                NameParticle(name, t);
-                auto texture = m_engine->LoadTexture("textures" / TempToPath(name));
+                auto texture = m_engine->LoadTexture("textures" / NameParticle(t));
                 m_renderer->SetTexture(texture);
                 loadTexture = true;
             }

--- a/colobot-base/src/graphics/engine/terrain.cpp
+++ b/colobot-base/src/graphics/engine/terrain.cpp
@@ -130,14 +130,13 @@ bool CTerrain::InitTextures(const std::filesystem::path& baseName, int* table, i
 {
     m_useMaterials = false;
 
-    std::filesystem::path texBaseName = baseName;
-    texBaseName.replace_extension();
-    m_texBaseName = TempToString(texBaseName);
+    m_texBaseName = baseName;
+    m_texBaseName.replace_extension();
 
-    m_texBaseExt = TempToString(baseName.extension());
+    m_texBaseExt = baseName.extension();
     if (m_texBaseExt.empty())
     {
-        m_texBaseExt = ".png";
+        m_texBaseExt = "png";
     }
 
     for (int y = 0; y < m_mosaicCount*m_textureSubdivCount; y++)
@@ -617,13 +616,15 @@ bool CTerrain::CreateMosaic(int ox, int oy, int step, int objRank)
             else
             {
                 int i = (ox*m_textureSubdivCount+mx)+(oy*m_textureSubdivCount+my)*m_mosaicCount;
+
                 std::stringstream s;
-                s << m_texBaseName;
                 s.width(3);
                 s.fill('0');
                 s << m_textures[i];
-                s << m_texBaseExt;
-                texName1 = TempToPath(s.str());
+
+                texName1 = m_texBaseName;
+                texName1 += StrUtils::ToPath(s.str());
+                texName1.replace_extension(m_texBaseExt);
             }
 
             for (int y = 0; y < brick; y += step)

--- a/colobot-base/src/graphics/engine/terrain.cpp
+++ b/colobot-base/src/graphics/engine/terrain.cpp
@@ -763,7 +763,7 @@ void CTerrain::GetTexture(int x, int y, std::filesystem::path& name, glm::vec2&u
     }
     else
     {
-        name = TempToPath(tm->texName);
+        name = StrUtils::ToPath(tm->texName);
         uv = tm->uv;
     }
 }

--- a/colobot-base/src/graphics/engine/terrain.cpp
+++ b/colobot-base/src/graphics/engine/terrain.cpp
@@ -168,7 +168,7 @@ void CTerrain::AddMaterial(int id, const std::filesystem::path& texName, const g
         id = m_materialAutoID++;
 
     TerrainMaterial tm;
-    tm.texName  = TempToString(texName);
+    tm.texName  = texName;
     tm.id       = id;
     tm.uv       = uv;
     tm.mat[0]   = up;
@@ -763,7 +763,7 @@ void CTerrain::GetTexture(int x, int y, std::filesystem::path& name, glm::vec2&u
     }
     else
     {
-        name = StrUtils::ToPath(tm->texName);
+        name = tm->texName;
         uv = tm->uv;
     }
 }

--- a/colobot-base/src/graphics/engine/terrain.cpp
+++ b/colobot-base/src/graphics/engine/terrain.cpp
@@ -579,8 +579,8 @@ bool CTerrain::CreateMosaic(int ox, int oy, int step, int objRank)
         m_engine->SetObjectBaseRank(objRank, baseObjRank);
     }
 
-    std::string texName1;
-    std::string texName2;
+    std::filesystem::path texName1;
+    std::filesystem::path texName2;
 
     if ( step == 1 )
     {
@@ -591,7 +591,7 @@ bool CTerrain::CreateMosaic(int ox, int oy, int step, int objRank)
         s.fill('0');
         s << i;
         s << ".png";
-        texName2 = s.str();
+        texName2 = StrUtils::ToPath(s.str());
     }
 
     int brick = m_brickCount/m_textureSubdivCount;
@@ -623,7 +623,7 @@ bool CTerrain::CreateMosaic(int ox, int oy, int step, int objRank)
                 s.fill('0');
                 s << m_textures[i];
                 s << m_texBaseExt;
-                texName1 = s.str();
+                texName1 = TempToPath(s.str());
             }
 
             for (int y = 0; y < brick; y += step)
@@ -719,7 +719,7 @@ bool CTerrain::CreateMosaic(int ox, int oy, int step, int objRank)
 
                 Gfx::Material material;
                 material.albedoTexture = texName1;
-                material.detailTexture = "textures" / StrUtils::ToPath(texName2);
+                material.detailTexture = "textures" / texName2;
                 material.tag = "brick_"
                     + std::to_string(mx + 1) + "_"
                     + std::to_string(my + 1) + "_"
@@ -749,7 +749,7 @@ CTerrain::TerrainMaterial* CTerrain::FindMaterial(int id)
     return nullptr;
 }
 
-void CTerrain::GetTexture(int x, int y, std::string& name, glm::vec2&uv)
+void CTerrain::GetTexture(int x, int y, std::filesystem::path& name, glm::vec2&uv)
 {
     x /= m_brickCount/m_textureSubdivCount;
     y /= m_brickCount/m_textureSubdivCount;
@@ -762,7 +762,7 @@ void CTerrain::GetTexture(int x, int y, std::string& name, glm::vec2&uv)
     }
     else
     {
-        name = tm->texName;
+        name = TempToPath(tm->texName);
         uv = tm->uv;
     }
 }

--- a/colobot-base/src/graphics/engine/terrain.cpp
+++ b/colobot-base/src/graphics/engine/terrain.cpp
@@ -159,7 +159,7 @@ void CTerrain::FlushMaterials()
     FlushMaterialPoints();
 }
 
-void CTerrain::AddMaterial(int id, const std::string& texName, const glm::vec2& uv,
+void CTerrain::AddMaterial(int id, const std::filesystem::path& texName, const glm::vec2& uv,
                            int up, int right, int down, int left,
                            float hardness)
 {
@@ -169,7 +169,7 @@ void CTerrain::AddMaterial(int id, const std::string& texName, const glm::vec2& 
         id = m_materialAutoID++;
 
     TerrainMaterial tm;
-    tm.texName  = texName;
+    tm.texName  = TempToString(texName);
     tm.id       = id;
     tm.uv       = uv;
     tm.mat[0]   = up;

--- a/colobot-base/src/graphics/engine/terrain.cpp
+++ b/colobot-base/src/graphics/engine/terrain.cpp
@@ -126,22 +126,18 @@ float CTerrain::GetReliefScale()
     return m_scaleRelief;
 }
 
-bool CTerrain::InitTextures(const std::string& baseName, int* table, int dx, int dy)
+bool CTerrain::InitTextures(const std::filesystem::path& baseName, int* table, int dx, int dy)
 {
     m_useMaterials = false;
 
-    m_texBaseName = baseName;
-    auto pos = baseName.rfind('.');
-    if(pos < baseName.find_last_of('/')) pos = std::string::npos; // If last . is not a part of filename (some directory, possibly . or ..)
+    std::filesystem::path texBaseName = baseName;
+    texBaseName.replace_extension();
+    m_texBaseName = TempToString(texBaseName);
 
-    if (pos == std::string::npos)
+    m_texBaseExt = TempToString(baseName.extension());
+    if (m_texBaseExt.empty())
     {
         m_texBaseExt = ".png";
-    }
-    else
-    {
-        m_texBaseExt = m_texBaseName.substr(pos);
-        m_texBaseName = m_texBaseName.substr(0, pos);
     }
 
     for (int y = 0; y < m_mosaicCount*m_textureSubdivCount; y++)

--- a/colobot-base/src/graphics/engine/terrain.h
+++ b/colobot-base/src/graphics/engine/terrain.h
@@ -318,9 +318,9 @@ protected:
     float           m_vision;
 
     //! Base name for single texture
-    std::string     m_texBaseName;
+    std::filesystem::path m_texBaseName;
     //! Extension for single texture
-    std::string     m_texBaseExt;
+    std::filesystem::path m_texBaseExt;
     //! Default hardness for level material
     float           m_defaultHardness;
     /**

--- a/colobot-base/src/graphics/engine/terrain.h
+++ b/colobot-base/src/graphics/engine/terrain.h
@@ -154,7 +154,7 @@ public:
     bool        Generate(int mosaicCount, int brickCountPow2, float brickSize, float vision, int depth, float hardness);
 
     //! Initializes the names of textures to use for the land
-    bool        InitTextures(const std::string& baseName, int* table, int dx, int dy);
+    bool        InitTextures(const std::filesystem::path& baseName, int* table, int dx, int dy);
 
     //! Clears all terrain materials
     void        FlushMaterials();

--- a/colobot-base/src/graphics/engine/terrain.h
+++ b/colobot-base/src/graphics/engine/terrain.h
@@ -266,7 +266,7 @@ protected:
     //! Seeks a material based on neighbor values
     int         FindMaterialByNeighbors(char *mat);
     //! Returns the texture name and UV coords to use for a given square
-    void        GetTexture(int x, int y, std::string& name, glm::vec2& uv);
+    void        GetTexture(int x, int y, std::filesystem::path& name, glm::vec2& uv);
     //! Returns the height of the terrain
     float       GetHeight(int x, int y);
     //! Decide whether a point is using the materials

--- a/colobot-base/src/graphics/engine/terrain.h
+++ b/colobot-base/src/graphics/engine/terrain.h
@@ -332,7 +332,7 @@ protected:
         //! Unique ID
         short       id = 0;
         //! Texture
-        std::string texName;
+        std::filesystem::path texName;
         //! UV texture coordinates
         glm::vec2   uv;
         //! Terrain hardness (defines e.g. sound of walking)

--- a/colobot-base/src/graphics/engine/terrain.h
+++ b/colobot-base/src/graphics/engine/terrain.h
@@ -159,7 +159,7 @@ public:
     //! Clears all terrain materials
     void        FlushMaterials();
     //! Adds a terrain material the names of textures to use for the land
-    void        AddMaterial(int id, const std::string& texName, const glm::vec2& uv,
+    void        AddMaterial(int id, const std::filesystem::path& texName, const glm::vec2& uv,
                             int up, int right, int down, int left, float hardness);
     //! Initializes all the ground with one material
     bool        InitMaterials(int id);

--- a/colobot-base/src/graphics/model/model_gltf.cpp
+++ b/colobot-base/src/graphics/model/model_gltf.cpp
@@ -256,7 +256,7 @@ void GLTFLoader::ReadMaterials()
 
                 const auto& image = m_images[texture.source];
 
-                mat.emissiveTexture = image.uri;
+                mat.emissiveTexture = StrUtils::ToPath(image.uri);
             }
         }
 

--- a/colobot-base/src/graphics/model/model_gltf.cpp
+++ b/colobot-base/src/graphics/model/model_gltf.cpp
@@ -328,7 +328,7 @@ void GLTFLoader::ReadMaterials()
 
                     const auto& image = m_images[texture.source];
 
-                    mat.materialTexture = image.uri;
+                    mat.materialTexture = StrUtils::ToPath(image.uri);
                 }
             }
 

--- a/colobot-base/src/graphics/model/model_gltf.cpp
+++ b/colobot-base/src/graphics/model/model_gltf.cpp
@@ -294,7 +294,7 @@ void GLTFLoader::ReadMaterials()
 
                     const auto& image = m_images[texture.source];
 
-                    mat.albedoTexture = image.uri;
+                    mat.albedoTexture = StrUtils::ToPath(image.uri);
                 }
             }
 

--- a/colobot-base/src/graphics/model/model_input.cpp
+++ b/colobot-base/src/graphics/model/model_input.cpp
@@ -25,6 +25,8 @@
 
 #include "graphics/model/model_io_exception.h"
 
+#include "common/stringutils.h"
+
 namespace Gfx
 {
 
@@ -46,7 +48,7 @@ std::unique_ptr<CModel> ModelInput::Read(const std::filesystem::path& path)
     }
     else
     {
-        throw CModelIOException(std::string("Unknown model format: ") + extension.string());
+        throw CModelIOException(std::string("Unknown model format: ") + StrUtils::ToString(extension));
     }
 }
 

--- a/colobot-base/src/graphics/model/model_manager.cpp
+++ b/colobot-base/src/graphics/model/model_manager.cpp
@@ -30,13 +30,14 @@
 namespace Gfx
 {
 
-CModel* CModelManager::GetModel(const std::string& modelName)
+CModel* CModelManager::GetModel(const std::filesystem::path& modelName)
 {
     auto it = m_models.find(modelName);
     if (it != m_models.end())
         return it->second.get();
 
-    std::filesystem::path modelFile = TempToPath("models-new/" + modelName + ".txt");
+    std::filesystem::path modelFile = "models-new" / modelName;
+    modelFile.replace_extension("txt");
 
     GetLogger()->Debug("Loading new model: %%", modelFile);
 

--- a/colobot-base/src/graphics/model/model_manager.cpp
+++ b/colobot-base/src/graphics/model/model_manager.cpp
@@ -38,7 +38,7 @@ CModel* CModelManager::GetModel(const std::string& modelName)
 
     std::filesystem::path modelFile = TempToPath("models-new/" + modelName + ".txt");
 
-    GetLogger()->Debug("Loading new model: %%", modelFile.string());
+    GetLogger()->Debug("Loading new model: %%", modelFile);
 
     m_models[modelName] = ModelInput::Read(modelFile);
 

--- a/colobot-base/src/graphics/model/model_manager.h
+++ b/colobot-base/src/graphics/model/model_manager.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <filesystem>
 
 namespace Gfx
 {
@@ -37,13 +38,13 @@ class CModelManager
 public:
     //! Returns a model named \a modelName
     /** @throws CModelIOException on read error */
-    CModel* GetModel(const std::string& modelName);
+    CModel* GetModel(const std::filesystem::path& modelName);
 
     //! Clears cached models
     void ClearCache();
 
 private:
-    std::unordered_map<std::string, std::unique_ptr<CModel>> m_models;
+    std::unordered_map<std::filesystem::path, std::unique_ptr<CModel>> m_models;
 };
 
 } // namespace Gfx

--- a/colobot-base/src/graphics/model/model_manager.h
+++ b/colobot-base/src/graphics/model/model_manager.h
@@ -23,7 +23,7 @@
 
 #include <memory>
 #include <string>
-#include <unordered_map>
+#include <map>
 #include <filesystem>
 
 namespace Gfx
@@ -44,7 +44,7 @@ public:
     void ClearCache();
 
 private:
-    std::unordered_map<std::filesystem::path, std::unique_ptr<CModel>> m_models;
+    std::map<std::filesystem::path, std::unique_ptr<CModel>> m_models;
 };
 
 } // namespace Gfx

--- a/colobot-base/src/graphics/model/model_mod.cpp
+++ b/colobot-base/src/graphics/model/model_mod.cpp
@@ -277,7 +277,7 @@ ModelLODLevel MinMaxToLodLevel(float min, float max)
 
 void ConvertOldTex1Name(ModelTriangle& triangle, const char* tex1Name)
 {
-    triangle.material.albedoTexture = TempToPath(tex1Name);
+    triangle.material.albedoTexture = StrUtils::ToPath(tex1Name);
     if (triangle.material.albedoTexture.extension() == "bmp" || triangle.material.albedoTexture.extension() == "tga")
     {
         triangle.material.albedoTexture.replace_extension("png");

--- a/colobot-base/src/graphics/model/model_mod.cpp
+++ b/colobot-base/src/graphics/model/model_mod.cpp
@@ -277,11 +277,11 @@ ModelLODLevel MinMaxToLodLevel(float min, float max)
 
 void ConvertOldTex1Name(ModelTriangle& triangle, const char* tex1Name)
 {
-    triangle.material.albedoTexture = tex1Name;
-    triangle.material.albedoTexture = StrUtils::Replace(
-        triangle.material.albedoTexture, "bmp", "png");
-    triangle.material.albedoTexture = StrUtils::Replace(
-        triangle.material.albedoTexture, "tga", "png");
+    triangle.material.albedoTexture = TempToPath(tex1Name);
+    if (triangle.material.albedoTexture.extension() == "bmp" || triangle.material.albedoTexture.extension() == "tga")
+    {
+        triangle.material.albedoTexture.replace_extension("png");
+    }
 }
 
 void ConvertFromOldRenderState(ModelTriangle& triangle, int state)

--- a/colobot-base/src/graphics/model/model_txt.cpp
+++ b/colobot-base/src/graphics/model/model_txt.cpp
@@ -132,7 +132,7 @@ void ReadTextModelV1AndV2(CModel& model, std::istream& stream)
         triangle.p1 = t.p1;
         triangle.p2 = t.p2;
         triangle.p3 = t.p3;
-        triangle.material.albedoTexture = t.tex1Name;
+        triangle.material.albedoTexture = TempToPath(t.tex1Name);
         triangle.material.detailTexture = "textures" / TempToPath(t.tex2Name);
         triangle.material.variableDetail = t.variableTex2;
         ConvertFromOldRenderState(triangle, t.state);
@@ -225,7 +225,7 @@ std::unique_ptr<CModelMesh> ReadTextMesh(std::istream& stream)
         t.p2.color = color;
         t.p3.color = color;
 
-        t.material.albedoTexture = ReadLineString(stream, "tex1");
+        t.material.albedoTexture = StrUtils::ToPath(ReadLineString(stream, "tex1"));
         t.material.detailTexture = StrUtils::ToPath(ReadLineString(stream, "tex2"));
         t.material.variableDetail = ReadLineString(stream, "var_tex2") == std::string("Y");
 

--- a/colobot-base/src/graphics/model/model_txt.cpp
+++ b/colobot-base/src/graphics/model/model_txt.cpp
@@ -132,8 +132,8 @@ void ReadTextModelV1AndV2(CModel& model, std::istream& stream)
         triangle.p1 = t.p1;
         triangle.p2 = t.p2;
         triangle.p3 = t.p3;
-        triangle.material.albedoTexture = TempToPath(t.tex1Name);
-        triangle.material.detailTexture = "textures" / TempToPath(t.tex2Name);
+        triangle.material.albedoTexture = StrUtils::ToPath(t.tex1Name);
+        triangle.material.detailTexture = "textures" / StrUtils::ToPath(t.tex2Name);
         triangle.material.variableDetail = t.variableTex2;
         ConvertFromOldRenderState(triangle, t.state);
 

--- a/colobot-base/src/level/parser/parser.cpp
+++ b/colobot-base/src/level/parser/parser.cpp
@@ -72,7 +72,7 @@ std::filesystem::path CLevelParser::BuildCategoryPath(std::string_view category)
     }
     else
     {
-        path /= category;
+        path /= StrUtils::ToPath(category);
     }
 
     return path;

--- a/colobot-base/src/level/parser/parser.cpp
+++ b/colobot-base/src/level/parser/parser.cpp
@@ -89,7 +89,7 @@ std::filesystem::path CLevelParser::BuildScenePath(std::string_view category, in
 
     if (category == "custom")
     {
-        path /= TempToPath(CRobotMain::GetInstancePointer()->GetCustomLevelName(chapter));
+        path /= CRobotMain::GetInstancePointer()->GetCustomLevelName(chapter);
 
         if (rank == 0)
         {

--- a/colobot-base/src/level/parser/parserparam.cpp
+++ b/colobot-base/src/level/parser/parserparam.cpp
@@ -97,6 +97,10 @@ CLevelParserParam::CLevelParserParam(Gfx::CameraType value)
   : m_value(FromCameraType(value))
 {}
 
+CLevelParserParam::CLevelParserParam(const std::filesystem::path& value)
+  : m_value(StrUtils::ToString(value))
+{}
+
 CLevelParserParam::CLevelParserParam(CLevelParserParamVec&& array)
 {
     m_array.swap(array);

--- a/colobot-base/src/level/parser/parserparam.cpp
+++ b/colobot-base/src/level/parser/parserparam.cpp
@@ -228,16 +228,15 @@ bool CLevelParserParam::AsBool(bool def)
 }
 
 
-std::filesystem::path CLevelParserParam::ToPath(std::string path, const std::string defaultDir)
+std::filesystem::path CLevelParserParam::ToPath(const std::string& path, const std::filesystem::path& defaultDir)
 {
     if (defaultDir == "" && path.find("%lvl%") != std::string::npos)
         throw CLevelParserException("TODO: Param "+m_name+" does not yet support %lvl%! :(");
 
-    return GetLine()->GetLevel()->InjectLevelPaths(
-        TempToPath(path), TempToPath(defaultDir));
+    return GetLine()->GetLevel()->InjectLevelPaths(StrUtils::ToPath(path), defaultDir);
 }
 
-std::filesystem::path CLevelParserParam::AsPath(const std::string defaultDir)
+std::filesystem::path CLevelParserParam::AsPath(const std::filesystem::path& defaultDir)
 {
     if (m_empty)
         throw CLevelParserExceptionMissingParam(this);
@@ -245,13 +244,12 @@ std::filesystem::path CLevelParserParam::AsPath(const std::string defaultDir)
     return ToPath(AsString(), defaultDir);
 }
 
-std::filesystem::path CLevelParserParam::AsPath(const std::string defaultDir, std::string def)
+std::filesystem::path CLevelParserParam::AsPath(const std::filesystem::path& defaultDir, const std::filesystem::path& def)
 {
     if (m_empty)
-        return GetLine()->GetLevel()->InjectLevelPaths(
-            TempToPath(def), TempToPath(defaultDir));
+        return GetLine()->GetLevel()->InjectLevelPaths(def, defaultDir);
 
-    return ToPath(AsString(def), defaultDir);
+    return ToPath(AsString(), defaultDir);
 }
 
 

--- a/colobot-base/src/level/parser/parserparam.h
+++ b/colobot-base/src/level/parser/parserparam.h
@@ -86,7 +86,7 @@ public:
     float AsFloat();
     std::string AsString();
     bool AsBool();
-    std::filesystem::path AsPath(const std::string defaultDir);
+    std::filesystem::path AsPath(const std::filesystem::path& defaultDir);
     Gfx::Color AsColor();
     glm::vec3 AsPoint();
     ObjectType AsObjectType();
@@ -110,7 +110,7 @@ public:
     float AsFloat(float def);
     std::string AsString(std::string def);
     bool AsBool(bool def);
-    std::filesystem::path AsPath(const std::string defaultDir, std::string def);
+    std::filesystem::path AsPath(const std::filesystem::path& defaultDir, const std::filesystem::path& def);
     Gfx::Color AsColor(Gfx::Color def);
     glm::vec3 AsPoint(glm::vec3 def);
     ObjectType AsObjectType(ObjectType def);
@@ -144,7 +144,7 @@ private:
     template<typename T> T Cast(const std::string& value, const std::string& requestedType);
     template<typename T> T Cast(const std::string& requestedType);
 
-    std::filesystem::path ToPath(std::string path, const std::string defaultDir);
+    std::filesystem::path ToPath(const std::string& path, const std::filesystem::path& defaultDir);
     ObjectType ToObjectType(std::string value);
     DriveType ToDriveType(std::string value);
     ToolType ToToolType(std::string value);

--- a/colobot-base/src/level/parser/parserparam.h
+++ b/colobot-base/src/level/parser/parserparam.h
@@ -72,6 +72,7 @@ public:
     CLevelParserParam(glm::vec3 value);
     CLevelParserParam(ObjectType value);
     CLevelParserParam(Gfx::CameraType value);
+    CLevelParserParam(const std::filesystem::path& value);
     CLevelParserParam(CLevelParserParamVec&& array);
     //@}
     //! Create param from string

--- a/colobot-base/src/level/player_profile.cpp
+++ b/colobot-base/src/level/player_profile.cpp
@@ -539,7 +539,8 @@ void CPlayerProfile::LoadScene(const std::filesystem::path& dir)
     if (cat == LevelCategory::CustomLevels)
     {
         chap = 0;
-        std::string dir = line->GetParam("dir")->AsString();
+        // Read "dir" as a string to avoid interpreting %lvl% etc.
+        std::filesystem::path dir = StrUtils::ToPath(line->GetParam("dir")->AsString());
         CRobotMain::GetInstancePointer()->UpdateCustomLevelList();
         auto customLevelList = CRobotMain::GetInstancePointer()->GetCustomLevelList();
         for (unsigned int i = 0; i < customLevelList.size(); i++)

--- a/colobot-base/src/level/player_profile.cpp
+++ b/colobot-base/src/level/player_profile.cpp
@@ -257,7 +257,7 @@ int CPlayerProfile::GetSelectedRank(LevelCategory category)
 void CPlayerProfile::LoadFinishedLevels(LevelCategory category)
 {
     m_levelInfo[category].clear();
-    std::filesystem::path filename = GetSaveFile(TempToPath(GetLevelCategoryDir(category) + ".gam"));
+    std::filesystem::path filename = GetSaveFile(StrUtils::ToPath(GetLevelCategoryDir(category) + ".gam"));
 
     if (!CResourceManager::Exists(filename))
         return;
@@ -299,7 +299,7 @@ void CPlayerProfile::LoadFinishedLevels(LevelCategory category)
 
 void CPlayerProfile::SaveFinishedLevels(LevelCategory category)
 {
-    std::filesystem::path filename = GetSaveFile(TempToPath(GetLevelCategoryDir(category) + ".gam"));
+    std::filesystem::path filename = GetSaveFile(StrUtils::ToPath(GetLevelCategoryDir(category) + ".gam"));
     COutputStream file;
     file.open(filename);
     if (!file.is_open())

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -2247,10 +2247,10 @@ void CRobotMain::HelpObject()
     CObject* obj = GetSelect();
     if (obj == nullptr) return;
 
-    std::string filename = GetHelpFilename(obj->GetType());
+    std::filesystem::path filename = GetHelpFilename(obj->GetType());
     if (filename.empty()) return;
 
-    StartDisplayInfo(TempToPath(filename), -1);
+    StartDisplayInfo(filename, -1);
 }
 
 

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -5360,7 +5360,7 @@ int CRobotMain::GetLevelRank()
 std::string CRobotMain::GetCustomLevelDir()
 {
     assert(m_levelCategory == LevelCategory::CustomLevels);
-    return m_ui->GetCustomLevelName(m_levelChap);
+    return TempToString(m_ui->GetCustomLevelName(m_levelChap));
 }
 
 void CRobotMain::SetReadScene(const std::filesystem::path& path)
@@ -5572,7 +5572,7 @@ void CRobotMain::UpdateCustomLevelList()
     m_ui->UpdateCustomLevelList();
 }
 
-std::string CRobotMain::GetCustomLevelName(int id)
+std::filesystem::path CRobotMain::GetCustomLevelName(int id)
 {
     return m_ui->GetCustomLevelName(id);
 }

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -3769,7 +3769,7 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
 
             if (line->GetCommand() == "NewScript" && !resetObject)
             {
-                m_newScriptName.push_back(NewScriptName(line->GetParam("type")->AsObjectType(OBJECT_NULL), line->GetParam("name")->AsString("")));
+                m_newScriptName.push_back(NewScriptName(line->GetParam("type")->AsObjectType(OBJECT_NULL), line->GetParam("name")->AsPath("/", "")));
                 continue;
             }
 
@@ -4400,9 +4400,9 @@ bool CRobotMain::ReadFileStack(CObject *obj, std::istream &istr)
     return false; // error: status == ??
 }
 
-std::vector<std::string> CRobotMain::GetNewScriptNames(ObjectType type)
+std::vector<std::filesystem::path> CRobotMain::GetNewScriptNames(ObjectType type)
 {
-    std::vector<std::string> names;
+    std::vector<std::filesystem::path> names;
     for (const auto& newScript : m_newScriptName)
     {
         if (newScript.type == type        ||

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -599,7 +599,7 @@ void CRobotMain::ChangePhase(Phase phase)
                     pe->SetFontType(Gfx::FONT_COMMON);
                     pe->SetEditCap(false);
                     pe->SetHighlightCap(false);
-                    pe->ReadText(std::filesystem::path("help") / StrUtils::ToPath(std::string(1, m_app->GetLanguageChar())) / "win.txt");
+                    pe->ReadText("help" / m_app->GetLanguageDir() / "win.txt");
                 }
                 else
                 {

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -3328,13 +3328,12 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
 
             if (line->GetCommand() == "TerrainMaterial" && !resetObject)
             {
-                std::string name = TempToString(line->GetParam("image")->AsPath("textures"));
-                if (name.find(".") == std::string::npos)
+                std::filesystem::path name = ".." / line->GetParam("image")->AsPath("textures");
+                if (name.extension().empty())
                     name += ".png";
-                name = "../" + name;
 
                 m_terrain->AddMaterial(line->GetParam("id")->AsInt(0),
-                                    name.c_str(),
+                                    name,
                                     { line->GetParam("u")->AsFloat(),
                                       line->GetParam("v")->AsFloat() },
                                     line->GetParam("up")->AsInt(),

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -4465,14 +4465,14 @@ void CRobotMain::IOWriteObject(CLevelParserLine* line, CObject* obj,
         CProgramStorageObject* programStorage = dynamic_cast<CProgramStorageObject*>(obj);
         if (programStorage->GetProgramStorageIndex() >= 0)
         {
-            programStorage->SaveAllProgramsForSavedScene(line, TempToString(programDir));
+            programStorage->SaveAllProgramsForSavedScene(line, programDir);
         }
         else
         {
             // Probably an object created after the scene started, not loaded from level file
             // This means it doesn't normally store programs so it doesn't have program storage id assigned
             programStorage->SetProgramStorageIndex(999-objRank); // Set something that won't collide with normal programs
-            programStorage->SaveAllProgramsForSavedScene(line, TempToString(programDir));
+            programStorage->SaveAllProgramsForSavedScene(line, programDir);
             programStorage->SetProgramStorageIndex(-1); // Disable again
         }
 

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -5702,9 +5702,9 @@ void CRobotMain::QuickLoad()
     m_playerProfile->LoadScene(dir);
 }
 
-void CRobotMain::LoadSaveFromDirName(const std::string& gameDir)
+void CRobotMain::LoadSaveFromDirName(const std::filesystem::path& gameDir)
 {
-    std::filesystem::path dir = m_playerProfile->GetSaveFile(TempToPath(gameDir));
+    std::filesystem::path dir = m_playerProfile->GetSaveFile(gameDir);
     if(!CResourceManager::Exists(dir))
     {
         GetLogger()->Error("Save slot not found");

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -4337,7 +4337,7 @@ void CRobotMain::SaveOneScript(CObject *obj)
     CProgramStorageObject* programStorage = dynamic_cast<CProgramStorageObject*>(obj);
 
     char categoryChar = GetLevelCategoryDir(m_levelCategory)[0];
-    programStorage->SaveAllUserPrograms(StrUtils::ToString(m_playerProfile->GetSaveFile(StrUtils::ToPath(StrUtils::Format("%c%.3d%.3d", categoryChar, m_levelChap, m_levelRank)))));
+    programStorage->SaveAllUserPrograms(m_playerProfile->GetSaveFile(StrUtils::ToPath(StrUtils::Format("%c%.3d%.3d", categoryChar, m_levelChap, m_levelRank))));
 }
 
 //! Saves the stack of the program in execution of a robot

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -4698,7 +4698,7 @@ CObject* CRobotMain::IOReadObject(CLevelParserLine *line,
         CProgramStorageObject* programStorage = dynamic_cast<CProgramStorageObject*>(obj);
         if (!line->GetParam("programStorageIndex")->IsDefined()) // Backwards compatibility
             programStorage->SetProgramStorageIndex(objRank);
-        programStorage->LoadAllProgramsForSavedScene(line, TempToString(programDir));
+        programStorage->LoadAllProgramsForSavedScene(line, programDir);
     }
 
     return obj;

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -5357,10 +5357,10 @@ int CRobotMain::GetLevelRank()
 }
 
 //! Returns folder name of the scene that user selected to play.
-std::string CRobotMain::GetCustomLevelDir()
+std::filesystem::path CRobotMain::GetCustomLevelDir()
 {
     assert(m_levelCategory == LevelCategory::CustomLevels);
-    return TempToString(m_ui->GetCustomLevelName(m_levelChap));
+    return m_ui->GetCustomLevelName(m_levelChap);
 }
 
 void CRobotMain::SetReadScene(const std::filesystem::path& path)

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -5577,7 +5577,7 @@ std::filesystem::path CRobotMain::GetCustomLevelName(int id)
     return m_ui->GetCustomLevelName(id);
 }
 
-const std::vector<std::string>& CRobotMain::GetCustomLevelList()
+const std::vector<std::filesystem::path>& CRobotMain::GetCustomLevelList()
 {
     return m_ui->GetCustomLevelList();
 }

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -3280,8 +3280,8 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
             if (line->GetCommand() == "TerrainInitTextures" && !resetObject)
             {
                 m_ui->GetLoadingScreen()->SetProgress(0.2f+(3.f/5.f)*0.05f, RT_LOADING_TERRAIN, RT_LOADING_TERRAIN_TEX);
-                std::string name = "../" + TempToString(line->GetParam("image")->AsPath("textures"));
-                if (name.find(".") == std::string::npos)
+                std::filesystem::path name = ".." / line->GetParam("image")->AsPath("textures");
+                if (name.extension().empty())
                     name += ".png";
                 unsigned int dx = line->GetParam("dx")->AsInt(1);
                 unsigned int dy = line->GetParam("dy")->AsInt(1);
@@ -3316,7 +3316,7 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
                     }
                 }
 
-                m_terrain->InitTextures(name.c_str(), tt, dx, dy);
+                m_terrain->InitTextures(name, tt, dx, dy);
                 continue;
             }
 

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -2875,7 +2875,7 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
 
             if (line->GetCommand() == "ScriptFile" && !resetObject)
             {
-                m_scriptFile = line->GetParam("name")->AsPath("/");
+                m_scriptFile = line->GetParam("name")->AsPath(".");
                 continue;
             }
 
@@ -3769,7 +3769,7 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
 
             if (line->GetCommand() == "NewScript" && !resetObject)
             {
-                m_newScriptName.push_back(NewScriptName(line->GetParam("type")->AsObjectType(OBJECT_NULL), line->GetParam("name")->AsPath("/", "")));
+                m_newScriptName.push_back(NewScriptName(line->GetParam("type")->AsObjectType(OBJECT_NULL), line->GetParam("name")->AsPath(".", "")));
                 continue;
             }
 

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -2875,7 +2875,7 @@ void CRobotMain::CreateScene(bool soluce, bool fixScene, bool resetObject)
 
             if (line->GetCommand() == "ScriptFile" && !resetObject)
             {
-                m_scriptFile = TempToPath(line->GetParam("name")->AsString());
+                m_scriptFile = line->GetParam("name")->AsPath("/");
                 continue;
             }
 

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -599,7 +599,7 @@ void CRobotMain::ChangePhase(Phase phase)
                     pe->SetFontType(Gfx::FONT_COMMON);
                     pe->SetEditCap(false);
                     pe->SetHighlightCap(false);
-                    pe->ReadText(TempToPath(std::string("help/") + m_app->GetLanguageChar() + std::string("/win.txt")));
+                    pe->ReadText(std::filesystem::path("help") / StrUtils::ToPath(std::string(1, m_app->GetLanguageChar())) / "win.txt");
                 }
                 else
                 {

--- a/colobot-base/src/level/robotmain.h
+++ b/colobot-base/src/level/robotmain.h
@@ -127,9 +127,9 @@ class CDebugMenu;
 struct NewScriptName
 {
     ObjectType  type = OBJECT_NULL;
-    std::string name = "";
+    std::filesystem::path name = "";
 
-    NewScriptName(ObjectType type, const std::string& name) : type(type), name(name) {}
+    NewScriptName(ObjectType type, const std::filesystem::path& name) : type(type), name(name) {}
 };
 
 
@@ -320,7 +320,7 @@ public:
     bool        ReadFileStack(CObject *obj, std::istream &istr);
 
     //! Return list of scripts to load to robot created in BotFactory
-    std::vector<std::string> GetNewScriptNames(ObjectType type);
+    std::vector<std::filesystem::path> GetNewScriptNames(ObjectType type);
 
     //! Return the scoreboard manager
     //! Note: this may return nullptr if the scoreboard is not enabled!

--- a/colobot-base/src/level/robotmain.h
+++ b/colobot-base/src/level/robotmain.h
@@ -382,7 +382,7 @@ public:
     void        SetExitAfterMission(bool exit);
 
     //! Load saved game (used by command line argument)
-    void        LoadSaveFromDirName(const std::string& gameDir);
+    void        LoadSaveFromDirName(const std::filesystem::path& gameDir);
 
     //! Returns true if player can interact with things manually
     bool        CanPlayerInteract();

--- a/colobot-base/src/level/robotmain.h
+++ b/colobot-base/src/level/robotmain.h
@@ -359,7 +359,7 @@ public:
 
     void        UpdateCustomLevelList();
     std::filesystem::path GetCustomLevelName(int id);
-    const std::vector<std::string>& GetCustomLevelList();
+    const std::vector<std::filesystem::path>& GetCustomLevelList();
 
     //! Returns true if the game is on the loading screen
     bool        IsLoading();

--- a/colobot-base/src/level/robotmain.h
+++ b/colobot-base/src/level/robotmain.h
@@ -358,7 +358,7 @@ public:
     void        DisplayError(Error err, glm::vec3 goal, float height=15.0f, float dist=60.0f, float time=10.0f);
 
     void        UpdateCustomLevelList();
-    std::string GetCustomLevelName(int id);
+    std::filesystem::path GetCustomLevelName(int id);
     const std::vector<std::string>& GetCustomLevelList();
 
     //! Returns true if the game is on the loading screen

--- a/colobot-base/src/level/robotmain.h
+++ b/colobot-base/src/level/robotmain.h
@@ -291,7 +291,7 @@ public:
     LevelCategory GetLevelCategory();
     int         GetLevelChap();
     int         GetLevelRank();
-    std::string GetCustomLevelDir();
+    std::filesystem::path GetCustomLevelDir();
     void        SetReadScene(const std::filesystem::path& path);
     void        UpdateChapterPassed();
 

--- a/colobot-base/src/object/auto/auto.cpp
+++ b/colobot-base/src/object/auto/auto.cpp
@@ -131,7 +131,7 @@ bool CAuto::SetValue(int rank, float value)
 
 // Getes the string.
 
-bool CAuto::SetString(char *string)
+bool CAuto::SetString(const std::string& string)
 {
     return false;
 }

--- a/colobot-base/src/object/auto/auto.h
+++ b/colobot-base/src/object/auto/auto.h
@@ -24,6 +24,7 @@
 
 #include "object/object_type.h"
 
+#include <string>
 
 class CRobotMain;
 class CSoundInterface;
@@ -68,7 +69,7 @@ public:
 
     virtual bool    SetType(ObjectType type);
     virtual bool    SetValue(int rank, float value);
-    virtual bool    SetString(char *string);
+    virtual bool    SetString(const std::string& string);
 
     virtual bool    CreateInterface(bool bSelect);
     virtual Error   GetError();

--- a/colobot-base/src/object/auto/autobase.cpp
+++ b/colobot-base/src/object/auto/autobase.cpp
@@ -1341,7 +1341,7 @@ void CAutoBase::BeginTransit()
     bool full, scale;
     m_engine->GetBackground(m_bgName, m_bgUp, m_bgDown, m_bgCloudUp, m_bgCloudDown, full, scale);
 
-    m_engine->SetBackground(TempToPath(m_bgBack), Gfx::Color(0.0f, 0.0f, 0.0f, 0.0f),
+    m_engine->SetBackground(m_bgBack, Gfx::Color(0.0f, 0.0f, 0.0f, 0.0f),
             Gfx::Color(0.0f, 0.0f, 0.0f, 0.0f),
             Gfx::Color(0.0f, 0.0f, 0.0f, 0.0f),
             Gfx::Color(0.0f, 0.0f, 0.0f, 0.0f));

--- a/colobot-base/src/object/auto/autobase.h
+++ b/colobot-base/src/object/auto/autobase.h
@@ -110,7 +110,7 @@ protected:
     int             m_soundChannel = 0;
     int             m_partiChannel[8] = {};
 
-    std::string     m_bgBack;
+    std::filesystem::path m_bgBack;
     std::filesystem::path m_bgName;
     Gfx::Color      m_bgUp;
     Gfx::Color      m_bgDown;

--- a/colobot-base/src/object/auto/autoegg.cpp
+++ b/colobot-base/src/object/auto/autoegg.cpp
@@ -147,9 +147,9 @@ bool CAutoEgg::SetValue(int rank, float value)
     return true;
 }
 
-bool CAutoEgg::SetString(char *string)
+bool CAutoEgg::SetString(const std::string& string)
 {
-    m_alienProgramName = string;
+    m_alienProgramName = StrUtils::ToPath(string);
     return true;
 }
 
@@ -196,9 +196,9 @@ bool CAutoEgg::EventProcess(const Event &event)
 
             CProgramStorageObject* programStorage = dynamic_cast<CProgramStorageObject*>(alien);
             Program* program = programStorage->AddProgram();
-            programStorage->ReadProgram(program, InjectLevelPathsForCurrentLevel(TempToPath(m_alienProgramName), "ai"));
+            programStorage->ReadProgram(program, InjectLevelPathsForCurrentLevel(m_alienProgramName, "ai"));
             program->readOnly = true;
-            program->filename = m_alienProgramName;
+            program->filename = StrUtils::ToString(m_alienProgramName);
             programmable->RunProgram(program);
         }
         Init();
@@ -327,7 +327,7 @@ bool CAutoEgg::Write(CLevelParserLine* line)
     line->AddParam("aSpeed", std::make_unique<CLevelParserParam>(m_speed));
     line->AddParam("aParamType", std::make_unique<CLevelParserParam>(m_type));
     line->AddParam("aParamValue1", std::make_unique<CLevelParserParam>(m_value));
-    line->AddParam("aParamString", std::make_unique<CLevelParserParam>(m_alienProgramName));
+    line->AddParam("aParamString", std::make_unique<CLevelParserParam>(StrUtils::ToString(m_alienProgramName)));
 
     return true;
 }
@@ -344,7 +344,8 @@ bool CAutoEgg::Read(CLevelParserLine* line)
     m_speed = line->GetParam("aSpeed")->AsFloat(1.0f);
     m_type = line->GetParam("aParamType")->AsObjectType(OBJECT_NULL);
     m_value = line->GetParam("aParamValue1")->AsFloat(0.0f);
-    m_alienProgramName = line->GetParam("aParamString")->AsString("");
+    // Read aParamString as a string to avoid interpreting %lvl% etc.
+    m_alienProgramName = StrUtils::ToPath(line->GetParam("aParamString")->AsString(""));
 
     return true;
 }

--- a/colobot-base/src/object/auto/autoegg.h
+++ b/colobot-base/src/object/auto/autoegg.h
@@ -21,7 +21,7 @@
 
 
 #include "object/auto/auto.h"
-
+#include <filesystem>
 
 class CObject;
 
@@ -54,7 +54,7 @@ public:
     bool        SetValue(int rank, float value) override;
     //! Sets program which will be run by created aliens
     // TODO: rename to be more meanigful
-    bool        SetString(char* string) override;
+    bool        SetString(const std::string& string) override;
 
     bool        Write(CLevelParserLine* line) override;
     bool        Read(CLevelParserLine* line) override;
@@ -65,7 +65,7 @@ protected:
 protected:
     ObjectType      m_type = OBJECT_NULL;
     float           m_value = 0.0f;
-    std::string     m_alienProgramName;
+    std::filesystem::path m_alienProgramName;
     int             m_param = 0;
     AutoEggPhase    m_phase = AEP_NULL;
     float           m_progress = 0.0f;

--- a/colobot-base/src/object/auto/autofactory.cpp
+++ b/colobot-base/src/object/auto/autofactory.cpp
@@ -675,12 +675,12 @@ bool CAutoFactory::CreateVehicle()
     if (vehicle->Implements(ObjectInterfaceType::ProgramStorage))
     {
         CProgramStorageObject* programStorage = dynamic_cast<CProgramStorageObject*>(vehicle);
-        for (const std::string& name : m_main->GetNewScriptNames(m_type))
+        for (const std::filesystem::path& name : m_main->GetNewScriptNames(m_type))
         {
             Program* prog = programStorage->AddProgram();
-            programStorage->ReadProgram(prog, InjectLevelPathsForCurrentLevel(TempToPath(name), "ai"));
+            programStorage->ReadProgram(prog, InjectLevelPathsForCurrentLevel(name, "ai"));
             prog->readOnly = true;
-            prog->filename = name;
+            prog->filename = StrUtils::ToString(name);
         }
     }
 

--- a/colobot-base/src/object/implementation/program_storage_impl.cpp
+++ b/colobot-base/src/object/implementation/program_storage_impl.cpp
@@ -359,7 +359,7 @@ void CProgramStorageObjectImpl::SaveAllProgramsForSavedScene(CLevelParserLine* l
     }
 }
 
-void CProgramStorageObjectImpl::LoadAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::string& levelSource)
+void CProgramStorageObjectImpl::LoadAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::filesystem::path& levelSource)
 {
     int run = levelSourceLine->GetParam("run")->AsInt(0)-1;
     m_programStorageIndex = levelSourceLine->GetParam("programStorageIndex")->AsInt(-1);
@@ -388,15 +388,14 @@ void CProgramStorageObjectImpl::LoadAllProgramsForSavedScene(CLevelParserLine* l
 
     if(m_programStorageIndex < 0) return;
 
-    GetLogger()->Debug("Loading saved scene programs from '%%'",
-        StrUtils::Format("%s/prog%.3d___.txt", levelSource.c_str(), m_programStorageIndex));
+    GetLogger()->Debug("Loading saved scene programs from '%%'", levelSource / StrUtils::ToPath(StrUtils::Format("prog%.3d___.txt", m_programStorageIndex)));
 
     for (int i = 0; i <= 999; i++)
     {
         std::string opReadOnly = "scriptReadOnly" + StrUtils::ToString<int>(i+1); // scriptReadOnly1..scriptReadOnly10
         std::string opRunnable = "scriptRunnable" + StrUtils::ToString<int>(i+1); // scriptRunnable1..scriptRunnable10
 
-        std::filesystem::path filename = TempToPath(levelSource + StrUtils::Format("/prog%.3d%.3d.txt", m_programStorageIndex, i));
+        std::filesystem::path filename = levelSource / StrUtils::ToPath(StrUtils::Format("prog%.3d%.3d.txt", m_programStorageIndex, i));
         if (CResourceManager::Exists(filename))
         {
             GetLogger()->Trace("Loading program '%%' from saved scene", filename);

--- a/colobot-base/src/object/implementation/program_storage_impl.cpp
+++ b/colobot-base/src/object/implementation/program_storage_impl.cpp
@@ -312,7 +312,7 @@ void CProgramStorageObjectImpl::LoadAllProgramsForLevel(CLevelParserLine* levelS
     }
 }
 
-void CProgramStorageObjectImpl::SaveAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::string& levelSource)
+void CProgramStorageObjectImpl::SaveAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::filesystem::path& levelSource)
 {
     levelSourceLine->AddParam("programStorageIndex", std::make_unique<CLevelParserParam>(m_programStorageIndex));
 
@@ -329,12 +329,11 @@ void CProgramStorageObjectImpl::SaveAllProgramsForSavedScene(CLevelParserLine* l
     if (m_programStorageIndex < 0) return;
     if (!m_object->Implements(ObjectInterfaceType::Controllable) || !dynamic_cast<CControllableObject&>(*m_object).GetSelectable() || m_object->GetType() == OBJECT_HUMAN) return;
 
-    GetLogger()->Debug("Saving saved scene programs to '%%'",
-        StrUtils::Format("%s/prog%.3d___.txt", levelSource.c_str(), m_programStorageIndex));
+    GetLogger()->Debug("Saving saved scene programs to '%%'", levelSource / StrUtils::ToPath(StrUtils::Format("prog%.3d___.txt", m_programStorageIndex)));
 
     for (unsigned int i = 0; i < m_program.size(); i++)
     {
-        std::filesystem::path filename = TempToPath(levelSource + StrUtils::Format("/prog%.3d%.3d.txt", m_programStorageIndex, i));
+        std::filesystem::path filename = levelSource / StrUtils::ToPath(StrUtils::Format("prog%.3d%.3d.txt", m_programStorageIndex, i));
         if (!m_program[i]->filename.empty() && m_program[i]->readOnly) continue;
 
         GetLogger()->Trace("Saving program '%%' to saved scene\n", filename);
@@ -344,7 +343,7 @@ void CProgramStorageObjectImpl::SaveAllProgramsForSavedScene(CLevelParserLine* l
     }
 
     std::regex regex(StrUtils::Format("prog%.3d([0-9]{3})\\.txt", m_programStorageIndex));
-    for (const std::filesystem::path& path : CResourceManager::ListFiles(StrUtils::ToPath(levelSource)))
+    for (const std::filesystem::path& path : CResourceManager::ListFiles(levelSource))
     {
         std::string filename = StrUtils::ToString(path);
         std::smatch matches;
@@ -354,7 +353,7 @@ void CProgramStorageObjectImpl::SaveAllProgramsForSavedScene(CLevelParserLine* l
             if (id >= m_program.size() || !m_program[id]->filename.empty())
             {
                 GetLogger()->Trace("Removing old program '%%/%%' from saved scene", levelSource, path);
-                CResourceManager::Remove(StrUtils::ToPath(levelSource) / path);
+                CResourceManager::Remove(levelSource / path);
             }
         }
     }

--- a/colobot-base/src/object/implementation/program_storage_impl.cpp
+++ b/colobot-base/src/object/implementation/program_storage_impl.cpp
@@ -209,16 +209,18 @@ int CProgramStorageObjectImpl::GetProgramStorageIndex()
     return m_programStorageIndex;
 }
 
-void CProgramStorageObjectImpl::SaveAllUserPrograms(const std::string& userSource)
+void CProgramStorageObjectImpl::SaveAllUserPrograms(const std::filesystem::path& userSource)
 {
     if (!m_allowProgramSave) return;
     if (m_programStorageIndex < 0) return;
-    GetLogger()->Debug("Saving user programs to '%%'",
-        StrUtils::Format("%s%.3d___.txt", userSource.c_str(), m_programStorageIndex));
+    std::filesystem::path filename = userSource;
+    filename += StrUtils::ToPath(StrUtils::Format("%.3d___.txt", m_programStorageIndex));
+    GetLogger()->Debug("Saving user programs to '%%'", filename);
 
     for (unsigned int i = 0; i < m_program.size(); i++)
     {
-        std::filesystem::path filename = TempToPath(userSource + StrUtils::Format("%.3d%.3d.txt", m_programStorageIndex, i));
+        std::filesystem::path filename = userSource;
+        filename += StrUtils::ToPath(StrUtils::Format("%.3d%.3d.txt", m_programStorageIndex, i));
 
         if (m_program[i]->filename.empty())
         {
@@ -227,9 +229,8 @@ void CProgramStorageObjectImpl::SaveAllUserPrograms(const std::string& userSourc
         }
     }
 
-    std::filesystem::path dir = StrUtils::ToPath(userSource.substr(0, userSource.find_last_of("/")));
-    std::string file = userSource.substr(userSource.find_last_of("/")+1) + StrUtils::Format("%.3d([0-9]{3})\\.txt", m_programStorageIndex);
-    std::regex regex(file);
+    std::filesystem::path dir = userSource.parent_path();
+    std::regex regex(StrUtils::ToString(userSource.filename()) + StrUtils::Format("%.3d([0-9]{3})\\.txt", m_programStorageIndex));
     for (const auto& path : CResourceManager::ListFiles(dir))
     {
         std::string filename = StrUtils::ToString(path);

--- a/colobot-base/src/object/implementation/program_storage_impl.h
+++ b/colobot-base/src/object/implementation/program_storage_impl.h
@@ -55,7 +55,7 @@ public:
     void SetProgramStorageIndex(int programStorageIndex) override;
     int GetProgramStorageIndex() override;
 
-    void SaveAllUserPrograms(const std::string& userSource) override;
+    void SaveAllUserPrograms(const std::filesystem::path& userSource) override;
     void LoadAllProgramsForLevel(CLevelParserLine* levelSource, const std::string& userSource, bool loadSoluce) override;
 
     void SaveAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::filesystem::path& levelSource) override;

--- a/colobot-base/src/object/implementation/program_storage_impl.h
+++ b/colobot-base/src/object/implementation/program_storage_impl.h
@@ -59,7 +59,7 @@ public:
     void LoadAllProgramsForLevel(CLevelParserLine* levelSource, const std::string& userSource, bool loadSoluce) override;
 
     void SaveAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::filesystem::path& levelSource) override;
-    void LoadAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::string& levelSource) override;
+    void LoadAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::filesystem::path& levelSource) override;
 
 private:
     CObject* m_object;

--- a/colobot-base/src/object/implementation/program_storage_impl.h
+++ b/colobot-base/src/object/implementation/program_storage_impl.h
@@ -58,7 +58,7 @@ public:
     void SaveAllUserPrograms(const std::string& userSource) override;
     void LoadAllProgramsForLevel(CLevelParserLine* levelSource, const std::string& userSource, bool loadSoluce) override;
 
-    void SaveAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::string& levelSource) override;
+    void SaveAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::filesystem::path& levelSource) override;
     void LoadAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::string& levelSource) override;
 
 private:

--- a/colobot-base/src/object/interface/program_storage_object.h
+++ b/colobot-base/src/object/interface/program_storage_object.h
@@ -102,7 +102,7 @@ public:
     virtual void LoadAllProgramsForLevel(CLevelParserLine* levelSource, const std::string& userSource, bool loadSoluce) = 0;
 
     //! Save all programs when saving the saved scene
-    virtual void SaveAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::string& levelSource) = 0;
+    virtual void SaveAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::filesystem::path& levelSource) = 0;
     //! Load all programs when loading the saved scene
     virtual void LoadAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::string& levelSource) = 0;
 };

--- a/colobot-base/src/object/interface/program_storage_object.h
+++ b/colobot-base/src/object/interface/program_storage_object.h
@@ -97,7 +97,7 @@ public:
     virtual int GetProgramStorageIndex() = 0;
 
     //! Save all user programs
-    virtual void SaveAllUserPrograms(const std::string& userSource) = 0;
+    virtual void SaveAllUserPrograms(const std::filesystem::path& userSource) = 0;
     //! Load all programs when loading the level including previously saved user programs
     virtual void LoadAllProgramsForLevel(CLevelParserLine* levelSource, const std::string& userSource, bool loadSoluce) = 0;
 

--- a/colobot-base/src/object/interface/program_storage_object.h
+++ b/colobot-base/src/object/interface/program_storage_object.h
@@ -104,5 +104,5 @@ public:
     //! Save all programs when saving the saved scene
     virtual void SaveAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::filesystem::path& levelSource) = 0;
     //! Load all programs when loading the saved scene
-    virtual void LoadAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::string& levelSource) = 0;
+    virtual void LoadAllProgramsForSavedScene(CLevelParserLine* levelSourceLine, const std::filesystem::path& levelSource) = 0;
 };

--- a/colobot-base/src/object/subclass/static_object.cpp
+++ b/colobot-base/src/object/subclass/static_object.cpp
@@ -142,7 +142,7 @@ CStaticObjectUPtr CStaticObject::Create(int id,
         if (model->GetMeshCount() != 1 || model->GetMesh("main") == nullptr)
             throw CObjectCreateException("Unexpected mesh configuration", type, StrUtils::ToString(modelFile));
 
-        return std::make_unique<CStaticObject>(id, type, modelFile, adjustedPosition, angleY, model, engine);
+        return std::make_unique<CStaticObject>(id, type, TempToString(modelFile), adjustedPosition, angleY, model, engine);
     }
     catch (const Gfx::CModelIOException& e)
     {

--- a/colobot-base/src/object/subclass/static_object.cpp
+++ b/colobot-base/src/object/subclass/static_object.cpp
@@ -30,8 +30,11 @@
 
 #include "object/object_create_exception.h"
 
+#include "common/stringutils.h"
 
-const std::unordered_map<ObjectType, std::string, ObjectTypeHash> CStaticObject::m_staticModelNames{};
+#include <filesystem>
+
+const std::unordered_map<ObjectType, std::filesystem::path, ObjectTypeHash> CStaticObject::m_staticModelNames{};
 // TODO: commenting out temporarily
 //=
 //{
@@ -126,7 +129,7 @@ CStaticObjectUPtr CStaticObject::Create(int id,
     if (it == m_staticModelNames.end())
         throw CObjectCreateException("Object type is not static object", type);
 
-    std::string modelFile = it->second;
+    std::filesystem::path modelFile = it->second;
 
     glm::vec3 adjustedPosition = position;
     terrain->AdjustToFloor(adjustedPosition);
@@ -137,12 +140,12 @@ CStaticObjectUPtr CStaticObject::Create(int id,
         auto model = modelManager->GetModel(modelFile);
 
         if (model->GetMeshCount() != 1 || model->GetMesh("main") == nullptr)
-            throw CObjectCreateException("Unexpected mesh configuration", type, modelFile);
+            throw CObjectCreateException("Unexpected mesh configuration", type, StrUtils::ToString(modelFile));
 
         return std::make_unique<CStaticObject>(id, type, modelFile, adjustedPosition, angleY, model, engine);
     }
     catch (const Gfx::CModelIOException& e)
     {
-        throw CObjectCreateException(std::string("Error loading model file: ") + e.what(), type, modelFile);
+        throw CObjectCreateException(std::string("Error loading model file: ") + e.what(), type, StrUtils::ToString(modelFile));
     }
 }

--- a/colobot-base/src/object/subclass/static_object.cpp
+++ b/colobot-base/src/object/subclass/static_object.cpp
@@ -142,7 +142,7 @@ CStaticObjectUPtr CStaticObject::Create(int id,
         if (model->GetMeshCount() != 1 || model->GetMesh("main") == nullptr)
             throw CObjectCreateException("Unexpected mesh configuration", type, StrUtils::ToString(modelFile));
 
-        return std::make_unique<CStaticObject>(id, type, TempToString(modelFile), adjustedPosition, angleY, model, engine);
+        return std::make_unique<CStaticObject>(id, type, StrUtils::ToString(modelFile), adjustedPosition, angleY, model, engine);
     }
     catch (const Gfx::CModelIOException& e)
     {

--- a/colobot-base/src/object/subclass/static_object.h
+++ b/colobot-base/src/object/subclass/static_object.h
@@ -25,6 +25,7 @@
 
 #include <memory>
 #include <unordered_map>
+#include <filesystem>
 
 namespace Gfx
 {
@@ -77,5 +78,5 @@ private:
 private:
     Gfx::CEngine* m_engine;
     int m_meshHandle;
-    static const std::unordered_map<ObjectType, std::string, ObjectTypeHash> m_staticModelNames;
+    static const std::unordered_map<ObjectType, std::filesystem::path, ObjectTypeHash> m_staticModelNames;
 };

--- a/colobot-base/src/script/cbottoken.cpp
+++ b/colobot-base/src/script/cbottoken.cpp
@@ -251,7 +251,7 @@ std::filesystem::path GetHelpFilename(ObjectType type)
     if (helpfile.empty())
         return "";
 
-    return ("help" / StrUtils::ToPath(std::string(1, CApplication::GetInstancePointer()->GetLanguageChar())) / helpfile).replace_extension("txt");
+    return ("help" / CApplication::GetInstancePointer()->GetLanguageDir() / helpfile).replace_extension("txt");
 }
 
 
@@ -423,7 +423,7 @@ std::filesystem::path GetHelpFilename(const char *token)
     if (helpfile.empty())
         return "";
 
-    return ("help" / StrUtils::ToPath(std::string(1, CApplication::GetInstancePointer()->GetLanguageChar())) / helpfile).replace_extension("txt");
+    return ("help" / CApplication::GetInstancePointer()->GetLanguageDir() / helpfile).replace_extension("txt");
 }
 
 

--- a/colobot-base/src/script/cbottoken.cpp
+++ b/colobot-base/src/script/cbottoken.cpp
@@ -23,8 +23,10 @@
 #include "app/app.h"
 
 #include "object/object_type.h"
+#include "common/stringutils.h"
 
 #include <string.h>
+#include <filesystem>
 
 
 // Seeking the name of an object.
@@ -149,9 +151,9 @@ const char* GetObjectAlias(ObjectType type)
 
 // Returns the help file to use for the object.
 
-std::string GetHelpFilename(ObjectType type)
+std::filesystem::path GetHelpFilename(ObjectType type)
 {
-    std::string helpfile = "";
+    std::filesystem::path helpfile = "";
 
     if ( type == OBJECT_BASE        )  helpfile = "object/base";
     if ( type == OBJECT_DERRICK     )  helpfile = "object/derrick";
@@ -249,15 +251,15 @@ std::string GetHelpFilename(ObjectType type)
     if (helpfile.empty())
         return "";
 
-    return std::string("help/") + CApplication::GetInstancePointer()->GetLanguageChar() + "/" + helpfile + ".txt";
+    return ("help" / StrUtils::ToPath(std::string(1, CApplication::GetInstancePointer()->GetLanguageChar())) / helpfile).replace_extension("txt");
 }
 
 
 // Returns the help file to use for instruction.
 
-std::string GetHelpFilename(const char *token)
+std::filesystem::path GetHelpFilename(const char *token)
 {
-    std::string helpfile = "";
+    std::filesystem::path helpfile = "";
 
     if ( strcmp(token, "if"            ) == 0 )  helpfile = "cbot/if";
     if ( strcmp(token, "else"          ) == 0 )  helpfile = "cbot/if";
@@ -421,7 +423,7 @@ std::string GetHelpFilename(const char *token)
     if (helpfile.empty())
         return "";
 
-    return std::string("help/") + CApplication::GetInstancePointer()->GetLanguageChar() + "/" + helpfile + ".txt";
+    return ("help" / StrUtils::ToPath(std::string(1, CApplication::GetInstancePointer()->GetLanguageChar())) / helpfile).replace_extension("txt");
 }
 
 

--- a/colobot-base/src/script/cbottoken.h
+++ b/colobot-base/src/script/cbottoken.h
@@ -27,7 +27,7 @@
 
 #include "object/object_type.h"
 
-#include <string>
+#include <filesystem>
 
 
 
@@ -35,8 +35,8 @@
 
 extern const char* GetObjectName(ObjectType type);
 extern const char* GetObjectAlias(ObjectType type);
-extern std::string GetHelpFilename(ObjectType type);
-extern std::string GetHelpFilename(const char *token);
+extern std::filesystem::path GetHelpFilename(ObjectType type);
+extern std::filesystem::path GetHelpFilename(const char *token);
 extern bool IsType(const char *token);
 extern bool IsFunction(const char *token);
 extern const char* GetHelpText(const char *token);

--- a/colobot-base/src/script/scriptfunc.cpp
+++ b/colobot-base/src/script/scriptfunc.cpp
@@ -3378,7 +3378,7 @@ class CBotFileColobot : public CBotFile
 public:
     static int m_numFilesOpen;
 
-    CBotFileColobot(const std::string& filename, CBotFileAccessHandler::OpenMode mode)
+    CBotFileColobot(const std::filesystem::path& filename, CBotFileAccessHandler::OpenMode mode)
     {
         if (mode == CBotFileAccessHandler::OpenMode::Read)
         {
@@ -3468,9 +3468,9 @@ int CBotFileColobot::m_numFilesOpen = 0;
 class CBotFileAccessHandlerColobot : public CBotFileAccessHandler
 {
 public:
-    virtual std::unique_ptr<CBotFile> OpenFile(const std::string& filename, OpenMode mode) override
+    virtual std::unique_ptr<CBotFile> OpenFile(const std::filesystem::path& filename, OpenMode mode) override
     {
-        return std::make_unique<CBotFileColobot>(TempToString(PrepareFilename(TempToPath(filename))), mode);
+        return std::make_unique<CBotFileColobot>(PrepareFilename(filename), mode);
     }
 
     virtual bool DeleteFile(const std::filesystem::path& filename) override

--- a/colobot-base/src/sound/oalsound/alsound.cpp
+++ b/colobot-base/src/sound/oalsound/alsound.cpp
@@ -135,10 +135,10 @@ int CALSound::GetMusicVolume()
     return m_musicVolume * MAXVOLUME;
 }
 
-bool CALSound::Cache(SoundType sound, const std::string &filename)
+bool CALSound::Cache(SoundType sound, const std::filesystem::path &filename)
 {
     auto buffer = std::make_unique<CBuffer>();
-    if (buffer->LoadFromFile(TempToPath(filename), sound))
+    if (buffer->LoadFromFile(filename, sound))
     {
         m_sounds[sound] = std::move(buffer);
         return true;

--- a/colobot-base/src/sound/oalsound/alsound.cpp
+++ b/colobot-base/src/sound/oalsound/alsound.cpp
@@ -166,9 +166,9 @@ bool CALSound::IsCached(SoundType sound)
     return m_sounds.find(sound) != m_sounds.end();
 }
 
-bool CALSound::IsCachedMusic(const std::string &filename)
+bool CALSound::IsCachedMusic(const std::filesystem::path &filename)
 {
-    return m_music.find(TempToPath(filename)) != m_music.end();
+    return m_music.find(filename) != m_music.end();
 }
 
 int CALSound::GetPriority(SoundType sound)

--- a/colobot-base/src/sound/oalsound/alsound.h
+++ b/colobot-base/src/sound/oalsound/alsound.h
@@ -86,7 +86,7 @@ public:
 
     bool Create() override;
     void Reset() override;
-    bool Cache(SoundType, const std::string &) override;
+    bool Cache(SoundType, const std::filesystem::path &) override;
     void CacheMusic(const std::filesystem::path &) override;
     bool IsCached(SoundType) override;
     bool IsCachedMusic(const std::string &) override;

--- a/colobot-base/src/sound/oalsound/alsound.h
+++ b/colobot-base/src/sound/oalsound/alsound.h
@@ -89,7 +89,7 @@ public:
     bool Cache(SoundType, const std::filesystem::path &) override;
     void CacheMusic(const std::filesystem::path &) override;
     bool IsCached(SoundType) override;
-    bool IsCachedMusic(const std::string &) override;
+    bool IsCachedMusic(const std::filesystem::path &) override;
 
     bool GetEnable() override;
     void SetAudioVolume(int volume) override;

--- a/colobot-base/src/sound/sound.cpp
+++ b/colobot-base/src/sound/sound.cpp
@@ -20,6 +20,7 @@
 #include "sound/sound.h"
 
 #include "common/logger.h"
+#include "common/stringutils.h"
 
 #include "math/func.h"
 
@@ -47,7 +48,7 @@ void CSoundInterface::CacheAll()
     {
         std::stringstream filename;
         filename << "sounds/sound" << std::setfill('0') << std::setw(3) << i << ".wav";
-        if ( !Cache(static_cast<SoundType>(i), filename.str()) )
+        if ( !Cache(static_cast<SoundType>(i), StrUtils::ToPath(filename.str())) )
             GetLogger()->Warn("Unable to load audio: %%", filename.str());
     }
 }
@@ -56,7 +57,7 @@ void CSoundInterface::Reset()
 {
 }
 
-bool CSoundInterface::Cache(SoundType sound, const std::string &file)
+bool CSoundInterface::Cache(SoundType sound, const std::filesystem::path &file)
 {
     return true;
 }

--- a/colobot-base/src/sound/sound.cpp
+++ b/colobot-base/src/sound/sound.cpp
@@ -71,7 +71,7 @@ bool CSoundInterface::IsCached(SoundType sound)
     return false;
 }
 
-bool CSoundInterface::IsCachedMusic(const std::string& file)
+bool CSoundInterface::IsCachedMusic(const std::filesystem::path& file)
 {
     return false;
 }

--- a/colobot-base/src/sound/sound.h
+++ b/colobot-base/src/sound/sound.h
@@ -99,7 +99,7 @@ public:
      * \param file - file to check
      * \return return true if the file was cached
      */
-    virtual bool IsCachedMusic(const std::string &file);
+    virtual bool IsCachedMusic(const std::filesystem::path &file);
 
     /** Return if plugin is enabled
      *  \return return true if plugin is enabled

--- a/colobot-base/src/sound/sound.h
+++ b/colobot-base/src/sound/sound.h
@@ -80,7 +80,7 @@ public:
      * \param file - file to load
      * \return return true on success
      */
-    virtual bool Cache(SoundType sound, const std::string &file);
+    virtual bool Cache(SoundType sound, const std::filesystem::path &file);
 
     /** Function called to cache music file.
      *  This function is called by CRobotMain for each file used in the mission.

--- a/colobot-base/src/ui/controls/edit.cpp
+++ b/colobot-base/src/ui/controls/edit.cpp
@@ -806,23 +806,22 @@ void CEdit::HyperFlush()
 void CEdit::HyperHome(std::string filename)
 {
     HyperFlush();
-    HyperAdd(filename, 0);
+    HyperAdd(TempToPath(filename), 0);
 }
 
 // Performs a hyper jump through a link.
 
-void CEdit::HyperJump(std::string name, std::string marker)
+void CEdit::HyperJump(const std::filesystem::path& name, std::string marker)
 {
     if ( m_historyCurrent >= 0 )
     {
         m_history[m_historyCurrent].firstLine = m_lineFirst;
     }
 
-    std::string filename = name + std::string(".txt");
-    filename = StrUtils::ToString(InjectLevelPathsForCurrentLevel(TempToPath(filename), "help/%lng%"));
-    filename = StrUtils::Replace(filename, "\\", "/"); //TODO: Fix this in files
+    std::filesystem::path filename = InjectLevelPathsForCurrentLevel(name, "help/%lng%");
+    filename.replace_extension("txt");
 
-    if ( ReadText(TempToPath(filename)) )
+    if ( ReadText(filename) )
     {
         Justif();
 
@@ -847,12 +846,12 @@ void CEdit::HyperJump(std::string name, std::string marker)
 
 // Adds text to the history of visited.
 
-bool CEdit::HyperAdd(std::string filename, int firstLine)
+bool CEdit::HyperAdd(const std::filesystem::path& filename, int firstLine)
 {
     if ( m_historyCurrent >= EDITHISTORYMAX-1 )  return false;
 
     m_historyCurrent ++;
-    m_history[m_historyCurrent].filename = filename;
+    m_history[m_historyCurrent].filename = TempToString(filename);
     m_history[m_historyCurrent].firstLine = firstLine;
 
     m_historyTotal = m_historyCurrent+1;
@@ -1617,7 +1616,7 @@ bool CEdit::ReadText(const std::filesystem::path& filename)
             if ( m_bSoluce || !bInSoluce )
             {
                 HyperLink link;
-                link.name = GetNameParam(buffer.data()+i+3, 0);
+                link.name = StrUtils::ToPath(GetNameParam(buffer.data()+i+3, 0));
                 link.marker = GetNameParam(buffer.data()+i+3, 1);
                 m_link.push_back(link);
                 font &= ~Gfx::FONT_MASK_LINK;

--- a/colobot-base/src/ui/controls/edit.cpp
+++ b/colobot-base/src/ui/controls/edit.cpp
@@ -1042,7 +1042,7 @@ void CEdit::Draw()
             unsigned int iIndex = m_text[beg];  // character = index in m_image
             assert(iIndex < m_image.size());
             pos.y -= m_lineHeight*(line-1);
-            DrawImage(pos, TempToString(m_image[iIndex].name),
+            DrawImage(pos, m_image[iIndex].name,
                       m_image[iIndex].width*(m_fontSize/Gfx::FONT_SIZE_SMALL),
                       m_image[iIndex].offset, m_image[iIndex].height*line, line);
             pos.y -= m_lineHeight;
@@ -1172,7 +1172,7 @@ static std::filesystem::path PrepareImageFilename(std::filesystem::path name)
     return InjectLevelPathsForCurrentLevel(name, "icons");
 }
 
-void CEdit::DrawImage(const glm::vec2& pos, std::string name, float width,
+void CEdit::DrawImage(const glm::vec2& pos, const std::filesystem::path& name, float width,
                       float offset, float height, int nbLine)
 {
     glm::vec2 uv1, uv2, dim;
@@ -1185,7 +1185,7 @@ void CEdit::DrawImage(const glm::vec2& pos, std::string name, float width,
     params.format = Gfx::TextureFormat::AUTO;
     params.filter = Gfx::TextureFilter::BILINEAR;
     params.padToNearestPowerOfTwo = true;
-    Gfx::Texture tex = m_engine->LoadTexture(PrepareImageFilename(TempToPath(name)), params);
+    Gfx::Texture tex = m_engine->LoadTexture(PrepareImageFilename(name), params);
 
     m_engine->GetUIRenderer()->SetTexture(tex);
 

--- a/colobot-base/src/ui/controls/edit.cpp
+++ b/colobot-base/src/ui/controls/edit.cpp
@@ -803,10 +803,10 @@ void CEdit::HyperFlush()
 
 // Indicates which is the home page.
 
-void CEdit::HyperHome(std::string filename)
+void CEdit::HyperHome(const std::filesystem::path& filename)
 {
     HyperFlush();
-    HyperAdd(TempToPath(filename), 0);
+    HyperAdd(filename, 0);
 }
 
 // Performs a hyper jump through a link.

--- a/colobot-base/src/ui/controls/edit.cpp
+++ b/colobot-base/src/ui/controls/edit.cpp
@@ -1042,7 +1042,7 @@ void CEdit::Draw()
             unsigned int iIndex = m_text[beg];  // character = index in m_image
             assert(iIndex < m_image.size());
             pos.y -= m_lineHeight*(line-1);
-            DrawImage(pos, m_image[iIndex].name,
+            DrawImage(pos, TempToString(m_image[iIndex].name),
                       m_image[iIndex].width*(m_fontSize/Gfx::FONT_SIZE_SMALL),
                       m_image[iIndex].offset, m_image[iIndex].height*line, line);
             pos.y -= m_lineHeight;
@@ -1450,7 +1450,7 @@ void CEdit::FreeImage()
 {
     for (auto& image : m_image)
     {
-        m_engine->DeleteTexture(PrepareImageFilename(TempToPath(image.name)));
+        m_engine->DeleteTexture(PrepareImageFilename(image.name));
     }
 }
 
@@ -1656,7 +1656,7 @@ bool CEdit::ReadText(const std::filesystem::path& filename)
                 for ( iCount=0 ; iCount<iLines ; iCount++ )
                 {
                     ImageLine image;
-                    image.name = iName;
+                    image.name = StrUtils::ToPath(iName);
                     image.offset = static_cast<float>(iCount) / static_cast<float>(iLines);
                     image.height = 1.0f/iLines;
                     image.width = iWidth*0.75f;

--- a/colobot-base/src/ui/controls/edit.cpp
+++ b/colobot-base/src/ui/controls/edit.cpp
@@ -1166,13 +1166,10 @@ void CEdit::Draw()
 
 // Draw an image part.
 
-static std::string PrepareImageFilename(std::string name)
+static std::filesystem::path PrepareImageFilename(std::filesystem::path name)
 {
-    std::string filename;
-    filename = name + ".png";
-    filename = StrUtils::ToString(InjectLevelPathsForCurrentLevel(TempToPath(filename), "icons"));
-    filename = StrUtils::Replace(filename, "\\", "/"); // TODO: Fix this in files
-    return filename;
+    name.replace_extension("png");
+    return InjectLevelPathsForCurrentLevel(name, "icons");
 }
 
 void CEdit::DrawImage(const glm::vec2& pos, std::string name, float width,
@@ -1188,7 +1185,7 @@ void CEdit::DrawImage(const glm::vec2& pos, std::string name, float width,
     params.format = Gfx::TextureFormat::AUTO;
     params.filter = Gfx::TextureFilter::BILINEAR;
     params.padToNearestPowerOfTwo = true;
-    Gfx::Texture tex = m_engine->LoadTexture(TempToPath(PrepareImageFilename(name)), params);
+    Gfx::Texture tex = m_engine->LoadTexture(PrepareImageFilename(TempToPath(name)), params);
 
     m_engine->GetUIRenderer()->SetTexture(tex);
 
@@ -1453,7 +1450,7 @@ void CEdit::FreeImage()
 {
     for (auto& image : m_image)
     {
-        m_engine->DeleteTexture(TempToPath(PrepareImageFilename(image.name)));
+        m_engine->DeleteTexture(PrepareImageFilename(TempToPath(image.name)));
     }
 }
 

--- a/colobot-base/src/ui/controls/edit.cpp
+++ b/colobot-base/src/ui/controls/edit.cpp
@@ -851,7 +851,7 @@ bool CEdit::HyperAdd(const std::filesystem::path& filename, int firstLine)
     if ( m_historyCurrent >= EDITHISTORYMAX-1 )  return false;
 
     m_historyCurrent ++;
-    m_history[m_historyCurrent].filename = TempToString(filename);
+    m_history[m_historyCurrent].filename = filename;
     m_history[m_historyCurrent].firstLine = firstLine;
 
     m_historyTotal = m_historyCurrent+1;
@@ -903,7 +903,7 @@ bool CEdit::HyperGo(EventType event)
         m_historyCurrent ++;
     }
 
-    ReadText(TempToPath(m_history[m_historyCurrent].filename));
+    ReadText(m_history[m_historyCurrent].filename);
     Justif();
     SetFirstLine(m_history[m_historyCurrent].firstLine);
     return true;

--- a/colobot-base/src/ui/controls/edit.h
+++ b/colobot-base/src/ui/controls/edit.h
@@ -69,7 +69,7 @@ enum OperUndo
 struct ImageLine
 {
     //! name of the image (without icons/)
-    std::string    name;
+    std::filesystem::path name;
     //! vertical offset (v texture)
     float   offset = 0.0f;
     //! height of the part (dv texture)

--- a/colobot-base/src/ui/controls/edit.h
+++ b/colobot-base/src/ui/controls/edit.h
@@ -190,7 +190,7 @@ protected:
     void        HyperJump(const std::filesystem::path& name, std::string marker);
     bool        HyperAdd(const std::filesystem::path& filename, int firstLine);
 
-    void        DrawImage(const glm::vec2& pos, std::string name, float width, float offset, float height, int nbLine);
+    void        DrawImage(const glm::vec2& pos, const std::filesystem::path& name, float width, float offset, float height, int nbLine);
     void        DrawBack(const glm::vec2& pos, const glm::vec2& dim);
 
     void        DrawHorizontalGradient(const glm::vec2& pos, const glm::vec2& dim, Gfx::Color color1, Gfx::Color color2);

--- a/colobot-base/src/ui/controls/edit.h
+++ b/colobot-base/src/ui/controls/edit.h
@@ -168,7 +168,7 @@ public:
     bool        Undo();
 
     void        HyperFlush();
-    void        HyperHome(std::string filename);
+    void        HyperHome(const std::filesystem::path& filename);
     bool        HyperTest(EventType event);
     bool        HyperGo(EventType event);
 

--- a/colobot-base/src/ui/controls/edit.h
+++ b/colobot-base/src/ui/controls/edit.h
@@ -81,7 +81,7 @@ struct ImageLine
 struct HyperLink
 {
     //! text file name (without help/)
-    std::string    name;
+    std::filesystem::path name;
     //! name of the marker
     std::string    marker;
 };
@@ -187,8 +187,8 @@ protected:
     int         MouseDetect(const glm::vec2& mouse);
     void        MoveAdjust();
 
-    void        HyperJump(std::string name, std::string marker);
-    bool        HyperAdd(std::string filename, int firstLine);
+    void        HyperJump(const std::filesystem::path& name, std::string marker);
+    bool        HyperAdd(const std::filesystem::path& filename, int firstLine);
 
     void        DrawImage(const glm::vec2& pos, std::string name, float width, float offset, float height, int nbLine);
     void        DrawBack(const glm::vec2& pos, const glm::vec2& dim);

--- a/colobot-base/src/ui/controls/edit.h
+++ b/colobot-base/src/ui/controls/edit.h
@@ -97,7 +97,7 @@ struct HyperMarker
 struct HyperHistory
 {
     //! full file name text
-    std::string    filename;
+    std::filesystem::path filename;
     //! rank of the first displayed line
     int firstLine = 0;
 };

--- a/colobot-base/src/ui/displayinfo.cpp
+++ b/colobot-base/src/ui/displayinfo.cpp
@@ -386,7 +386,7 @@ void CDisplayInfo::StartDisplayInfo(const std::filesystem::path& filename, int i
     edit->SetFontType(Gfx::FONT_SATCOM);
     edit->SetSoluceMode(bSoluce);
     edit->ReadText(filename);
-    edit->HyperHome(StrUtils::ToString(filename));
+    edit->HyperHome(filename);
     edit->SetEditCap(false);  // just to see!
     edit->SetHighlightCap(false);
     m_interface->SetFocus(edit);
@@ -664,9 +664,9 @@ void CDisplayInfo::ChangeIndexButton(int index)
     edit = static_cast<Ui::CEdit*>(pw->SearchControl(EVENT_EDIT1));
     if ( edit != nullptr )
     {
-        const auto& filename = m_main->GetDisplayInfoName(m_index);
+        const std::filesystem::path& filename = m_main->GetDisplayInfoName(m_index);
         edit->ReadText(filename);
-        edit->HyperHome(StrUtils::ToString(filename));
+        edit->HyperHome(filename);
         SetPosition(0);
     }
 

--- a/colobot-base/src/ui/filedialog.cpp
+++ b/colobot-base/src/ui/filedialog.cpp
@@ -895,7 +895,7 @@ bool CFileDialog::ListItemIsFolder()
 
     if (name.find_first_of(".*?:<>\"|/\\") != std::string::npos) return false;
 
-    return DirectoryExists(name);
+    return DirectoryExists(TempToPath(name));
 }
 
 // Updates the list after a change in name.
@@ -948,7 +948,7 @@ void CFileDialog::UpdateAction()
         return;
     }
     std::filesystem::path filename = StrUtils::ToPath(text);
-    if (DirectoryExists(TempToString(filename)))
+    if (DirectoryExists(filename))
     {
         pb->SetState(STATE_ENABLE, false);
         return;
@@ -1000,7 +1000,7 @@ void CFileDialog::UpdateNewFolder()
     if ( !text.empty() )
     {
         if (text.find_first_of(".*?:<>\"|/\\") == std::string::npos)
-            bError = DirectoryExists(text);
+            bError = DirectoryExists(TempToPath(text));
     }
 
     if (bError) GetResource(RES_EVENT, EVENT_DIALOG_CANCEL, text);
@@ -1127,13 +1127,13 @@ std::filesystem::path CFileDialog::SearchDirectory(bool bCreate)
     return dir;
 }
 
-bool CFileDialog::DirectoryExists(const std::string &name)
+bool CFileDialog::DirectoryExists(const std::filesystem::path& name)
 {
     if ( name.empty() ) return false;
 
     if ( name == ".." ) return !m_subDirPath.empty();
 
-    return CResourceManager::DirectoryExists(SearchDirectory(false) / TempToPath(name));
+    return CResourceManager::DirectoryExists(SearchDirectory(false) / name);
 }
 
 // Make folder
@@ -1177,7 +1177,7 @@ void CFileDialog::OpenFolder()
     {
         m_subDirPath = m_subDirPath.parent_path();
     }
-    else if ( DirectoryExists(name) )
+    else if ( DirectoryExists(TempToPath(name)) )
     {
         m_subDirPath /= TempToPath(name);
     }

--- a/colobot-base/src/ui/filedialog.cpp
+++ b/colobot-base/src/ui/filedialog.cpp
@@ -1000,12 +1000,13 @@ void CFileDialog::UpdateNewFolder()
     if ( !text.empty() )
     {
         if (text.find_first_of(".*?:<>\"|/\\") == std::string::npos)
-            bError = DirectoryExists(TempToPath(text));
+            bError = DirectoryExists(StrUtils::ToPath(text));
     }
 
-    if (bError) GetResource(RES_EVENT, EVENT_DIALOG_CANCEL, text);
-    else GetResource(RES_EVENT, EVENT_DIALOG_OK, text);
-    pb->SetName(text);
+    std::string res;
+    if (bError) GetResource(RES_EVENT, EVENT_DIALOG_CANCEL, res);
+    else GetResource(RES_EVENT, EVENT_DIALOG_OK, res);
+    pb->SetName(res);
 }
 
 // Updates the private/public buttons.

--- a/colobot-base/src/ui/filedialog.cpp
+++ b/colobot-base/src/ui/filedialog.cpp
@@ -1246,7 +1246,7 @@ bool CFileDialog::ActionSave(bool checkFileExist)
 
     if ( !CheckFilename(filename) ) // add default extension ?
     {
-        if ( !m_extension.empty() ) filename.replace_extension(m_extension);
+        if ( !m_extension.empty() ) filename += m_extension;
         if ( !CheckFilename(filename) ) return false; // file name is ok ?
     }
 

--- a/colobot-base/src/ui/filedialog.cpp
+++ b/colobot-base/src/ui/filedialog.cpp
@@ -1238,35 +1238,35 @@ bool CFileDialog::ActionSave(bool checkFileExist)
 
     CEdit* pe = static_cast< CEdit* >(pw->SearchControl(EVENT_DIALOG_EDIT));
     if ( pe == nullptr ) return false;
-    std::string filename = pe->GetText(100);
+    std::filesystem::path filename = StrUtils::ToPath(pe->GetText(100));
     if ( filename.empty() ) return false;
 
-    if ( !CheckFilename(filename) ) // add default extension ?
+    if ( !CheckFilename(TempToString(filename)) ) // add default extension ?
     {
-        if ( !m_extension.empty() ) filename += m_extension;
-        if ( !CheckFilename(filename) ) return false; // file name is ok ?
+        if ( !m_extension.empty() ) filename.replace_extension(TempToPath(m_extension));
+        if ( !CheckFilename(TempToString(filename)) ) return false; // file name is ok ?
     }
 
     SearchDirectory(true);
 
     if ( checkFileExist )
     {
-        if (CResourceManager::Exists(SearchDirectory(false) / TempToPath(filename)))
+        if (CResourceManager::Exists(SearchDirectory(false) / filename))
         {
             if ( !StartAskOverwrite(filename) ) StopAskOverwrite();
             return false;
         }
     }
 
-    SetFilename(TempToPath(filename));
-    SetFilenameField(pe, TempToPath(filename));
+    SetFilename(filename);
+    SetFilenameField(pe, filename);
     pe->SetCursor(999, 0);  // select all
     pw->SetFocus(pe);
 
     return true;
 }
 
-bool CFileDialog::StartAskOverwrite(const std::string& name)
+bool CFileDialog::StartAskOverwrite(const std::filesystem::path& name)
 {
     CWindow* pw = static_cast< CWindow* >(m_interface->SearchControl(m_windowEvent)); // dialog window
     if ( pw == nullptr ) return false;
@@ -1311,7 +1311,7 @@ bool CFileDialog::StartAskOverwrite(const std::string& name)
     pla = static_cast< CLabel* >(pw->SearchControl(EVENT_LABEL1));       // filename label
     if ( pla == nullptr ) return false;
     pla->SetState(STATE_VISIBLE | STATE_ENABLE);
-    pla->SetName(name);
+    pla->SetName(StrUtils::ToString(name));
 
     pb = static_cast< CButton* >(pw->SearchControl(EVENT_BUTTON_CANCEL)); // Cancel button
     if ( pb == nullptr ) return false;

--- a/colobot-base/src/ui/filedialog.cpp
+++ b/colobot-base/src/ui/filedialog.cpp
@@ -946,7 +946,7 @@ void CFileDialog::UpdateAction()
             bError = DirectoryExists(text);
 
         if (!bError && !CheckFilename(TempToPath(text)))
-            bError = !CheckFilename(TempToPath(text+m_extension));
+            bError = !CheckFilename(TempToPath(text + TempToString(m_extension)));
     }
 
     pb->SetState(STATE_ENABLE, !bError);
@@ -1194,7 +1194,7 @@ bool CFileDialog::CheckFilename(const std::filesystem::path& name)
 
     if ( !m_extension.empty() ) // default extension?
     {
-        if ( TempToPath(m_extension) == name.extension() ) return true;
+        if ( m_extension == name.extension() ) return true;
     }
     return false;
 }
@@ -1211,7 +1211,7 @@ bool CFileDialog::ActionOpen()
 
     if ( !CheckFilename(TempToPath(filename)) ) // add default extension ?
     {
-        if ( !m_extension.empty() ) filename += m_extension;
+        if ( !m_extension.empty() ) filename += TempToString(m_extension);
         if ( !CheckFilename(TempToPath(filename)) ) return false; // file name is ok ?
     }
 
@@ -1236,7 +1236,7 @@ bool CFileDialog::ActionSave(bool checkFileExist)
 
     if ( !CheckFilename(filename) ) // add default extension ?
     {
-        if ( !m_extension.empty() ) filename.replace_extension(TempToPath(m_extension));
+        if ( !m_extension.empty() ) filename.replace_extension(m_extension);
         if ( !CheckFilename(filename) ) return false; // file name is ok ?
     }
 

--- a/colobot-base/src/ui/filedialog.cpp
+++ b/colobot-base/src/ui/filedialog.cpp
@@ -1145,17 +1145,17 @@ void CFileDialog::CreateNewFolder()
 
     CEdit* pe = static_cast< CEdit* >(pw->SearchControl(EVENT_DIALOG_EDIT2));
     if ( pe == nullptr ) return;
-    std::string name = pe->GetText(999);
+    std::filesystem::path name = StrUtils::ToPath(pe->GetText(999));
     if ( name.empty() ) return;
 
-    m_subDirPath /= TempToPath(name);   // add to current path
+    m_subDirPath /= name;   // add to current path
 
     SearchDirectory(true);  // make the new folder
 
     m_subDirPath = m_subDirPath.parent_path();
 
     PopulateList();         // redraw the list
-    SearchList(name, true); // highlight the new folder in list box
+    SearchList(StrUtils::ToString(name), true); // highlight the new folder in list box
 }
 
 // Open folder

--- a/colobot-base/src/ui/filedialog.cpp
+++ b/colobot-base/src/ui/filedialog.cpp
@@ -1197,9 +1197,9 @@ bool CFileDialog::CheckFilename(const std::filesystem::path& name)
 
     if ( m_extension.empty() && m_extlist.empty() ) return true;      // no required extension?
 
-    for ( std::string ext : m_extlist ) // allowed extensions?
+    for ( const std::filesystem::path& ext : m_extlist ) // allowed extensions?
     {
-        if ( TempToPath(ext) == name.extension() ) return true;
+        if ( ext == name.extension() ) return true;
     }
 
     if ( !m_extension.empty() ) // default extension?

--- a/colobot-base/src/ui/filedialog.h
+++ b/colobot-base/src/ui/filedialog.h
@@ -250,7 +250,7 @@ public:
      * \brief Define extensions that will be accepted as part of a valid file name.
      * \param ext A string with an extension. Ex. ".txt"
      */
-    void        AddOptionalExtension(const std::string& ext) { m_extlist.push_back(ext); }
+    void        AddOptionalExtension(const std::filesystem::path& ext) { m_extlist.push_back(ext); }
 
     /**
      * \brief Set the filename that appears in the edit box when the dialog opens.
@@ -359,7 +359,7 @@ private:
     //! The extension to add to a filename if needed
     std::filesystem::path  m_extension = "";
     //! List of extensions accepted as part of a valid file name
-    std::vector<std::string> m_extlist = {};
+    std::vector<std::filesystem::path> m_extlist = {};
 };
 
 } // namespace Ui

--- a/colobot-base/src/ui/filedialog.h
+++ b/colobot-base/src/ui/filedialog.h
@@ -297,7 +297,7 @@ private:
     void        UpdateSelectFolder();
 
     bool        ListItemIsFolder();
-    bool        DirectoryExists(const std::string &name);
+    bool        DirectoryExists(const std::filesystem::path& name);
 
     bool        CheckFilename(const std::filesystem::path& name);
     bool        ActionOpen();

--- a/colobot-base/src/ui/filedialog.h
+++ b/colobot-base/src/ui/filedialog.h
@@ -303,7 +303,7 @@ private:
     bool        ActionOpen();
     bool        ActionSave(bool checkFileExist = false);
 
-    bool        StartAskOverwrite(const std::string& name);
+    bool        StartAskOverwrite(const std::filesystem::path& name);
     bool        StopAskOverwrite();
     bool        EventAskOverwrite(const Event &event);
 

--- a/colobot-base/src/ui/filedialog.h
+++ b/colobot-base/src/ui/filedialog.h
@@ -244,7 +244,7 @@ public:
      * with those extensions.
      * \param ext A string with an extension. Ex. ".txt"
      */
-    void        SetAutoExtension(const std::string& ext) { m_extension = ext; }
+    void        SetAutoExtension(const std::filesystem::path& ext) { m_extension = ext; }
 
     /**
      * \brief Define extensions that will be accepted as part of a valid file name.
@@ -357,7 +357,7 @@ private:
     std::filesystem::path  m_filename = "";
 
     //! The extension to add to a filename if needed
-    std::string  m_extension = "";
+    std::filesystem::path  m_extension = "";
     //! List of extensions accepted as part of a valid file name
     std::vector<std::string> m_extlist = {};
 };

--- a/colobot-base/src/ui/filedialog.h
+++ b/colobot-base/src/ui/filedialog.h
@@ -299,7 +299,7 @@ private:
     bool        ListItemIsFolder();
     bool        DirectoryExists(const std::string &name);
 
-    bool        CheckFilename(const std::string& name);
+    bool        CheckFilename(const std::filesystem::path& name);
     bool        ActionOpen();
     bool        ActionSave(bool checkFileExist = false);
 

--- a/colobot-base/src/ui/filedialog.h
+++ b/colobot-base/src/ui/filedialog.h
@@ -360,6 +360,10 @@ private:
     std::filesystem::path  m_extension = "";
     //! List of extensions accepted as part of a valid file name
     std::vector<std::filesystem::path> m_extlist = {};
+
+    //! Contents of the dirrectory
+    std::vector<std::filesystem::path> m_entries = {};
+    int m_dirCount = 0;
 };
 
 } // namespace Ui

--- a/colobot-base/src/ui/mainui.cpp
+++ b/colobot-base/src/ui/mainui.cpp
@@ -822,10 +822,10 @@ void CMainUserInterface::UpdateCustomLevelList()
 
 std::filesystem::path CMainUserInterface::GetCustomLevelName(int id)
 {
-    return TempToPath(m_screenLevelList->GetCustomLevelName(id));
+    return m_screenLevelList->GetCustomLevelName(id);
 }
 
-const std::vector<std::string>& CMainUserInterface::GetCustomLevelList()
+const std::vector<std::filesystem::path>& CMainUserInterface::GetCustomLevelList()
 {
     return m_screenLevelList->GetCustomLevelList();
 }

--- a/colobot-base/src/ui/mainui.cpp
+++ b/colobot-base/src/ui/mainui.cpp
@@ -25,7 +25,7 @@
 #include "common/event.h"
 #include "common/logger.h"
 #include "common/settings.h"
-
+#include "common/stringutils.h"
 #include "common/resources/resourcemanager.h"
 
 #include "level/robotmain.h"
@@ -820,9 +820,9 @@ void CMainUserInterface::UpdateCustomLevelList()
     m_screenLevelList->UpdateCustomLevelList();
 }
 
-std::string CMainUserInterface::GetCustomLevelName(int id)
+std::filesystem::path CMainUserInterface::GetCustomLevelName(int id)
 {
-    return m_screenLevelList->GetCustomLevelName(id);
+    return TempToPath(m_screenLevelList->GetCustomLevelName(id));
 }
 
 const std::vector<std::string>& CMainUserInterface::GetCustomLevelList()

--- a/colobot-base/src/ui/mainui.h
+++ b/colobot-base/src/ui/mainui.h
@@ -95,7 +95,7 @@ public:
 
     void    UpdateCustomLevelList();
     std::filesystem::path GetCustomLevelName(int id);
-    const std::vector<std::string>& GetCustomLevelList();
+    const std::vector<std::filesystem::path>& GetCustomLevelList();
 
 protected:
     void    GlintMove();

--- a/colobot-base/src/ui/mainui.h
+++ b/colobot-base/src/ui/mainui.h
@@ -28,6 +28,7 @@
 #include <array>
 #include <string>
 #include <vector>
+#include <filesystem>
 
 
 class CApplication;
@@ -93,7 +94,7 @@ public:
     void    ShowSoluceUpdate();
 
     void    UpdateCustomLevelList();
-    std::string GetCustomLevelName(int id);
+    std::filesystem::path GetCustomLevelName(int id);
     const std::vector<std::string>& GetCustomLevelList();
 
 protected:

--- a/colobot-base/src/ui/screen/screen.cpp
+++ b/colobot-base/src/ui/screen/screen.cpp
@@ -49,9 +49,9 @@ CScreen::~CScreen()
 {
 }
 
-void CScreen::SetBackground(const std::string& filename, bool scaled)
+void CScreen::SetBackground(const std::filesystem::path& filename, bool scaled)
 {
-    m_engine->SetBackground(TempToPath(filename),
+    m_engine->SetBackground(filename,
             Gfx::Color(0.0f, 0.0f, 0.0f, 0.0f),
             Gfx::Color(0.0f, 0.0f, 0.0f, 0.0f),
             Gfx::Color(0.0f, 0.0f, 0.0f, 0.0f),

--- a/colobot-base/src/ui/screen/screen.h
+++ b/colobot-base/src/ui/screen/screen.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <string>
+#include <filesystem>
 
 #include <glm/glm.hpp>
 
@@ -50,7 +51,7 @@ public:
 
 protected:
     void CreateVersionDisplay();
-    void SetBackground(const std::string& filename, bool scaled = false);
+    void SetBackground(const std::filesystem::path& filename, bool scaled = false);
 
 protected:
     CRobotMain* m_main;

--- a/colobot-base/src/ui/screen/screen_io.cpp
+++ b/colobot-base/src/ui/screen/screen_io.cpp
@@ -240,7 +240,7 @@ void CScreenIO::IOWriteScene()
     std::filesystem::path dir;
     if (static_cast<unsigned int>(sel) >= m_saveList.size())
     {
-        dir = m_main->GetPlayerProfile()->GetSaveFile(TempToPath("save" + clearName(info)));
+        dir = m_main->GetPlayerProfile()->GetSaveFile(StrUtils::ToPath("save" + clearName(info)));
     }
     else
     {

--- a/colobot-base/src/ui/screen/screen_level_list.cpp
+++ b/colobot-base/src/ui/screen/screen_level_list.cpp
@@ -672,16 +672,16 @@ void CScreenLevelList::UpdateCustomLevelList()
     m_customLevelList.clear();
 
     for (const auto& path : userLevelDirs)
-        m_customLevelList.push_back(StrUtils::ToString(path));
+        m_customLevelList.push_back(path);
 }
 
-std::string CScreenLevelList::GetCustomLevelName(int id)
+std::filesystem::path CScreenLevelList::GetCustomLevelName(int id)
 {
     if(id < 1 || id > static_cast<int>(m_customLevelList.size())) return "";
     return m_customLevelList[id-1];
 }
 
-const std::vector<std::string>& CScreenLevelList::GetCustomLevelList()
+const std::vector<std::filesystem::path>& CScreenLevelList::GetCustomLevelList()
 {
     return m_customLevelList;
 }

--- a/colobot-base/src/ui/screen/screen_level_list.h
+++ b/colobot-base/src/ui/screen/screen_level_list.h
@@ -25,6 +25,7 @@
 
 #include <map>
 #include <vector>
+#include <filesystem>
 
 namespace Ui
 {
@@ -54,8 +55,8 @@ public:
     void NextMission();
 
     void UpdateCustomLevelList();
-    std::string GetCustomLevelName(int id);
-    const std::vector<std::string>& GetCustomLevelList();
+    std::filesystem::path GetCustomLevelName(int id);
+    const std::vector<std::filesystem::path>& GetCustomLevelList();
 
 protected:
     void UpdateSceneChap(int &chap);
@@ -76,7 +77,7 @@ protected:
     std::map<LevelCategory, int> m_sel;      // chosen mission (0..98)
     int m_maxList;
 
-    std::vector<std::string> m_customLevelList;
+    std::vector<std::filesystem::path> m_customLevelList;
 
     int m_accessChap;
 };

--- a/colobot-base/src/ui/screen/screen_quit.cpp
+++ b/colobot-base/src/ui/screen/screen_quit.cpp
@@ -64,7 +64,7 @@ void CScreenQuit::CreateInterface()
     pe->SetHighlightCap(false);
     pe->SetFontType(Gfx::FONT_STUDIO);
     pe->SetFontSize(Gfx::FONT_SIZE_SMALL);
-    pe->ReadText(TempToPath(std::string("help/") + m_app->GetLanguageChar() + std::string("/authors.txt")));
+    pe->ReadText("help" / m_app->GetLanguageDir() / "authors.txt");
 
     pos.x  =  40.0f/640.0f;
     pos.y  =  83.0f/480.0f;

--- a/colobot-base/src/ui/screen/screen_welcome.cpp
+++ b/colobot-base/src/ui/screen/screen_welcome.cpp
@@ -65,7 +65,7 @@ void CScreenWelcome::CreateInterface()
         m_engine->SetOverColor(Gfx::Color(0.0f, 0.0f, 0.0f, 0.0f), Gfx::TransparencyMode::WHITE);
     m_engine->SetOverFront(true);
 
-    SetBackground("textures/interface/intro"+StrUtils::ToString<int>(m_imageIndex+1)+".png", true);
+    SetBackground(StrUtils::ToPath("textures/interface/intro"+StrUtils::ToString<int>(m_imageIndex+1)+".png"), true);
 }
 
 bool CScreenWelcome::EventProcess(const Event &event)

--- a/colobot-base/src/ui/studio.cpp
+++ b/colobot-base/src/ui/studio.cpp
@@ -143,7 +143,7 @@ bool CStudio::EventProcess(const Event &event)
 
     if ( event.type == EVENT_STUDIO_LIST )  // list clicked?
     {
-        m_main->StartDisplayInfo(TempToPath(m_helpFilename), -1);
+        m_main->StartDisplayInfo(m_helpFilename, -1);
     }
 
     if ( event.type == EVENT_STUDIO_NEW )  // new?
@@ -506,8 +506,8 @@ void CStudio::SearchToken(CEdit* edit)
     }
     token[i] = 0;
 
-    m_helpFilename = TempToString(GetHelpFilename(token.c_str()));
-    if ( m_helpFilename.length() == 0 )
+    m_helpFilename = GetHelpFilename(token.c_str());
+    if ( m_helpFilename.empty() )
     {
         for ( i=0 ; i<OBJECT_MAX ; i++ )
         {
@@ -517,7 +517,7 @@ void CStudio::SearchToken(CEdit* edit)
             {
                 if ( token == text )
                 {
-                    m_helpFilename = TempToString(GetHelpFilename(type));
+                    m_helpFilename = GetHelpFilename(type);
                     SetInfoText(token, true);
                     return;
                 }
@@ -527,7 +527,7 @@ void CStudio::SearchToken(CEdit* edit)
             {
                 if ( token == text )
                 {
-                    m_helpFilename = TempToString(GetHelpFilename(type));
+                    m_helpFilename = GetHelpFilename(type);
                     SetInfoText(token, true);
                     return;
                 }
@@ -536,7 +536,7 @@ void CStudio::SearchToken(CEdit* edit)
     }
 
     text = const_cast<char *>(GetHelpText(token.c_str()));
-    if ( text[0] == 0 && m_helpFilename.length() > 0 )
+    if ( text[0] == 0 && !m_helpFilename.empty() )
     {
         SetInfoText(token, true);
     }

--- a/colobot-base/src/ui/studio.cpp
+++ b/colobot-base/src/ui/studio.cpp
@@ -506,7 +506,7 @@ void CStudio::SearchToken(CEdit* edit)
     }
     token[i] = 0;
 
-    m_helpFilename = GetHelpFilename(token.c_str());
+    m_helpFilename = TempToString(GetHelpFilename(token.c_str()));
     if ( m_helpFilename.length() == 0 )
     {
         for ( i=0 ; i<OBJECT_MAX ; i++ )
@@ -517,7 +517,7 @@ void CStudio::SearchToken(CEdit* edit)
             {
                 if ( token == text )
                 {
-                    m_helpFilename = GetHelpFilename(type);
+                    m_helpFilename = TempToString(GetHelpFilename(type));
                     SetInfoText(token, true);
                     return;
                 }
@@ -527,7 +527,7 @@ void CStudio::SearchToken(CEdit* edit)
             {
                 if ( token == text )
                 {
-                    m_helpFilename = GetHelpFilename(type);
+                    m_helpFilename = TempToString(GetHelpFilename(type));
                     SetInfoText(token, true);
                     return;
                 }

--- a/colobot-base/src/ui/studio.h
+++ b/colobot-base/src/ui/studio.h
@@ -113,7 +113,7 @@ protected:
     bool         m_bRealTime;
     ActivePause* m_editorPause = nullptr;
     ActivePause* m_runningPause = nullptr;
-    std::string  m_helpFilename;
+    std::filesystem::path m_helpFilename;
 
     std::unique_ptr<CFileDialog>  m_fileDialog;
 };


### PR DESCRIPTION
* Continuation from #1747

* **Note: this pull request includes** #1778

## Context

In our codebase std::string usually (always?) uses utf-8. Conversions of std::filesystem::path to/from std::string provided by the C++ standard library assume std::string uses "native narrow encoding". This was causing encoding problems on windows.