### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,7 @@ jobs:
       uses: lukka/run-vcpkg@v7
       with:
         setupOnly: true
-        vcpkgGitCommitId: 'f6a5d4e8eb7476b8d7fc12a56dff300c1c986131'
+        vcpkgGitCommitId: 'b322364f06308bdd24823f9d8f03fe0cc86fd46f'
         vcpkgTriplet: ${{ matrix.vcpkg_triplet }}
         # SHA-256 hash of the vcpkg.json file, recalculated automatically when it changes
         appendedCacheKey: ${{ hashFiles( '**/vcpkg.json' ) }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,7 +30,8 @@
                 "PORTABLE": true,
                 "TOOLS": true,
                 "TESTS": true,
-                "DESKTOP": true
+                "DESKTOP": true,
+                "CMAKE_MAKE_PROGRAM": "ninja.exe"
             }
         },
         {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
     "name": "colobot",
     "version-string": "0.1.0",
-    "builtin-baseline": "f6a5d4e8eb7476b8d7fc12a56dff300c1c986131",
+    "builtin-baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f",
     "dependencies": [
         {
             "name": "freetype",
@@ -42,6 +42,12 @@
         },
         {
             "name": "physfs", "version": "3.0.2"
+        },
+        {
+            "name": "brotli", "version": "1.0.9"
+        },
+        {
+            "name": "openal-soft", "version": "1.23.0"
         }
     ]
 }


### PR DESCRIPTION
I pinned the version of brotli due to this error:
```
CMake Warning at CMakeLists.txt:318 (message):
  Data directory is not available; make sure colobot-data is installed in
  D:/a/colobot/colobot/install/data.


-- Configuring done (961.2s)
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
BROTLICOMMON_LIBRARY
    linked by target "Colobot-Base" in directory D:/a/colobot/colobot/colobot-base
BROTLIDEC_LIBRARY
    linked by target "Colobot-Base" in directory D:/a/colobot/colobot/colobot-base
BROTLIENC_LIBRARY
    linked by target "Colobot-Base" in directory D:/a/colobot/colobot/colobot-base

CMake Generate step failed.  Build files cannot be regenerated correctly.
-- Generating done (0.2s)
Error: Process completed with exit code 1.
```

