### PR TITLE
Unhide UI when typing cheat

### DIFF
--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -809,6 +809,7 @@ bool CRobotMain::ProcessEvent(Event &event)
                 if (m_phase == PHASE_SIMUL) m_cmdEditPause = m_pause->ActivatePause(PAUSE_ENGINE);
                 m_cmdEdit = true;
                 m_commandHistoryIndex = -1; // no element selected in command history
+                m_engine->SetRenderInterface(true);
             }
             return false;
         }


### PR DESCRIPTION
* fix https://github.com/colobot/colobot/issues/1012

It's hard to type cheats when the UI is hidden. The simplest solution I could think of: activating cheat console ends the effect of `invui`