### PR TITLE
Do not forget quotes when saving std::filesystem::path

### DIFF
--- a/colobot-base/src/level/parser/parserparam.cpp
+++ b/colobot-base/src/level/parser/parserparam.cpp
@@ -98,7 +98,7 @@ CLevelParserParam::CLevelParserParam(Gfx::CameraType value)
 {}
 
 CLevelParserParam::CLevelParserParam(const std::filesystem::path& value)
-  : m_value(StrUtils::ToString(value))
+  : CLevelParserParam(StrUtils::ToString(value))
 {}
 
 CLevelParserParam::CLevelParserParam(CLevelParserParamVec&& array)


### PR DESCRIPTION
* Fixes #1787

CC: @tomangelo2, @melex750