### PR TITLE
Fix default fullscreen

### DIFF
--- a/colobot-base/src/app/app.cpp
+++ b/colobot-base/src/app/app.cpp
@@ -563,7 +563,6 @@ bool CApplication::Create()
     if (!m_headless)
     {
         // load settings from profile
-        int iValue;
         std::string sValue;
 
         // GetVideoResolutionList() has to be called here because it is responsible
@@ -593,9 +592,9 @@ bool CApplication::Create()
             }
         }
 
-        if ( GetConfigFile().GetIntProperty("Setup", "Fullscreen", iValue) && !m_resolutionOverride )
+        if ( !m_resolutionOverride )
         {
-            m_deviceConfig->fullScreen = (iValue == 1);
+            GetConfigFile().GetBoolProperty("Setup", "Fullscreen", m_deviceConfig->fullScreen);
         }
 
         if (! CreateVideoSurface())
@@ -870,12 +869,15 @@ void CApplication::TryToSetVSync()
     }
 }
 
-bool CApplication::ChangeVideoConfig(const Gfx::DeviceConfig &newConfig)
+bool CApplication::ChangeVideoConfig(const Gfx::DeviceConfig &newConfig, bool isSetSize)
 {
     *m_deviceConfig = newConfig;
 
-    // TODO: Somehow this doesn't work for maximized windows (at least on Ubuntu)
-    SDL_SetWindowSize(m_private->window, m_deviceConfig->size.x, m_deviceConfig->size.y);
+    if ( isSetSize ) {
+        // TODO: Somehow this doesn't work for maximized windows (at least on Ubuntu)
+        // It appears that "doesn't work" means "is a no-op"
+        SDL_SetWindowSize(m_private->window, m_deviceConfig->size.x, m_deviceConfig->size.y);
+    }
     SDL_SetWindowFullscreen(m_private->window, m_deviceConfig->fullScreen ? SDL_WINDOW_FULLSCREEN : 0);
 
     TryToSetVSync();
@@ -1214,7 +1216,7 @@ Event CApplication::ProcessSystemEvent()
             newConfig.size.x = m_private->currentEvent.window.data1;
             newConfig.size.y = m_private->currentEvent.window.data2;
             if (newConfig.size != m_deviceConfig->size)
-                ChangeVideoConfig(newConfig);
+                ChangeVideoConfig(newConfig, /* isSetSize */ false);
         }
 
         if (m_private->currentEvent.window.event == SDL_WINDOWEVENT_ENTER)

--- a/colobot-base/src/app/app.h
+++ b/colobot-base/src/app/app.h
@@ -189,7 +189,7 @@ public:
     const Gfx::DeviceConfig& GetVideoConfig() const;
 
     //! Change the video mode to given mode
-    bool        ChangeVideoConfig(const Gfx::DeviceConfig &newConfig);
+    bool        ChangeVideoConfig(const Gfx::DeviceConfig &newConfig, bool isSetSize);
 
     //! Suspends animation (time will not be updated)
     void        SuspendSimulation();

--- a/colobot-base/src/ui/screen/screen_setup_display.cpp
+++ b/colobot-base/src/ui/screen/screen_setup_display.cpp
@@ -281,7 +281,7 @@ void CScreenSetupDisplay::ChangeDisplay()
 
     m_settings->SaveResolutionSettings(config);
 
-    m_app->ChangeVideoConfig(config);
+    m_app->ChangeVideoConfig(config, /* isSetSize */ true);
 }
 
 


### PR DESCRIPTION
* Fix https://github.com/colobot/colobot/issues/1724

1. .Setup.Fullscreen is a bool property. Trying to get it as an int resulted in colobot thinking that the property is not set:
   https://github.com/colobot/colobot/blob/8a40853234a054a73753a3afe7e80ff2e209f43f/colobot-base/src/common/config_file.cpp#L158
1. The game used to call `SDL_SetWindowSize()` every time it got the `SDL_WINDOWEVENT_SIZE_CHANGED` event. Somehow this created an infinite feedback loop, where the game flips back and forth between two different resolutions, making the game freeze before it even displays the main menu. For some reason on master with -graphics gl14 (the default) the infinite feedback loop either does not happen or does not break the game. For some reason enabling fullscreen once the menu is shown also does not break the game, but starting the game in fullscreen does break it :shrug: