### PR TITLE
Fix small font and mouse cursor in Hires displays

### DIFF
--- a/colobot-base/src/graphics/engine/engine.cpp
+++ b/colobot-base/src/graphics/engine/engine.cpp
@@ -157,6 +157,9 @@ struct EngineMouse
 };
 
 constexpr glm::ivec2 MOUSE_SIZE(32, 32);
+// Reference size for Hires scaling (same as font reference)
+constexpr glm::ivec2 REFERENCE_SIZE(800, 600);
+
 const std::map<EngineMouseType, EngineMouse> MOUSE_TYPES = {
     {{ENG_MOUSE_NORM},    {EngineMouse( 0,  1, 32, TransparencyMode::WHITE, TransparencyMode::BLACK, glm::ivec2( 1,  1))}},
     {{ENG_MOUSE_WAIT},    {EngineMouse( 2,  3, 33, TransparencyMode::WHITE, TransparencyMode::BLACK, glm::ivec2( 8, 12))}},
@@ -4585,19 +4588,37 @@ void CEngine::DrawMouse()
 
     SetWindowCoordinates();
 
+    // Calculate scale factor based on window size (same pattern as font scaling)
+    float scale = glm::length(glm::vec2(m_size)) / glm::length(glm::vec2(REFERENCE_SIZE));
+    // Prevent cursor from becoming smaller than base size
+    scale = std::max(scale, 1.0f);
+    // Scale mouse size for Hi Res displays
+    glm::ivec2 scaledMouseSize = glm::ivec2(MOUSE_SIZE.x * scale, MOUSE_SIZE.y * scale);
+
     glm::vec2 mousePos = CInput::GetInstancePointer()->GetMousePos();
     glm::ivec2 pos(mousePos.x * m_size.x, m_size.y - mousePos.y * m_size.y);
-    pos.x -= MOUSE_TYPES.at(m_mouseType).hotPoint.x;
-    pos.y -= MOUSE_TYPES.at(m_mouseType).hotPoint.y;
 
-    glm::ivec2 shadowPos = { pos.x + 4, pos.y - 3 };
+    // Scale hotPoint to maintain correct cursor positioning
+    glm::ivec2 scaledHotPoint = glm::ivec2(
+        static_cast<int>(MOUSE_TYPES.at(m_mouseType).hotPoint.x * scale),
+        static_cast<int>(MOUSE_TYPES.at(m_mouseType).hotPoint.y * scale)
+    );
+    pos.x -= scaledHotPoint.x;
+    pos.y -= scaledHotPoint.y;
+
+    // Scale shadow offset
+    glm::ivec2 shadowPos = {
+        pos.x + static_cast<int>(4 * scale),
+        pos.y - static_cast<int>(3 * scale)
+    };
 
     auto renderer = m_device->GetUIRenderer();
     renderer->SetTexture(m_miceTexture);
 
-    DrawMouseSprite(shadowPos, MOUSE_SIZE, MOUSE_TYPES.at(m_mouseType).iconShadow, TransparencyMode::WHITE);
-    DrawMouseSprite(pos, MOUSE_SIZE, MOUSE_TYPES.at(m_mouseType).icon1, MOUSE_TYPES.at(m_mouseType).mode1);
-    DrawMouseSprite(pos, MOUSE_SIZE, MOUSE_TYPES.at(m_mouseType).icon2, MOUSE_TYPES.at(m_mouseType).mode2);
+    // Draw with scaled size for HiRes displays
+    DrawMouseSprite(shadowPos, scaledMouseSize, MOUSE_TYPES.at(m_mouseType).iconShadow, TransparencyMode::WHITE);
+    DrawMouseSprite(pos, scaledMouseSize, MOUSE_TYPES.at(m_mouseType).icon1, MOUSE_TYPES.at(m_mouseType).mode1);
+    DrawMouseSprite(pos, scaledMouseSize, MOUSE_TYPES.at(m_mouseType).icon2, MOUSE_TYPES.at(m_mouseType).mode2);
 
     SetInterfaceCoordinates();
 }

