### PR TITLE
Fix SecondTexture

### DIFF
--- a/colobot-base/src/graphics/engine/engine.cpp
+++ b/colobot-base/src/graphics/engine/engine.cpp
@@ -1990,15 +1990,24 @@ bool CEngine::LoadAllTextures()
                     ok = false;
             }
 
-            if (!data.material.detailTexture.empty())
+            const std::filesystem::path& detailTexture = data.material.variableDetail ? GetSecondTexture() : data.material.detailTexture;
+            if (!detailTexture.empty())
             {
                 if (terrain)
-                    data.detailTexture = LoadTexture(data.material.detailTexture, m_terrainTexParams);
+                {
+                    data.detailTexture = LoadTexture(detailTexture, m_terrainTexParams);
+                }
                 else
-                    data.detailTexture = LoadTexture(data.material.detailTexture);
+                {
+                    data.detailTexture = LoadTexture(detailTexture);
+                }
 
                 if (!data.detailTexture.Valid())
                     ok = false;
+            }
+            else
+            {
+                data.detailTexture = Texture();
             }
 
             if (!data.material.materialTexture.empty())
@@ -4755,9 +4764,6 @@ void CEngine::AddBaseObjTriangles(int baseObjRank, const std::vector<Gfx::ModelT
 
         if (!material.emissiveTexture.empty())
             material.emissiveTexture = "objects" / material.emissiveTexture;
-
-        if (material.variableDetail)
-            material.detailTexture = GetSecondTexture();
 
         EngineBaseObjDataTier& data = AddLevel(p1, EngineTriangleType::TRIANGLES, material);
 


### PR DESCRIPTION
CEngine::AddBaseObjTriangles() modifies a cached version of a model. It is only executed once for each model. CEngine::LoadAllTextures() is guaranteed to be executed when starting, restarting or loading a level.

I have tested the code. The pull request fixes both of the below bugs:

* fix https://github.com/colobot/colobot/issues/847
* fix https://github.com/colobot/colobot/issues/776