### PR TITLE
Do not define main() as extern "C"

### DIFF
--- a/colobot-app/src/main.cpp
+++ b/colobot-app/src/main.cpp
@@ -94,10 +94,14 @@ The current layout is the following:
  - src/script - link with the CBot library
 */
 
-//! Entry point to the program
+// On *some* platforms, SDL declares a macro which renames main to SDL_main.
+// If that's the case, use "extern C" to prevent name mangling.
+#ifdef main
 extern "C"
 {
+#endif
 
+//! Entry point to the program
 int main(int argc, char *argv[])
 {
     CLogger logger; // single instance of logger
@@ -176,4 +180,6 @@ int main(int argc, char *argv[])
     return code;
 }
 
+#ifdef main
 } // extern "C"
+#endif


### PR DESCRIPTION
gcc15 disallows this when building with `-Wpedantic`.
```
error: cannot declare ‘::main’ with a linkage specification [-Wpedantic]
```