### PR TITLE
Fix SatCom links

### DIFF
--- a/colobot-base/src/ui/controls/edit.cpp
+++ b/colobot-base/src/ui/controls/edit.cpp
@@ -48,6 +48,7 @@
 #include <SDL.h>
 
 #include <cstring>
+#include <regex>
 
 namespace Ui
 {
@@ -1613,7 +1614,9 @@ bool CEdit::ReadText(const std::filesystem::path& filename)
             if ( m_bSoluce || !bInSoluce )
             {
                 HyperLink link;
-                link.name = StrUtils::ToPath(GetNameParam(buffer.data()+i+3, 0));
+                std::string name = GetNameParam(buffer.data()+i+3, 0);
+                name = std::regex_replace(name, std::regex("\\\\"), "/");  //TODO: Fix this in files
+                link.name = StrUtils::ToPath(name);
                 link.marker = GetNameParam(buffer.data()+i+3, 1);
                 m_link.push_back(link);
                 font &= ~Gfx::FONT_MASK_LINK;


### PR DESCRIPTION
https://github.com/colobot/colobot/pull/1781#discussion_r1862505888

> This line from log seems to show backslash as part of the filename:
> 
> > [ERROR]: Failed to load text file help/E/cbot\radarall.txt

> Found it. I removed this line:
> 
> https://github.com/colobot/colobot/blob/84ac0d3ba8bc7c590da0b999f132f765f6d56ed1/src/ui/controls/edit.cpp#L819
> 
> Will fix soon

CC @melex750 