--- a/colobot-base/src/graphics/engine/text.cpp
+++ b/colobot-base/src/graphics/engine/text.cpp
@@ -1387,7 +1387,7 @@ glm::ivec2 CText::GetNextTilePos(const FontTexture& fontTexture)
     int tileNumber = totalTiles - fontTexture.freeSlots;
 
     int verticalTileIndex = tileNumber / std::max(1, horizontalTiles);
-    int horizontalTileIndex = tileNumber % horizontalTiles;
+    int horizontalTileIndex = tileNumber % std::max(1, horizontalTiles);
 
     return { horizontalTileIndex * fontTexture.tileSize.x,
              verticalTileIndex * fontTexture.tileSize.y };

--- a/colobot-base/src/graphics/engine/text.cpp
+++ b/colobot-base/src/graphics/engine/text.cpp
@@ -152,7 +152,8 @@ std::string ToString(FontType type)
 namespace
 {
 constexpr glm::ivec2 REFERENCE_SIZE(800, 600);
-constexpr glm::ivec2 FONT_TEXTURE_SIZE(256, 256);
+constexpr int FONT_TEXTURE_BASE_SIZE = 256;
+constexpr int FONT_TEXTURE_MAX_SIZE = 2048;
 
 Gfx::FontType ToBoldFontType(Gfx::FontType type)
 {
@@ -408,6 +409,10 @@ CText::CText(CEngine* engine)
     m_fontsCache = std::make_unique<FontsCache>();
 
     m_quadBatch = std::make_unique<CQuadBatch>(*engine);
+
+    m_fontTextureSize = glm::ivec2(FONT_TEXTURE_BASE_SIZE, FONT_TEXTURE_BASE_SIZE);
+    GetLogger()->Info("Font texture initialized at base size %%x%%", m_fontTextureSize.x, m_fontTextureSize.y);
+    m_requiredFontTextureSize = glm::ivec2(FONT_TEXTURE_BASE_SIZE, FONT_TEXTURE_BASE_SIZE);
 }
 
 CText::~CText()
@@ -1219,10 +1224,10 @@ void CText::DrawCharAndAdjustPos(StrUtils::CodePoint ch, FontType font, float si
         glm::vec2 p2(pos.x + tex.charSize.x, pos.y);
 
         const float halfPixelMargin = 0.5f;
-        glm::vec2 texCoord1(static_cast<float>(tex.charPos.x + halfPixelMargin) / FONT_TEXTURE_SIZE.x,
-                            static_cast<float>(tex.charPos.y + halfPixelMargin) / FONT_TEXTURE_SIZE.y);
-        glm::vec2 texCoord2(static_cast<float>(tex.charPos.x + tex.charSize.x - halfPixelMargin) / FONT_TEXTURE_SIZE.x,
-                            static_cast<float>(tex.charPos.y + tex.charSize.y - halfPixelMargin) / FONT_TEXTURE_SIZE.y);
+        glm::vec2 texCoord1(static_cast<float>(tex.charPos.x + halfPixelMargin) / m_fontTextureSize.x,
+                            static_cast<float>(tex.charPos.y + halfPixelMargin) / m_fontTextureSize.y);
+        glm::vec2 texCoord2(static_cast<float>(tex.charPos.x + tex.charSize.x - halfPixelMargin) / m_fontTextureSize.x,
+                            static_cast<float>(tex.charPos.y + tex.charSize.y - halfPixelMargin) / m_fontTextureSize.y);
 
         Gfx::IntColor col = Gfx::ColorToIntColor(color);
 
@@ -1256,6 +1261,46 @@ CachedFont* CText::GetOrOpenFont(FontType type, float size)
     return cachedFont;
 }
 
+void CText::ResizeFontTexture() {
+    // Calculate new texture size - grow to next power of 2 that fits
+    int newSize = std::max(m_requiredFontTextureSize.x, m_requiredFontTextureSize.y);
+    newSize = Math::NextPowerOfTwo(newSize);
+    // Cap at max
+    newSize = std::min(newSize, FONT_TEXTURE_MAX_SIZE);
+
+    glm::ivec2 newTextureSize(newSize, newSize);
+
+    // Only resize if size actually changed
+    if (newTextureSize == m_fontTextureSize)
+    {
+        return;
+    }
+    // Perform resize
+    float scaleFactor = static_cast<float>(newSize) / FONT_TEXTURE_BASE_SIZE;
+
+    GetLogger()->Info("Resizing font textures from %%x%% to %%x%% (scale factor: %%)",
+                      m_fontTextureSize.x, m_fontTextureSize.y, newTextureSize.x, newTextureSize.y, scaleFactor);
+
+    // Clear existing font textures - they will be recreated on demand
+    FlushCache();
+
+    // Update texture size
+    m_fontTextureSize = newTextureSize;
+    m_requiredFontTextureSize = newTextureSize;
+
+    // FlushCache() clears the font cache, so we must reload fonts before any font operations, any cached font obtained before will be invalid
+    if (!ReloadFonts())
+    {
+        GetLogger()->Error("Failed to reload fonts after resize: %%", GetError());
+    }
+}
+
+
+void CText::ResizeFontTexture(FontType font, float size, CachedFont *&cf) {
+    ResizeFontTexture();
+    cf = GetOrOpenFont(font, size);
+}
+
 CharTexture CText::GetCharTexture(StrUtils::CodePoint ch, FontType font, float size)
 {
     CachedFont* cf = GetOrOpenFont(font, size);
@@ -1273,8 +1318,23 @@ CharTexture CText::GetCharTexture(StrUtils::CodePoint ch, FontType font, float s
     {
         tex = CreateCharTexture(ch, cf);
 
-        if (tex.id == 0) // invalid
-            return CharTexture();
+        if (tex.id == 0) // invalid - may need texture resize
+        {
+            if (m_fontTextureSize.x < m_requiredFontTextureSize.x || m_fontTextureSize.y < m_requiredFontTextureSize.y)
+            {
+                ResizeFontTexture(font, size, cf);
+                if (cf == nullptr)
+                    return CharTexture();
+
+                tex = CreateCharTexture(ch, cf);
+                if (tex.id == 0)
+                    return CharTexture();
+            }
+            else
+            {
+                return CharTexture();
+            }
+        }
 
         cf->cache[ch] = tex;
     }
@@ -1283,7 +1343,7 @@ CharTexture CText::GetCharTexture(StrUtils::CodePoint ch, FontType font, float s
 
 glm::ivec2 CText::GetFontTextureSize()
 {
-    return FONT_TEXTURE_SIZE;
+    return m_fontTextureSize;
 }
 
 CharTexture CText::CreateCharTexture(StrUtils::CodePoint ch, CachedFont* font)
@@ -1302,8 +1362,25 @@ CharTexture CText::CreateCharTexture(StrUtils::CodePoint ch, CachedFont* font)
     }
 
     const int pixelMargin = 1;
-    glm::ivec2 tileSize(Math::Max(16, Math::NextPowerOfTwo(textSurface->w)) + pixelMargin,
-                        Math::Max(16, Math::NextPowerOfTwo(textSurface->h)) + pixelMargin);
+    //add pixel margin before finding the next power reduces font texture resizing frequency
+    glm::ivec2 tileSize(Math::Max(16, Math::NextPowerOfTwo(textSurface->w + pixelMargin)),
+                        Math::Max(16, Math::NextPowerOfTwo(textSurface->h + pixelMargin)));
+
+    // Check if tile size fits in current texture
+    if (tileSize.x > m_fontTextureSize.x || tileSize.y > m_fontTextureSize.y)
+    {
+        // Tile is too big - signal that resize is needed and return empty
+        GetLogger()->Info("Character '%%' tile size %%x%% exceeds texture size %%x%% - signaling resize",
+                          ch.Data(), tileSize.x, tileSize.y, m_fontTextureSize.x, m_fontTextureSize.y);
+
+        // Signal resize needed (caller will handle it)
+        m_requiredFontTextureSize.x = tileSize.x;
+        m_requiredFontTextureSize.y = tileSize.y;
+
+        // Return empty texture - caller will retry after resize
+        SDL_FreeSurface(textSurface);
+        return texture;
+    }
 
     FontTexture* fontTexture = GetOrCreateFontTexture(tileSize);
 
@@ -1354,7 +1431,7 @@ FontTexture* CText::GetOrCreateFontTexture(const glm::ivec2& tileSize)
 
 FontTexture CText::CreateFontTexture(const glm::ivec2& tileSize)
 {
-    SDL_Surface* textureSurface = SDL_CreateRGBSurface(0, FONT_TEXTURE_SIZE.x, FONT_TEXTURE_SIZE.y, 32,
+    SDL_Surface* textureSurface = SDL_CreateRGBSurface(0, m_fontTextureSize.x, m_fontTextureSize.y, 32,
                                                        0x00ff0000, 0x0000ff00, 0x000000ff, 0xff000000);
     ImageData data;
     data.surface = textureSurface;
@@ -1372,17 +1449,18 @@ FontTexture CText::CreateFontTexture(const glm::ivec2& tileSize)
     FontTexture fontTexture;
     fontTexture.id = tex.id;
     fontTexture.tileSize = tileSize;
-    int horizontalTiles = FONT_TEXTURE_SIZE.x / tileSize.x;
-    int verticalTiles = FONT_TEXTURE_SIZE.y / tileSize.y;
+    int horizontalTiles = m_fontTextureSize.x / tileSize.x;
+    int verticalTiles = m_fontTextureSize.y / tileSize.y;
     fontTexture.freeSlots = horizontalTiles * verticalTiles;
     return fontTexture;
 }
 
 glm::ivec2 CText::GetNextTilePos(const FontTexture& fontTexture)
 {
-    int horizontalTiles = FONT_TEXTURE_SIZE.x / std::max(1, fontTexture.tileSize.x); //this should prevent crashes in some combinations of resolution and font size, see issue #1128
-    int verticalTiles = FONT_TEXTURE_SIZE.y / std::max(1, fontTexture.tileSize.y);
-
+    // Tile size is validated in CreateCharTexture before this is called, it should not be 0 anymore
+    int horizontalTiles = m_fontTextureSize.x / std::max(1, fontTexture.tileSize.x);
+    int verticalTiles = m_fontTextureSize.y / std::max(1, fontTexture.tileSize.y);
+    
     int totalTiles = horizontalTiles * verticalTiles;
     int tileNumber = totalTiles - fontTexture.freeSlots;
 

--- a/colobot-base/src/graphics/engine/text.h
+++ b/colobot-base/src/graphics/engine/text.h
@@ -292,12 +292,14 @@ public:
     glm::ivec2 GetFontTextureSize();
 
 protected:
-    int GetFontPointSize(float size) const;
+    int         GetFontPointSize(float size) const;
     CachedFont* GetOrOpenFont(FontType type, float size);
+    void        ResizeFontTexture();
+    void        ResizeFontTexture(FontType font, float size, CachedFont *&cf);
     CharTexture CreateCharTexture(StrUtils::CodePoint ch, CachedFont* font);
     FontTexture* GetOrCreateFontTexture(const glm::ivec2& tileSize);
     FontTexture CreateFontTexture(const glm::ivec2& tileSize);
-    glm::ivec2 GetNextTilePos(const FontTexture& fontTexture);
+    glm::ivec2  GetNextTilePos(const FontTexture& fontTexture);
 
     void        DrawString(const std::string &text, std::vector<FontMetaChar>::iterator format,
                            std::vector<FontMetaChar>::iterator end,
@@ -324,6 +326,10 @@ protected:
 
     class CQuadBatch;
     std::unique_ptr<CQuadBatch> m_quadBatch;
+
+    glm::ivec2   m_fontTextureSize;
+    // Signal that texture resize is needed (set by CreateCharTexture, handled by GetCharTexture)
+    glm::ivec2   m_requiredFontTextureSize;
 };
 
 

--- a/colobot-base/src/ui/displayinfo.cpp
+++ b/colobot-base/src/ui/displayinfo.cpp
@@ -162,21 +162,21 @@ bool CDisplayInfo::EventProcess(const Event &event)
 
         if ( event.type == EVENT_HYPER_SIZE1 )  // size 1?
         {
-            CSettings::GetInstancePointer()->SetFontSize(9.0f);
+            CSettings::GetInstancePointer()->SetFontSize(12.0f);
             slider = static_cast<Ui::CSlider*>(pw->SearchControl(EVENT_STUDIO_SIZE));
             if ( slider != nullptr )  slider->SetVisibleValue((CSettings::GetInstancePointer()->GetFontSize()-9.0f)/15.0f);
             ViewDisplayInfo();
         }
         if ( event.type == EVENT_HYPER_SIZE2 )  // size 2?
         {
-            CSettings::GetInstancePointer()->SetFontSize(14.0f);
+            CSettings::GetInstancePointer()->SetFontSize(15.0f);
             slider = static_cast<Ui::CSlider*>(pw->SearchControl(EVENT_STUDIO_SIZE));
             if ( slider != nullptr )  slider->SetVisibleValue((CSettings::GetInstancePointer()->GetFontSize()-9.0f)/15.0f);
             ViewDisplayInfo();
         }
         if ( event.type == EVENT_HYPER_SIZE3 )  // size 3?
         {
-            CSettings::GetInstancePointer()->SetFontSize(19.0f);
+            CSettings::GetInstancePointer()->SetFontSize(18.0f);
             slider = static_cast<Ui::CSlider*>(pw->SearchControl(EVENT_STUDIO_SIZE));
             if ( slider != nullptr )  slider->SetVisibleValue((CSettings::GetInstancePointer()->GetFontSize()-9.0f)/15.0f);
             ViewDisplayInfo();
@@ -895,8 +895,7 @@ void CDisplayInfo::ViewDisplayInfo()
     edit = static_cast<Ui::CEdit*>(pw->SearchControl(EVENT_EDIT1));
     if ( edit == nullptr )  return;
 
-    auto dim = m_engine->GetWindowSize();
-    edit->SetFontSize(CSettings::GetInstancePointer()->GetFontSize()/(dim.x / 640.0f));
+    edit->SetFontSize(CSettings::GetInstancePointer()->GetFontSize());
 }
 
 // Returns the object human.

--- a/colobot-base/src/ui/studio.cpp
+++ b/colobot-base/src/ui/studio.cpp
@@ -1113,8 +1113,7 @@ void CStudio::ViewEditScript()
     edit = static_cast< CEdit* >(pw->SearchControl(EVENT_STUDIO_EDIT));
     if ( edit == nullptr )  return;
 
-    glm::ivec2 dim = m_engine->GetWindowSize();
-    edit->SetFontSize(m_settings->GetFontSize()/(dim.x/640.0f));
+    edit->SetFontSize(m_settings->GetFontSize());
 }
 
 


### PR DESCRIPTION
Removed redundant scaling in text.cpp and displayInfo.cpp
Changed font button size pre-sets in displayInfo.cpp to start at 12, 15, 18, 24 instead of 9,14, 19, 24
Added dynamic font texture size in text.cpp
Scaled mouse based on reference size resolution (800x600)
Reformat some entries in text.h to improve readability