### PR TITLE
Fix initial text in CBOT editor save dialog

### DIFF
--- a/colobot-base/src/ui/studio.cpp
+++ b/colobot-base/src/ui/studio.cpp
@@ -1020,7 +1020,7 @@ void CStudio::StartDialog(const Event &event)
             {
                 m_fileDialog->SetSubFolderPath(filename.parent_path());
             }
-            m_fileDialog->SetFilename(filename);
+            m_fileDialog->SetFilename(filename.filename());
         }
 
         m_fileDialog->StartDialog();


### PR DESCRIPTION
Specifically, after load then save, or save twice a file in a sub-folder.