I pinned the version of openal-soft due to this error:
```
[298/316] Linking CXX executable colobot.exe
FAILED: colobot.exe 
C:\Windows\system32\cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_exe --msvc-ver=1929 --intdir=colobot-app\CMakeFiles\colobot.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~2\MICROS~2\2019\ENTERP~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\link.exe /nologo colobot-app\CMakeFiles\colobot.dir\src\main.cpp.obj colobot-app\CMakeFiles\colobot.dir\__\desktop\colobot.rc.res  /out:colobot.exe /implib:colobot-app\colobot.lib /pdb:colobot.pdb /version:0.0 /machine:x64 /debug /INCREMENTAL /subsystem:console  /STACK:8388608  colobot-base\Colobot-Base.lib  CBot\CBot.lib  colobot-common\Colobot-Common.lib  lib\localename\localename.lib  vcpkg_installed\x64-windows-static\lib\SDL2_image-static.lib  vcpkg_installed\x64-windows-static\lib\SDL2_ttf.lib  opengl32.lib  vcpkg_installed\x64-windows-static\lib\libpng16.lib  vcpkg_installed\x64-windows-static\lib\zlib.lib  vcpkg_installed\x64-windows-static\lib\glew32.lib  opengl32.lib  glu32.lib  vcpkg_installed\x64-windows-static\lib\glm.lib  vcpkg_installed\x64-windows-static\lib\physfs-static.lib  vcpkg_installed\x64-windows-static\lib\sndfile.lib  vcpkg_installed\x64-windows-static\lib\opus.lib  vcpkg_installed\x64-windows-static\lib\FLAC.lib  vcpkg_installed\x64-windows-static\lib\vorbisenc.lib  vcpkg_installed\x64-windows-static\lib\vorbis.lib  vcpkg_installed\x64-windows-static\lib\ogg.lib  vcpkg_installed\x64-windows-static\lib\intl.lib  vcpkg_installed\x64-windows-static\lib\OpenAL32.lib  lib\wingetopt\wingetopt.lib  Dbghelp.lib  vcpkg_installed\x64-windows-static\lib\bz2.lib  vcpkg_installed\x64-windows-static\lib\freetype.lib  vcpkg_installed\x64-windows-static\lib\iconv.lib  vcpkg_installed\x64-windows-static\lib\charset.lib  vcpkg_installed\x64-windows-static\lib\brotlicommon-static.lib  vcpkg_installed\x64-windows-static\lib\brotlienc-static.lib  vcpkg_installed\x64-windows-static\lib\brotlidec-static.lib  winmm.lib  dxguid.lib  imm32.lib  ole32.lib  oleaut32.lib  version.lib  wsock32.lib  ws2_32.lib  setupapi.lib  vcpkg_installed\x64-windows-static\lib\manual-link\SDL2main.lib  vcpkg_installed\x64-windows-static\lib\SDL2-static.lib  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && C:\Windows\system32\cmd.exe /C "cd /D D:\a\colobot\colobot\build\colobot-app && "C:\Program Files\PowerShell\7\pwsh.exe" -noprofile -executionpolicy Bypass -file D:/a/colobot/colobot/vcpkg/scripts/buildsystems/msbuild/applocal.ps1 -targetBinary D:/a/colobot/colobot/build/colobot.exe -installedDir D:/a/colobot/colobot/build/vcpkg_installed/x64-windows-static/bin -OutVariable out""
LINK Pass 1: command "C:\PROGRA~2\MICROS~2\2019\ENTERP~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\link.exe /nologo colobot-app\CMakeFiles\colobot.dir\src\main.cpp.obj colobot-app\CMakeFiles\colobot.dir\__\desktop\colobot.rc.res /out:colobot.exe /implib:colobot-app\colobot.lib /pdb:colobot.pdb /version:0.0 /machine:x64 /debug /INCREMENTAL /subsystem:console /STACK:8388608 colobot-base\Colobot-Base.lib CBot\CBot.lib colobot-common\Colobot-Common.lib lib\localename\localename.lib vcpkg_installed\x64-windows-static\lib\SDL2_image-static.lib vcpkg_installed\x64-windows-static\lib\SDL2_ttf.lib opengl32.lib vcpkg_installed\x64-windows-static\lib\libpng16.lib vcpkg_installed\x64-windows-static\lib\zlib.lib vcpkg_installed\x64-windows-static\lib\glew32.lib opengl32.lib glu32.lib vcpkg_installed\x64-windows-static\lib\glm.lib vcpkg_installed\x64-windows-static\lib\physfs-static.lib vcpkg_installed\x64-windows-static\lib\sndfile.lib vcpkg_installed\x64-windows-static\lib\opus.lib vcpkg_installed\x64-windows-static\lib\FLAC.lib vcpkg_installed\x64-windows-static\lib\vorbisenc.lib vcpkg_installed\x64-windows-static\lib\vorbis.lib vcpkg_installed\x64-windows-static\lib\ogg.lib vcpkg_installed\x64-windows-static\lib\intl.lib vcpkg_installed\x64-windows-static\lib\OpenAL32.lib lib\wingetopt\wingetopt.lib Dbghelp.lib vcpkg_installed\x64-windows-static\lib\bz2.lib vcpkg_installed\x64-windows-static\lib\freetype.lib vcpkg_installed\x64-windows-static\lib\iconv.lib vcpkg_installed\x64-windows-static\lib\charset.lib vcpkg_installed\x64-windows-static\lib\brotlicommon-static.lib vcpkg_installed\x64-windows-static\lib\brotlienc-static.lib vcpkg_installed\x64-windows-static\lib\brotlidec-static.lib winmm.lib dxguid.lib imm32.lib ole32.lib oleaut32.lib version.lib wsock32.lib ws2_32.lib setupapi.lib vcpkg_installed\x64-windows-static\lib\manual-link\SDL2main.lib vcpkg_installed\x64-windows-static\lib\SDL2-static.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:colobot-app\CMakeFiles\colobot.dir/intermediate.manifest colobot-app\CMakeFiles\colobot.dir/manifest.res" failed (exit code 1120) with the following output:
   Creating library colobot-app\colobot.lib and object colobot-app\colobot.exp
OpenAL32.lib(wasapi.cpp.obj) : error LNK2019: unresolved external symbol __imp_AvSetMmThreadCharacteristicsW referenced in function "public: int __cdecl `anonymous namespace'::WasapiPlayback::mixerProc(void)" (?mixerProc@WasapiPlayback@?A0x28a696ab@@QEAAHXZ)
OpenAL32.lib(wasapi.cpp.obj) : error LNK2019: unresolved external symbol __imp_AvRevertMmThreadCharacteristics referenced in function "public: __cdecl std::unique_ptr<void,struct `anonymous namespace'::AvrtHandleCloser>::~unique_ptr<void,struct `anonymous namespace'::AvrtHandleCloser>(void)" (??1?$unique_ptr@XUAvrtHandleCloser@?A0x28a696ab@@@std@@QEAA@XZ)

