### PR TITLE
Make limit particles unaffected by the wind

### DIFF
--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -4245,7 +4245,7 @@ void CRobotMain::SetShowLimit(int i, Gfx::ParticleType parti, CObject *obj,
 
     for (int j = 0; j < m_showLimit[i].total; j++)
     {
-        m_showLimit[i].parti[j] = m_particle->CreateParticle(pos, glm::vec3(0.0f, 0.0f, 0.0f), dim, parti, duration);
+        m_showLimit[i].parti[j] = m_particle->CreateParticle(pos, glm::vec3(0.0f, 0.0f, 0.0f), dim, parti, duration, /* mass */ 0.0f, /* windSensitivity */ 0.0f);
     }
 }
 


### PR DESCRIPTION
* Fixes https://github.com/colobot/colobot/issues/684

Titanium build zone particles, tower range particles and power captor range particles should now be unaffected by wind