### PR TITLE
The macOS-12 environment is deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         target_os: [macos]
-        host_os: [macos-12, macos-13]
+        host_os: [macos-13, macos-14]
         container: ['']
       fail-fast: false
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         target_os: [macos]
-        host_os: [macos-13, macos-14]
+        host_os: [macos-13]
         container: ['']
       fail-fast: false
     steps:


### PR DESCRIPTION
> The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15. For more details, see https://github.com/actions/runner-images/issues/10721