colobot.exe : fatal error LNK1120: 2 unresolved externals

[299/316] Linking CXX executable CBot-Console.exe
FAILED: CBot-Console.exe 
C:\Windows\system32\cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_exe --msvc-ver=1929 --intdir=tools\cbot-console\CMakeFiles\CBot-Console.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~2\MICROS~2\2019\ENTERP~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\link.exe /nologo tools\cbot-console\CMakeFiles\CBot-Console.dir\src\console.cpp.obj  /out:CBot-Console.exe /implib:tools\cbot-console\CBot-Console.lib /pdb:CBot-Console.pdb /version:0.0 /machine:x64 /debug /INCREMENTAL /subsystem:console  /STACK:8388608 -LIBPATH:D:\a\colobot\colobot\tools\cbot-console   -LIBPATH:D:\a\colobot\colobot\build\tools\cbot-console CBot\CBot.lib  colobot-base\Colobot-Base.lib  CBot\CBot.lib  colobot-common\Colobot-Common.lib  lib\localename\localename.lib  vcpkg_installed\x64-windows-static\lib\SDL2_image-static.lib  vcpkg_installed\x64-windows-static\lib\SDL2_ttf.lib  vcpkg_installed\x64-windows-static\lib\SDL2-static.lib  opengl32.lib  vcpkg_installed\x64-windows-static\lib\libpng16.lib  vcpkg_installed\x64-windows-static\lib\zlib.lib  vcpkg_installed\x64-windows-static\lib\glew32.lib  opengl32.lib  glu32.lib  vcpkg_installed\x64-windows-static\lib\glm.lib  vcpkg_installed\x64-windows-static\lib\physfs-static.lib  vcpkg_installed\x64-windows-static\lib\sndfile.lib  vcpkg_installed\x64-windows-static\lib\opus.lib  vcpkg_installed\x64-windows-static\lib\FLAC.lib  vcpkg_installed\x64-windows-static\lib\vorbisenc.lib  vcpkg_installed\x64-windows-static\lib\vorbis.lib  vcpkg_installed\x64-windows-static\lib\ogg.lib  vcpkg_installed\x64-windows-static\lib\intl.lib  vcpkg_installed\x64-windows-static\lib\OpenAL32.lib  lib\wingetopt\wingetopt.lib  Dbghelp.lib  vcpkg_installed\x64-windows-static\lib\bz2.lib  vcpkg_installed\x64-windows-static\lib\freetype.lib  vcpkg_installed\x64-windows-static\lib\iconv.lib  vcpkg_installed\x64-windows-static\lib\charset.lib  vcpkg_installed\x64-windows-static\lib\brotlicommon-static.lib  vcpkg_installed\x64-windows-static\lib\brotlienc-static.lib  vcpkg_installed\x64-windows-static\lib\brotlidec-static.lib  winmm.lib  dxguid.lib  imm32.lib  ole32.lib  oleaut32.lib  version.lib  wsock32.lib  ws2_32.lib  setupapi.lib  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && C:\Windows\system32\cmd.exe /C "cd /D D:\a\colobot\colobot\build\tools\cbot-console && "C:\Program Files\PowerShell\7\pwsh.exe" -noprofile -executionpolicy Bypass -file D:/a/colobot/colobot/vcpkg/scripts/buildsystems/msbuild/applocal.ps1 -targetBinary D:/a/colobot/colobot/build/CBot-Console.exe -installedDir D:/a/colobot/colobot/build/vcpkg_installed/x64-windows-static/bin -OutVariable out""
LINK Pass 1: command "C:\PROGRA~2\MICROS~2\2019\ENTERP~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\link.exe /nologo tools\cbot-console\CMakeFiles\CBot-Console.dir\src\console.cpp.obj /out:CBot-Console.exe /implib:tools\cbot-console\CBot-Console.lib /pdb:CBot-Console.pdb /version:0.0 /machine:x64 /debug /INCREMENTAL /subsystem:console /STACK:8388608 -LIBPATH:D:\a\colobot\colobot\tools\cbot-console -LIBPATH:D:\a\colobot\colobot\build\tools\cbot-console CBot\CBot.lib colobot-base\Colobot-Base.lib CBot\CBot.lib colobot-common\Colobot-Common.lib lib\localename\localename.lib vcpkg_installed\x64-windows-static\lib\SDL2_image-static.lib vcpkg_installed\x64-windows-static\lib\SDL2_ttf.lib vcpkg_installed\x64-windows-static\lib\SDL2-static.lib opengl32.lib vcpkg_installed\x64-windows-static\lib\libpng16.lib vcpkg_installed\x64-windows-static\lib\zlib.lib vcpkg_installed\x64-windows-static\lib\glew32.lib opengl32.lib glu32.lib vcpkg_installed\x64-windows-static\lib\glm.lib vcpkg_installed\x64-windows-static\lib\physfs-static.lib vcpkg_installed\x64-windows-static\lib\sndfile.lib vcpkg_installed\x64-windows-static\lib\opus.lib vcpkg_installed\x64-windows-static\lib\FLAC.lib vcpkg_installed\x64-windows-static\lib\vorbisenc.lib vcpkg_installed\x64-windows-static\lib\vorbis.lib vcpkg_installed\x64-windows-static\lib\ogg.lib vcpkg_installed\x64-windows-static\lib\intl.lib vcpkg_installed\x64-windows-static\lib\OpenAL32.lib lib\wingetopt\wingetopt.lib Dbghelp.lib vcpkg_installed\x64-windows-static\lib\bz2.lib vcpkg_installed\x64-windows-static\lib\freetype.lib vcpkg_installed\x64-windows-static\lib\iconv.lib vcpkg_installed\x64-windows-static\lib\charset.lib vcpkg_installed\x64-windows-static\lib\brotlicommon-static.lib vcpkg_installed\x64-windows-static\lib\brotlienc-static.lib vcpkg_installed\x64-windows-static\lib\brotlidec-static.lib winmm.lib dxguid.lib imm32.lib ole32.lib oleaut32.lib version.lib wsock32.lib ws2_32.lib setupapi.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:tools\cbot-console\CMakeFiles\CBot-Console.dir/intermediate.manifest tools\cbot-console\CMakeFiles\CBot-Console.dir/manifest.res" failed (exit code 1120) with the following output:
   Creating library tools\cbot-console\CBot-Console.lib and object tools\cbot-console\CBot-Console.exp
OpenAL32.lib(wasapi.cpp.obj) : error LNK2019: unresolved external symbol __imp_AvSetMmThreadCharacteristicsW referenced in function "public: int __cdecl `anonymous namespace'::WasapiPlayback::mixerProc(void)" (?mixerProc@WasapiPlayback@?A0x28a696ab@@QEAAHXZ)

OpenAL32.lib(wasapi.cpp.obj) : error LNK2019: unresolved external symbol __imp_AvRevertMmThreadCharacteristics referenced in function "public: __cdecl std::unique_ptr<void,struct `anonymous namespace'::AvrtHandleCloser>::~unique_ptr<void,struct `anonymous namespace'::AvrtHandleCloser>(void)" (??1?$unique_ptr@XUAvrtHandleCloser@?A0x28a696ab@@@std@@QEAA@XZ)

CBot-Console.exe : fatal error LNK1120: 2 unresolved externals

[300/316] Building CXX object lib\googletest\googletest\CMakeFiles\gtest.dir\src\gtest-all.cc.obj
[301/316] Linking CXX executable CBot-CompileGraph.exe
ninja: build stopped: subcommand failed.
Error: Process completed with exit code 1.
```