### PR TITLE
Fix the square smoke particles

### DIFF
--- a/colobot-base/src/graphics/engine/particle.cpp
+++ b/colobot-base/src/graphics/engine/particle.cpp
@@ -3472,7 +3472,18 @@ void CParticle::DrawParticle(int sheet)
 
             m_renderer->SetTransparency(mode);
             m_renderer->SetColor(IntensityToColor(m_particle[i].intensity));
+            if (t == 4)
+            {
+                Color color1 = IntensityToColor(1.0f);
+                Color color2 = IntensityToColor(m_particle[i].intensity);
 
+                float r = std::min(color1.r + color2.r, 1.0f);
+                float g = std::min(color1.g + color2.g, 1.0f);
+                float b = std::min(color1.b + color2.b, 1.0f);
+                
+                Color blendedColor(r, g, b);
+                m_renderer->SetColor(blendedColor);
+            }
             if (m_particle[i].ray)  // ray?
             {
                 DrawParticleRay(i);


### PR DESCRIPTION
Fixes #1856 
A slightly modified version of the workaround from there.
@tomaszkax86 Could you take a look at it? Just verified that it works but should we use this workaround long-term?
I'm unable to test this on Windows though.