### PR TITLE
Reenable -Werror in CI

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -54,7 +54,8 @@
             "inherits": ["Linux-CI-base"],
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++"
+                "CMAKE_CXX_COMPILER": "g++",
+                "CMAKE_CXX_FLAGS": "-Werror"
             }
         },
         {

--- a/colobot-base/src/graphics/engine/particle.cpp
+++ b/colobot-base/src/graphics/engine/particle.cpp
@@ -143,7 +143,7 @@ void CParticle::FlushParticle(int sheet)
 
 
 //! Returns file name of the effect effectNN.png, with NN = number
-std::filesystem::path NameParticle(int num)
+static std::filesystem::path NameParticle(int num)
 {
     switch(num)
     {

--- a/colobot-common/src/common/stringutils.cpp
+++ b/colobot-common/src/common/stringutils.cpp
@@ -305,8 +305,10 @@ int StrUtils::UTF8CharLength(std::string_view string)
 
     int len = UTF8SequenceLength(static_cast<char8_t>(string.front()));
 
+    if (len < 0) return 0;
+
     // UTF-8 sequence is not long enough
-    if (string.size() < len) return 0;
+    if (string.size() < static_cast<size_t>(len)) return 0;
 
     // Check continuation bytes
     for (int i = 1; i < len; i++)
@@ -324,10 +326,10 @@ int StrUtils::UTF8StringLength(std::string_view string)
     {
         auto count = UTF8SequenceLength(static_cast<char8_t>(string.front()));
 
-        if (count == 0)
+        if (count <= 0)
             throw std::invalid_argument("Invalid character");
         
-        if (string.size() < count)
+        if (string.size() < static_cast<size_t>(count))
             throw std::invalid_argument("Invalid character");
         
         for (int i = 1; i < count; i++)


### PR DESCRIPTION
For now - only for gcc because there are still some clang warnings we did not tackle