### PR TITLE
Fix #1891: Builder crashes when executing grab() instruction.

### DIFF
--- a/colobot-base/src/object/task/taskmanip.cpp
+++ b/colobot-base/src/object/task/taskmanip.cpp
@@ -58,8 +58,6 @@ CTaskManip::CTaskManip(COldObject* object) : CForegroundTask(object)
 {
     m_arm  = TMA_NEUTRAL;
     m_hand = TMH_OPEN;
-
-    assert(m_object->MapPseudoSlot(CSlottedObject::Pseudoslot::CARRYING) >= 0);
 }
 
 // Object's destructor.


### PR DESCRIPTION
This assert here is too early. The bot type doesn't get checked until CTaskManip::Start. There's no need to put another assert back after the bot type check, since it's already checked by m_object->GetSlotContainedObjectReq