### PR TITLE
Fix race condition in worker_thread.h

### DIFF
--- a/colobot-base/src/common/thread/worker_thread.h
+++ b/colobot-base/src/common/thread/worker_thread.h
@@ -73,9 +73,9 @@ private:
         }
     }
 
-    std::thread m_thread;
     std::mutex m_mutex;
     std::condition_variable m_cond;
     bool m_running = true;
     std::queue<ThreadFunctionPtr> m_queue;
+    std::thread m_thread;
 };


### PR DESCRIPTION
The fields of CWorkerThread that are used in `Run()` have to be constructed before the constructor of std::thread is called to prevent a race condition.