### PR TITLE
Fix loadig of the first `object`

### DIFF
--- a/colobot-base/src/object/object_manager.cpp
+++ b/colobot-base/src/object/object_manager.cpp
@@ -45,7 +45,7 @@ CObjectManager::CObjectManager(Gfx::CEngine* engine,
                                                oldModelManager,
                                                modelManager,
                                                particle)),
-    m_nextId(0),
+    m_nextId(1),
     m_activeObjectIterators(0),
     m_shouldCleanRemovedObjects(false)
 {
@@ -108,7 +108,7 @@ void CObjectManager::DeleteAllObjects()
 
     m_objects.clear();
 
-    m_nextId = 0;
+    m_nextId = 1;
 }
 
 CObject* CObjectManager::GetObjectById(int id)


### PR DESCRIPTION
* fix #1696

CreateObject ids used to start with 0. Because of this CBot values of type `object` referring to the first CreateObject in the scene used to not load correctly.

Solution: start numbering the objects from 1 instead.