### PR TITLE
Tests: print stack trace from exceptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,14 @@ if(TESTS)
     # Hippomocks library
     add_subdirectory(${colobot_SOURCE_DIR}/lib/hippomocks)
 
+    include(FetchContent)
+    FetchContent_Declare(
+      cpptrace
+      GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
+      GIT_TAG        v0.7.3 # <HASH or TAG>
+    )
+    FetchContent_MakeAvailable(cpptrace)
+
     # Tests targets
     enable_testing()
     include(GoogleTest)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,7 +41,19 @@ target_link_libraries(Colobot-UnitTests PRIVATE
     GTest::GTest
     hippomocks
     Colobot-Base
+    cpptrace::cpptrace
 )
+
+# Needed for shared library builds on windows:  copy cpptrace.dll to the same directory as the
+# executable for your_target
+if(WIN32)
+  add_custom_command(
+    TARGET Colobot-UnitTests POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    $<TARGET_FILE:cpptrace::cpptrace>
+    $<TARGET_FILE_DIR:Colobot-UnitTests>
+  )
+endif()
 
 gtest_discover_tests(Colobot-UnitTests
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -20,8 +20,17 @@
 #include "common/logger.h"
 
 #include <gtest/gtest.h>
+#include <cpptrace/from_current.hpp>
 
 #include <clocale>
+
+// For compatibility with gtest < 1.12.0
+#ifndef GTEST_FLAG_GET
+#define GTEST_FLAG_GET(name) ::testing::GTEST_FLAG(name)
+#endif
+#ifndef GTEST_FLAG_SET
+#define GTEST_FLAG_SET(name, value) (void)(::testing::GTEST_FLAG(name) = value)
+#endif
 
 extern bool g_cbotTestSaveState;
 
@@ -41,5 +50,27 @@ int main(int argc, char* argv[])
             g_cbotTestSaveState = true;
     }
 
-    return RUN_ALL_TESTS();
+    if (!GTEST_FLAG_GET(catch_exceptions))
+    {
+        // Pass the exception through to the debugger
+        return RUN_ALL_TESTS();
+    }
+
+    GTEST_FLAG_SET(catch_exceptions, false);
+    CPPTRACE_TRY
+    {
+        return RUN_ALL_TESTS();
+    }
+    CPPTRACE_CATCH(const std::exception& e)
+    {
+        cpptrace::from_current_exception().print(std::cout);
+        std::cout << "Exception: " << e.what() << std::endl;
+        throw;
+    }
+    CPPTRACE_CATCH_ALT(...)
+    {
+        cpptrace::from_current_exception().print(std::cout);
+        std::cout << "Not std::exception" << std::endl;
+        throw;
+    }
 }


### PR DESCRIPTION
Sometimes our tests throw exceptions. This is easy to debug when the error can be reproduced locally, but I recently had to debug an issue that I could only reproduce in CI on macos-14. It turns out that gtest can't print the stack trace when it catches an exception. Figuring out what code throws and why without a stack trace turned out to be impossible.

I am adding a workaround to make similar issues easier to debug in the future:
1. Tell gtest to not catch exceptions
2. Wrap cpptrace around RUN_ALL_TESTS() to capture and print the stack trace as well as the error message